### PR TITLE
Simple go verification scripts

### DIFF
--- a/hack/update-gofmt.sh
+++ b/hack/update-gofmt.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+find . -name "*.go" | grep -v "\/vendor\/" | xargs gofmt -s -w

--- a/hack/update-gofmt.sh
+++ b/hack/update-gofmt.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017 The Kubernetes Authors.
+# Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017 The Kubernetes Authors.
+# Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+PKG_ROOT=$(git rev-parse --show-toplevel)
+
+${PKG_ROOT}/hack/verify-gofmt.sh
+${PKG_ROOT}/hack/verify-govet.sh

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "Verifying gofmt"
+
+diff=$(find . -name "*.go" | grep -v "\/vendor\/" | xargs gofmt -s -d 2>&1)
+if [[ -n "${diff}" ]]; then
+  echo "${diff}"
+  echo
+  echo "Please run hack/update-gofmt.sh"
+  exit 1
+fi

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2017 The Kubernetes Authors.
+# Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "Verifying govet"
+
+go vet $(go list ./... | grep -v vendor)

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2017 The Kubernetes Authors.
+# Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/gce-csi-driver/controller_test.go
+++ b/pkg/gce-csi-driver/controller_test.go
@@ -205,7 +205,7 @@ func TestCreateVolumeArguments(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create fake cloud provider: %v", err)
 		}
-		err = gceDriver.SetupGCEDriver(fakeCloudProvider, driver, node)
+		err = gceDriver.SetupGCEDriver(fakeCloudProvider, nil, driver, node)
 		if err != nil {
 			t.Fatalf("Failed to setup GCE Driver: %v", err)
 		}

--- a/pkg/gce-csi-driver/identity.go
+++ b/pkg/gce-csi-driver/identity.go
@@ -43,7 +43,7 @@ func (gceIdentity *GCEIdentityServer) GetPluginCapabilities(ctx context.Context,
 	glog.V(5).Infof("Using default GetPluginCapabilities")
 	return &csi.GetPluginCapabilitiesResponse{
 		Capabilities: []*csi.PluginCapability{
-			&csi.PluginCapability{
+			{
 				Type: &csi.PluginCapability_Service_{
 					Service: &csi.PluginCapability_Service{
 						Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,

--- a/test/remote/run_remote/run_remote.go
+++ b/test/remote/run_remote/run_remote.go
@@ -466,7 +466,7 @@ func addPubKeyToInstance(project, zone, name, pubKeyFile string) error {
 	newMeta := &compute.Metadata{
 		Fingerprint: fingerprint,
 		Items: []*compute.MetadataItems{
-			&compute.MetadataItems{
+			{
 				Key:   "ssh-keys",
 				Value: &newKeys,
 			},


### PR DESCRIPTION
Fixes #33

Add some simple go verification scripts like gofmt and govet.

Entrypoint is `hack/verify-all`. More verification scripts can be added later

test-infra change: https://github.com/kubernetes/test-infra/pull/8500

/assign @msau42 @krzyzacy