### PR TITLE
Improve setup-project.sh to be more robust

### DIFF
--- a/deploy/setup-project.sh
+++ b/deploy/setup-project.sh
@@ -6,11 +6,14 @@ set -o errexit
 IAM_NAME="${GCEPD_SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
 
 # Cleanup old Service Account and Key
-rm -f "${SA_FILE}"
-gcloud iam service-accounts delete "${IAM_NAME}" --quiet
+if [ -f $SA_FILE ]; then
+  rm "$SA_FILE"
+fi
+gcloud iam service-accounts delete "$IAM_NAME" --quiet || true
 # TODO: Delete ALL policy bindings
 
 # Create new Service Account and Keys
 gcloud iam service-accounts create "${GCEPD_SA_NAME}"
 gcloud iam service-accounts keys create "${SA_FILE}" --iam-account "${IAM_NAME}"
-gcloud projects add-iam-policy-binding "${PROJECT}" --member serviceAccount:"${IAM_NAME}" --role roles/compute.storageAdmin
+gcloud projects add-iam-policy-binding "${PROJECT}" --member serviceAccount:"${IAM_NAME}" --role roles/compute.admin
+gcloud projects add-iam-policy-binding "${PROJECT}" --member serviceAccount:"${IAM_NAME}" --role roles/iam.serviceAccountUser


### PR DESCRIPTION
Stops project creation from failing when file doesn't exist, or service account doesn't exist.
Expand service account roles as necessary for functionality of driver.

/assign @msau42 