### PR TITLE
Added unit tests for identity server, fixed small spec inconsistency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+
 FROM golang:1.10.1-alpine3.7 as builder
 WORKDIR /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 ADD . .
-RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o bin/gce-pd-csi-driver ./cmd/
+ARG TAG
+RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-X main.vendorVersion='"${TAG:-latest}"' -extldflags "-static"' -o bin/gce-pd-csi-driver ./cmd/
 
 # Start from Google Debian base
 FROM gcr.io/google-containers/debian-base-amd64:0.3

--- a/Makefile
+++ b/Makefile
@@ -17,21 +17,23 @@ STAGINGVERSION=latest
 
 PRODIMAGE=gcr.io/google-containers/volume-csi/compute-persistent-disk-csi-driver
 PRODVERSION=v0.2.0.alpha
+
 all: gce-pd-driver
 
 gce-pd-driver:
 	mkdir -p bin
-	go build -o bin/gce-pd-csi-driver ./cmd/
+	go build -ldflags "-X main.vendorVersion=${STAGINGVERSION}" -o bin/gce-pd-csi-driver ./cmd/
 	go test -c sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/test/e2e -o bin/e2e.test
 
-build-container: gce-pd-driver
-	docker build -t $(STAGINGIMAGE):$(STAGINGVERSION) .
+build-container:
+# TODO CHANGE PRODVERSION TO STAGINGVERSION AFTER TESTING
+	docker build --build-arg TAG=$(STAGINGVERSION) -t $(STAGINGIMAGE):$(STAGINGVERSION) .
 
 push-container: build-container
 	gcloud docker -- push $(STAGINGIMAGE):$(STAGINGVERSION)
 
-prod-build-container: gce-pd-driver
-	docker build -t $(PRODIMAGE):$(PRODVERSION)
+prod-build-container:
+	docker build --build-arg TAG=$(PRODVERSION) -t $(PRODIMAGE):$(PRODVERSION)
 
 prod-push-container: prod-build-container
 	gcloud docker -- push $(PRODIMAGE):$(PRODVERSION)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,7 +46,7 @@ func handle() {
 	gceDriver := driver.GetGCEDriver()
 
 	//Initialize GCE Driver (Move setup to main?)
-	cloudProvider, err := gce.CreateCloudProvider()
+	cloudProvider, err := gce.CreateCloudProvider(gceDriver.GetVendorVersion())
 	if err != nil {
 		glog.Fatalf("Failed to get cloud provider: %v", err)
 	}

--- a/pkg/gce-cloud-provider/gce.go
+++ b/pkg/gce-cloud-provider/gce.go
@@ -46,8 +46,8 @@ type CloudProvider struct {
 
 var _ GCECompute = &CloudProvider{}
 
-func CreateCloudProvider() (*CloudProvider, error) {
-	svc, err := createCloudService()
+func CreateCloudProvider(vendorVersion string) (*CloudProvider, error) {
+	svc, err := createCloudService(vendorVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -66,13 +66,13 @@ func CreateCloudProvider() (*CloudProvider, error) {
 
 }
 
-func createCloudService() (*compute.Service, error) {
+func createCloudService(vendorVersion string) (*compute.Service, error) {
 	// TODO: support alternate methods of authentication
-	svc, err := createCloudServiceWithDefaultServiceAccount()
+	svc, err := createCloudServiceWithDefaultServiceAccount(vendorVersion)
 	return svc, err
 }
 
-func createCloudServiceWithDefaultServiceAccount() (*compute.Service, error) {
+func createCloudServiceWithDefaultServiceAccount(vendorVersion string) (*compute.Service, error) {
 	client, err := newDefaultOauthClient()
 	if err != nil {
 		return nil, err
@@ -82,7 +82,7 @@ func createCloudServiceWithDefaultServiceAccount() (*compute.Service, error) {
 		return nil, err
 	}
 	// TODO(dyzz) parameterize version number
-	service.UserAgent = fmt.Sprintf("GCE CSI Driver/%s (%s %s)", "0.2.0", runtime.GOOS, runtime.GOARCH)
+	service.UserAgent = fmt.Sprintf("GCE CSI Driver/%s (%s %s)", vendorVersion, runtime.GOOS, runtime.GOARCH)
 	return service, nil
 }
 

--- a/pkg/gce-cloud-provider/gce.go
+++ b/pkg/gce-cloud-provider/gce.go
@@ -81,7 +81,6 @@ func createCloudServiceWithDefaultServiceAccount(vendorVersion string) (*compute
 	if err != nil {
 		return nil, err
 	}
-	// TODO(dyzz) parameterize version number
 	service.UserAgent = fmt.Sprintf("GCE CSI Driver/%s (%s %s)", vendorVersion, runtime.GOOS, runtime.GOARCH)
 	return service, nil
 }

--- a/pkg/gce-pd-csi-driver/gce-pd-driver.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver.go
@@ -39,21 +39,11 @@ type GCEDriver struct {
 	nscap []*csi.NodeServiceCapability
 }
 
-const (
-	vendorVersion = "v0.3.0-alpha"
-)
-
 func GetGCEDriver() *GCEDriver {
-	return &GCEDriver{
-		vendorVersion: vendorVersion,
-	}
+	return &GCEDriver{}
 }
 
-func (gceDriver *GCEDriver) GetVendorVersion() string {
-	return gceDriver.vendorVersion
-}
-
-func (gceDriver *GCEDriver) SetupGCEDriver(cloudProvider gce.GCECompute, mounter mountmanager.Mounter, name, nodeID string) error {
+func (gceDriver *GCEDriver) SetupGCEDriver(cloudProvider gce.GCECompute, mounter mountmanager.Mounter, name, nodeID, vendorVersion string) error {
 	if name == "" {
 		return fmt.Errorf("Driver name missing")
 	}
@@ -63,6 +53,7 @@ func (gceDriver *GCEDriver) SetupGCEDriver(cloudProvider gce.GCECompute, mounter
 
 	gceDriver.name = name
 	gceDriver.nodeID = nodeID
+	gceDriver.vendorVersion = vendorVersion
 
 	// Adding Capabilities
 	vcam := []csi.VolumeCapability_AccessMode_Mode{

--- a/pkg/gce-pd-csi-driver/gce-pd-driver.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver.go
@@ -26,8 +26,9 @@ import (
 )
 
 type GCEDriver struct {
-	name   string
-	nodeID string
+	name          string
+	nodeID        string
+	vendorVersion string
 
 	ids *GCEIdentityServer
 	ns  *GCENodeServer
@@ -38,11 +39,15 @@ type GCEDriver struct {
 	nscap []*csi.NodeServiceCapability
 }
 
+const (
+	vendorVersion = "v0.3.0-alpha"
+)
+
 func GetGCEDriver() *GCEDriver {
 	return &GCEDriver{}
 }
 
-func (gceDriver *GCEDriver) SetupGCEDriver(cloudProvider gce.GCECompute, mounter mountmanager.Mounter, name string, nodeID string) error {
+func (gceDriver *GCEDriver) SetupGCEDriver(cloudProvider gce.GCECompute, mounter mountmanager.Mounter, name, nodeID string) error {
 	if name == "" {
 		return fmt.Errorf("Driver name missing")
 	}
@@ -52,6 +57,7 @@ func (gceDriver *GCEDriver) SetupGCEDriver(cloudProvider gce.GCECompute, mounter
 
 	gceDriver.name = name
 	gceDriver.nodeID = nodeID
+	gceDriver.vendorVersion = vendorVersion
 
 	// Adding Capabilities
 	vcam := []csi.VolumeCapability_AccessMode_Mode{

--- a/pkg/gce-pd-csi-driver/gce-pd-driver.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver.go
@@ -44,7 +44,13 @@ const (
 )
 
 func GetGCEDriver() *GCEDriver {
-	return &GCEDriver{}
+	return &GCEDriver{
+		vendorVersion: vendorVersion,
+	}
+}
+
+func (gceDriver *GCEDriver) GetVendorVersion() string {
+	return gceDriver.vendorVersion
 }
 
 func (gceDriver *GCEDriver) SetupGCEDriver(cloudProvider gce.GCECompute, mounter mountmanager.Mounter, name, nodeID string) error {
@@ -57,7 +63,6 @@ func (gceDriver *GCEDriver) SetupGCEDriver(cloudProvider gce.GCECompute, mounter
 
 	gceDriver.name = name
 	gceDriver.nodeID = nodeID
-	gceDriver.vendorVersion = vendorVersion
 
 	// Adding Capabilities
 	vcam := []csi.VolumeCapability_AccessMode_Mode{

--- a/pkg/gce-pd-csi-driver/identity.go
+++ b/pkg/gce-pd-csi-driver/identity.go
@@ -35,7 +35,8 @@ func (gceIdentity *GCEIdentityServer) GetPluginInfo(ctx context.Context, req *cs
 	}
 
 	return &csi.GetPluginInfoResponse{
-		Name: gceIdentity.Driver.name,
+		Name:          gceIdentity.Driver.name,
+		VendorVersion: gceIdentity.Driver.vendorVersion,
 	}, nil
 }
 

--- a/pkg/gce-pd-csi-driver/identity_test.go
+++ b/pkg/gce-pd-csi-driver/identity_test.go
@@ -13,3 +13,66 @@ limitations under the License.
 */
 
 package gceGCEDriver
+
+import (
+	"testing"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"golang.org/x/net/context"
+)
+
+func TestGetPluginInfo(t *testing.T) {
+	gceDriver := GetGCEDriver()
+	err := gceDriver.SetupGCEDriver(nil, nil, driver, node)
+	if err != nil {
+		t.Fatalf("Failed to setup GCE Driver: %v", err)
+	}
+
+	resp, err := gceDriver.ids.GetPluginInfo(context.TODO(), &csi.GetPluginInfoRequest{})
+	if err != nil {
+		t.Fatalf("GetPluginInfo returned unexpected error: %v", err)
+	}
+
+	if resp.GetName() != driver {
+		t.Fatalf("Response name expected: %v, got: %v", driver, resp.GetName())
+	}
+
+	respVer := resp.GetVendorVersion()
+	if respVer != vendorVersion {
+		t.Fatalf("Vendor version expected: %v, got: %v", vendorVersion, respVer)
+	}
+}
+
+func TestGetPluginCapabilities(t *testing.T) {
+	gceDriver := GetGCEDriver()
+	err := gceDriver.SetupGCEDriver(nil, nil, driver, node)
+	if err != nil {
+		t.Fatalf("Failed to setup GCE Driver: %v", err)
+	}
+
+	resp, err := gceDriver.ids.GetPluginCapabilities(context.TODO(), &csi.GetPluginCapabilitiesRequest{})
+	if err != nil {
+		t.Fatalf("GetPluginCapabilities returned unexpected error: %v", err)
+	}
+
+	for _, capability := range resp.GetCapabilities() {
+		switch capability.GetService().GetType() {
+		case csi.PluginCapability_Service_CONTROLLER_SERVICE:
+		default:
+			t.Fatalf("Unknown capability: %v", capability.GetService().GetType())
+		}
+	}
+}
+
+func TestProbe(t *testing.T) {
+	gceDriver := GetGCEDriver()
+	err := gceDriver.SetupGCEDriver(nil, nil, driver, node)
+	if err != nil {
+		t.Fatalf("Failed to setup GCE Driver: %v", err)
+	}
+
+	_, err = gceDriver.ids.Probe(context.TODO(), &csi.ProbeRequest{})
+	if err != nil {
+		t.Fatalf("Probe returned unexpected error: %v", err)
+	}
+}

--- a/test/e2e/gce_pd_e2e_test.go
+++ b/test/e2e/gce_pd_e2e_test.go
@@ -78,10 +78,11 @@ var _ = BeforeSuite(func() {
 	// TODO(dyzz): better defaults
 	driverName := "testdriver"
 	nodeID = "gce-pd-csi-e2e"
+	vendorVersion := "testVendor"
 
 	// TODO(dyzz): Start a driver
 	gceDriver := driver.GetGCEDriver()
-	gceCloud, err = gce.CreateCloudProvider(gceDriver.GetVendorVersion())
+	gceCloud, err = gce.CreateCloudProvider(vendorVersion)
 
 	Expect(err).To(BeNil(), "Failed to get cloud provider: %v", err)
 
@@ -91,7 +92,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).To(BeNil(), "Failed to get mounter %v", err)
 
 	//Initialize GCE Driver
-	err = gceDriver.SetupGCEDriver(gceCloud, mounter, driverName, nodeID)
+	err = gceDriver.SetupGCEDriver(gceCloud, mounter, driverName, nodeID, vendorVersion)
 	Expect(err).To(BeNil(), "Failed to initialize GCE CSI Driver: %v", err)
 
 	go func() {

--- a/test/e2e/gce_pd_e2e_test.go
+++ b/test/e2e/gce_pd_e2e_test.go
@@ -74,13 +74,14 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	var err error
 	// TODO(dyzz): better defaults
 	driverName := "testdriver"
 	nodeID = "gce-pd-csi-e2e"
 
 	// TODO(dyzz): Start a driver
 	gceDriver := driver.GetGCEDriver()
-	cloudProvider, err := gce.CreateCloudProvider()
+	gceCloud, err = gce.CreateCloudProvider(gceDriver.GetVendorVersion())
 
 	Expect(err).To(BeNil(), "Failed to get cloud provider: %v", err)
 
@@ -90,7 +91,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).To(BeNil(), "Failed to get mounter %v", err)
 
 	//Initialize GCE Driver
-	err = gceDriver.SetupGCEDriver(cloudProvider, mounter, driverName, nodeID)
+	err = gceDriver.SetupGCEDriver(gceCloud, mounter, driverName, nodeID)
 	Expect(err).To(BeNil(), "Failed to initialize GCE CSI Driver: %v", err)
 
 	go func() {
@@ -99,7 +100,6 @@ var _ = BeforeSuite(func() {
 
 	client = createCSIClient()
 
-	gceCloud, err = gce.CreateCloudProvider()
 	Expect(err).To(BeNil(), "Failed to create cloud service")
 	// TODO: This is a hack to make sure the driver is fully up before running the tests, theres probably a better way to do this.
 	time.Sleep(20 * time.Second)

--- a/test/run-e2e-local.sh
+++ b/test/run-e2e-local.sh
@@ -5,4 +5,4 @@ set -x
 
 readonly PKGDIR=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 
-go run "$GOPATH/src/${PKGDIR}/test/remote/run_remote/run_remote.go" --logtostderr --v 2 --project "${PROJECT}" --zone "${ZONE}" --ssh-env gce --delete-instances=true --cleanup=true --results-dir=my_test  --service-account="${IAM_NAME}"
+go run "$GOPATH/src/${PKGDIR}/test/remote/run_remote/run_remote.go" --logtostderr --v 2 --project "${PROJECT}" --zone "${ZONE}" --ssh-env gce --delete-instances=false --cleanup=true --results-dir=my_test  --service-account="${IAM_NAME}"

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -31,6 +31,7 @@ func TestSanity(t *testing.T) {
 	nodeID := "io.kubernetes.storage.mock"
 	project := "test-project"
 	zone := "test-zone"
+	vendorVersion := "test-version"
 	// TODO(dyzz): Only one of these can be correct, the way endpoint is defined in GCE driver is INCORRECT
 	endpoint := "unix://tmp/csi.sock"
 	csiSanityEndpoint := "unix:/tmp/csi.sock"
@@ -50,7 +51,7 @@ func TestSanity(t *testing.T) {
 	}
 
 	//Initialize GCE Driver
-	err = gceDriver.SetupGCEDriver(cloudProvider, mounter, driverName, nodeID)
+	err = gceDriver.SetupGCEDriver(cloudProvider, mounter, driverName, nodeID, vendorVersion)
 	if err != nil {
 		t.Fatalf("Failed to initialize GCE CSI Driver: %v", err)
 	}


### PR DESCRIPTION
Added unit tests. In the process found out the GetPluginInfo was missing vendor version so it was fixed to return the vendor version now.

vendor version is: The version of the driver as declared by the vendor (driver author)
so it makes sense to be a const and not a flag

/assign @msau42 

Fixes: #47 