### PR TITLE
Added a waitforattach verification at the end of ControllerPublishVolume

### DIFF
--- a/pkg/gce-cloud-provider/fake-gce.go
+++ b/pkg/gce-cloud-provider/fake-gce.go
@@ -34,6 +34,8 @@ type FakeCloudProvider struct {
 	instances map[string]*compute.Instance
 }
 
+var _ GCECompute = &FakeCloudProvider{}
+
 func FakeCreateCloudProvider(project, zone string) (*FakeCloudProvider, error) {
 	return &FakeCloudProvider{
 		project:   project,
@@ -154,6 +156,10 @@ func (cloud *FakeCloudProvider) GetDiskSourceURI(disk *compute.Disk, zone string
 
 func (cloud *FakeCloudProvider) GetDiskTypeURI(zone, diskType string) string {
 	return ""
+}
+
+func (cloud *FakeCloudProvider) WaitForAttach(ctx context.Context, zone, diskName, instanceName string) error {
+	return nil
 }
 
 // Instance Methods

--- a/pkg/gce-cloud-provider/gce.go
+++ b/pkg/gce-cloud-provider/gce.go
@@ -44,6 +44,8 @@ type CloudProvider struct {
 	zone    string
 }
 
+var _ GCECompute = &CloudProvider{}
+
 func CreateCloudProvider() (*CloudProvider, error) {
 	svc, err := createCloudService()
 	if err != nil {

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -296,6 +296,11 @@ func (gceCS *GCEControllerServer) ControllerPublishVolume(ctx context.Context, r
 		return nil, status.Error(codes.Internal, fmt.Sprintf("unknown Attach operation error: %v", err))
 	}
 
+	err = gceCS.CloudProvider.WaitForAttach(ctx, volumeZone, disk.Name, nodeID)
+	if err != nil {
+		return nil, status.Error(codes.Internal, fmt.Sprintf("unknown WaitForAttach error: %v", err))
+	}
+
 	glog.Infof("Disk %v attached to instance %v successfully", disk.Name, nodeID)
 	return pubVolResp, nil
 }

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -255,6 +255,7 @@ func TestCreateVolumeArguments(t *testing.T) {
 }
 
 // Test volume already exists
+
 // Test volume with op pending
 
 // Test DeleteVolume


### PR DESCRIPTION
Fixes: #43 

There is an issue where Attach and the Attach Op can return success/DONE but the volume may not actually be attached to the instance. This PR adds an extra check where we poll the disk object for the instances it is attached to before returning success.

/assign @msau42 