### PR TITLE
Remove old policy bindings so that setup-project is reentrant

### DIFF
--- a/deploy/gcp-compute-persistent-disk-csi-driver-custom-role.yaml
+++ b/deploy/gcp-compute-persistent-disk-csi-driver-custom-role.yaml
@@ -1,0 +1,6 @@
+title: "GCP Compute Persistent Disk CSI Driver Custom Roles"
+description: Custom roles required for functions of the gcp-compute-persistent-disk-csi-driver
+stage: ALPHA
+includedPermissions:
+- compute.instances.get
+- compute.instances.attachDisk


### PR DESCRIPTION
Have the `setup-project.sh` script remove old policy bindings so that they can be recreated successfully.

Part of: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/73

/assign @msau42 