### PR TITLE
Topology support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -51,13 +51,13 @@
   revision = "b7773ae218740a7be65057fc60b366a49b538a44"
 
 [[projects]]
-  branch = "master"
+  branch = "v0.3.0"
   name = "github.com/kubernetes-csi/csi-test"
   packages = [
     "pkg/sanity",
     "utils"
   ]
-  revision = "1bf94ed5c3afa2db7d3117f206f1b00249764790"
+  revision = "53045fadb43cf34da55260ee767f7e45645388e9"
 
 [[projects]]
   name = "github.com/onsi/ginkgo"
@@ -306,6 +306,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4ca1df328310c5afd5b74eb573280af9e650de8dc4a6573c1aa15de82d72edd9"
+  inputs-digest = "52dfe28773229d8cbf1622d274e5f1bf9b9b263f3edb684802cc87095162a5c4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -76,7 +76,7 @@
   non-go = true
 
 [[constraint]]
-  branch = "master"
+  branch = "v0.3.0"
   name = "github.com/kubernetes-csi/csi-test"
   
 [[constraint]]

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+const (
+	// Keys for Storage Class Parameters
+	ParameterKeyZone = "zone"
+	ParameterKeyType = "type"
+
+	// Keys for Topology. This key will be shared amonst drivers from GCP
+	TopologyKeyZone = "com.google.topology/zone"
+)

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package common
 
 import (
 	"fmt"

--- a/pkg/gce-cloud-provider/compute/gce.go
+++ b/pkg/gce-cloud-provider/compute/gce.go
@@ -51,7 +51,6 @@ func CreateCloudProvider(vendorVersion string) (*CloudProvider, error) {
 	if err != nil {
 		return nil, err
 	}
-	// TODO: Use metadata server or flags to retrieve project and zone. Fallback on flag if necessary
 
 	project, zone, err := getProjectAndZoneFromMetadata()
 	if err != nil {

--- a/pkg/gce-cloud-provider/metadata/fake.go
+++ b/pkg/gce-cloud-provider/metadata/fake.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+type fakeServiceManager struct{}
+
+var _ MetadataService = &fakeServiceManager{}
+
+func NewFakeService() MetadataService {
+	return &fakeServiceManager{}
+}
+
+func (manager *fakeServiceManager) GetZone() string {
+	return "test-location"
+}
+
+func (manager *fakeServiceManager) GetProject() string {
+	return "test-project"
+}

--- a/pkg/gce-cloud-provider/metadata/metadata.go
+++ b/pkg/gce-cloud-provider/metadata/metadata.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	"fmt"
+
+	"cloud.google.com/go/compute/metadata"
+)
+
+// MetadataService is a fakeable interface exposing necessary data
+// from the GCE Metadata service
+type MetadataService interface {
+	GetZone() string
+	GetProject() string
+}
+
+type metadataServiceManager struct {
+	// Current zone the driver is running in
+	zone    string
+	project string
+}
+
+var _ MetadataService = &metadataServiceManager{}
+
+func NewMetadataService() (MetadataService, error) {
+	zone, err := metadata.Zone()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current zone: %v", err)
+	}
+	projectID, err := metadata.ProjectID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get project: %v", err)
+	}
+
+	return &metadataServiceManager{
+		project: projectID,
+		zone:    zone,
+	}, nil
+}
+
+func (manager *metadataServiceManager) GetZone() string {
+	return manager.zone
+}
+
+func (manager *metadataServiceManager) GetProject() string {
+	return manager.project
+}

--- a/pkg/gce-pd-csi-driver/gce-pd-driver_test.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver_test.go
@@ -17,7 +17,8 @@ package gceGCEDriver
 import (
 	"testing"
 
-	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider"
+	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute"
+	metadataservice "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/metadata"
 )
 
 func initGCEDriver(t *testing.T) *GCEDriver {
@@ -27,7 +28,7 @@ func initGCEDriver(t *testing.T) *GCEDriver {
 	if err != nil {
 		t.Fatalf("Failed to create fake cloud provider: %v", err)
 	}
-	err = gceDriver.SetupGCEDriver(fakeCloudProvider, nil, nil, driver, node, vendorVersion)
+	err = gceDriver.SetupGCEDriver(fakeCloudProvider, nil, nil, metadataservice.NewFakeService(), driver, node, vendorVersion)
 	if err != nil {
 		t.Fatalf("Failed to setup GCE Driver: %v", err)
 	}

--- a/pkg/gce-pd-csi-driver/identity.go
+++ b/pkg/gce-pd-csi-driver/identity.go
@@ -51,6 +51,13 @@ func (gceIdentity *GCEIdentityServer) GetPluginCapabilities(ctx context.Context,
 					},
 				},
 			},
+			{
+				Type: &csi.PluginCapability_Service_{
+					Service: &csi.PluginCapability_Service{
+						Type: csi.PluginCapability_Service_ACCESSIBILITY_CONSTRAINTS,
+					},
+				},
+			},
 		},
 	}, nil
 }

--- a/pkg/gce-pd-csi-driver/identity_test.go
+++ b/pkg/gce-pd-csi-driver/identity_test.go
@@ -19,12 +19,13 @@ import (
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
 	"golang.org/x/net/context"
+	metadataservice "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/metadata"
 )
 
 func TestGetPluginInfo(t *testing.T) {
 	vendorVersion := "test-vendor"
 	gceDriver := GetGCEDriver()
-	err := gceDriver.SetupGCEDriver(nil, nil, nil, driver, node, vendorVersion)
+	err := gceDriver.SetupGCEDriver(nil, nil, nil, metadataservice.NewFakeService(), driver, node, vendorVersion)
 	if err != nil {
 		t.Fatalf("Failed to setup GCE Driver: %v", err)
 	}
@@ -46,7 +47,7 @@ func TestGetPluginInfo(t *testing.T) {
 
 func TestGetPluginCapabilities(t *testing.T) {
 	gceDriver := GetGCEDriver()
-	err := gceDriver.SetupGCEDriver(nil, nil, nil, driver, node, "test-vendor")
+	err := gceDriver.SetupGCEDriver(nil, nil, nil, metadataservice.NewFakeService(), driver, node, "test-vendor")
 	if err != nil {
 		t.Fatalf("Failed to setup GCE Driver: %v", err)
 	}
@@ -59,6 +60,7 @@ func TestGetPluginCapabilities(t *testing.T) {
 	for _, capability := range resp.GetCapabilities() {
 		switch capability.GetService().GetType() {
 		case csi.PluginCapability_Service_CONTROLLER_SERVICE:
+		case csi.PluginCapability_Service_ACCESSIBILITY_CONSTRAINTS:
 		default:
 			t.Fatalf("Unknown capability: %v", capability.GetService().GetType())
 		}
@@ -67,7 +69,7 @@ func TestGetPluginCapabilities(t *testing.T) {
 
 func TestProbe(t *testing.T) {
 	gceDriver := GetGCEDriver()
-	err := gceDriver.SetupGCEDriver(nil, nil, nil, driver, node, "test-vendor")
+	err := gceDriver.SetupGCEDriver(nil, nil, nil, metadataservice.NewFakeService(), driver, node, "test-vendor")
 	if err != nil {
 		t.Fatalf("Failed to setup GCE Driver: %v", err)
 	}

--- a/test/binremote/instance.go
+++ b/test/binremote/instance.go
@@ -46,19 +46,25 @@ type InstanceInfo struct {
 	zone    string
 	name    string
 
+	// External IP is filled in after instance creation
+	// TODO: Maybe combine create instance and create instance info so all fields are set up at the same time...
 	externalIP string
 
 	computeService *compute.Service
 }
 
-func CreateInstanceInfo(project, zone, name string) (*InstanceInfo, error) {
-	cs, err := getComputeClient()
-	if err != nil {
-		return nil, err
-	}
+func (i *InstanceInfo) GetIdentity() (string, string, string) {
+	return i.project, i.zone, i.name
+}
+
+func (i *InstanceInfo) GetName() string {
+	return i.name
+}
+
+func CreateInstanceInfo(project, instanceZone, name string, cs *compute.Service) (*InstanceInfo, error) {
 	return &InstanceInfo{
 		project: project,
-		zone:    zone,
+		zone:    instanceZone,
 		name:    name,
 
 		computeService: cs,
@@ -66,7 +72,7 @@ func CreateInstanceInfo(project, zone, name string) (*InstanceInfo, error) {
 }
 
 // Provision a gce instance using image
-func (i *InstanceInfo) CreateInstance(serviceAccount string) error {
+func (i *InstanceInfo) CreateOrGetInstance(serviceAccount string) error {
 	var err error
 	var instance *compute.Instance
 	glog.V(4).Infof("Creating instance: %v", i.name)
@@ -236,7 +242,7 @@ func (i *InstanceInfo) createDefaultFirewallRule() error {
 	return nil
 }
 
-func getComputeClient() (*compute.Service, error) {
+func GetComputeClient() (*compute.Service, error) {
 	const retries = 10
 	const backoff = time.Second * 6
 

--- a/test/e2e/tests/multi_zone_e2e_test.go
+++ b/test/e2e/tests/multi_zone_e2e_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
+	testutils "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/test/e2e/utils"
+)
+
+var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
+	BeforeEach(func() {
+		Expect(len(testInstances)).To(BeNumerically(">", 1))
+		// TODO: Check whether the instances are in different zones???
+		// I Think there should be a better way of guaranteeing this. Like a map from zone to instance for testInstances (?)
+	})
+
+	It("Should get reasonable topology from nodes with NodeGetInfo", func() {
+		for _, instance := range testInstances {
+			testContext, err := testutils.SetupNewDriverAndClient(instance)
+			Expect(err).To(BeNil(), "Set up new Driver and Client failed with error")
+
+			resp, err := testContext.Client.NodeGetInfo()
+			Expect(err).To(BeNil())
+
+			// Get Cloud Instance
+			p, z, n := testContext.Instance.GetIdentity()
+			cloudInstance, err := computeService.Instances.Get(p, z, n).Do()
+			Expect(err).To(BeNil())
+			Expect(cloudInstance).ToNot(BeNil())
+
+			// Check topology matches
+			segments := resp.GetAccessibleTopology().GetSegments()
+			Expect(segments).ToNot(BeNil())
+
+			Expect(segments[common.TopologyKeyZone]).To(Equal(z))
+			Expect(len(segments)).To(Equal(1))
+		}
+
+	})
+
+})

--- a/test/e2e/tests/setup_e2e_test.go
+++ b/test/e2e/tests/setup_e2e_test.go
@@ -16,16 +16,26 @@ package tests
 
 import (
 	"flag"
+	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	compute "google.golang.org/api/compute/v1"
+	remote "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/test/binremote"
+	testutils "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/test/e2e/utils"
 )
 
 var (
-	project        = flag.String("project", "", "Project to run tests in")
-	serviceAccount = flag.String("service-account", "", "Service account to bring up instance with")
-	runInProw      = flag.Bool("run-in-prow", false, "If true, use a Boskos loaned project and special CI service accounts and ssh keys")
+	project         = flag.String("project", "", "Project to run tests in")
+	serviceAccount  = flag.String("service-account", "", "Service account to bring up instance with")
+	runInProw       = flag.Bool("run-in-prow", false, "If true, use a Boskos loaned project and special CI service accounts and ssh keys")
+	deleteInstances = flag.Bool("delete-instances", false, "Delete the instances after tests run")
+
+	testInstances  = []*remote.InstanceInfo{}
+	computeService *compute.Service
 )
 
 func TestE2E(t *testing.T) {
@@ -33,3 +43,45 @@ func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Google Compute Engine Persistent Disk Container Storage Interface Driver Tests")
 }
+
+var _ = BeforeSuite(func() {
+	var err error
+	zones := []string{"us-central1-c", "us-central1-b"}
+
+	rand.Seed(time.Now().UnixNano())
+
+	computeService, err = remote.GetComputeClient()
+	Expect(err).To(BeNil())
+
+	for _, zone := range zones {
+		nodeID := fmt.Sprintf("gce-pd-csi-e2e-%s", zone)
+
+		if *runInProw {
+			*project, *serviceAccount = testutils.SetupProwConfig()
+		}
+
+		Expect(*project).ToNot(BeEmpty(), "Project should not be empty")
+		Expect(*serviceAccount).ToNot(BeEmpty(), "Service account should not be empty")
+
+		i, err := testutils.SetupInstance(*project, zone, nodeID, *serviceAccount, computeService)
+		Expect(err).To(BeNil())
+
+		testInstances = append(testInstances, i)
+	}
+
+})
+
+var _ = AfterSuite(func() {
+	/*
+		err := node.client.CloseConn()
+		if err != nil {
+			Logf("Failed to close the client")
+		} else {
+			Logf("Closed the client")
+	*/
+	for _, i := range testInstances {
+		if *deleteInstances {
+			i.DeleteInstance()
+		}
+	}
+})

--- a/test/e2e/utils/client_wrappers.go
+++ b/test/e2e/utils/client_wrappers.go
@@ -87,10 +87,13 @@ func (c *CsiClient) CloseConn() error {
 	return c.conn.Close()
 }
 
-func (c *CsiClient) CreateVolume(volName string) (string, error) {
+func (c *CsiClient) CreateVolume(volName string, topReq *csipb.TopologyRequirement) (string, error) {
 	cvr := &csipb.CreateVolumeRequest{
 		Name:               volName,
 		VolumeCapabilities: stdVolCaps,
+	}
+	if topReq != nil {
+		cvr.AccessibilityRequirements = topReq
 	}
 	cresp, err := c.ctrlClient.CreateVolume(context.Background(), cvr)
 	if err != nil {
@@ -165,4 +168,9 @@ func (c *CsiClient) NodePublishVolume(volumeId, stageDir, publishDir string) err
 	}
 	_, err := c.nodeClient.NodePublishVolume(context.Background(), nodePublishReq)
 	return err
+}
+
+func (c *CsiClient) NodeGetInfo() (*csipb.NodeGetInfoResponse, error) {
+	resp, err := c.nodeClient.NodeGetInfo(context.Background(), &csipb.NodeGetInfoRequest{})
+	return resp, err
 }

--- a/test/run-e2e-local.sh
+++ b/test/run-e2e-local.sh
@@ -5,4 +5,4 @@ set -o errexit
 
 readonly PKGDIR=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 
-go test --v=true "${PKGDIR}/test/e2e/tests" --logtostderr --project ${PROJECT} --service-account ${IAM_NAME}
+ginkgo -v "test/e2e/tests" --logtostderr -- --project ${PROJECT} --service-account ${IAM_NAME}

--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -5,4 +5,4 @@ set -x
 
 readonly PKGDIR=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 
-go test --v=true "${PKGDIR}/test/e2e/tests" --logtostderr --run-in-prow=true
+go test --v=true "${PKGDIR}/test/e2e/tests" --logtostderr --run-in-prow=true --delete-instances=true

--- a/test/run-unit.sh
+++ b/test/run-unit.sh
@@ -8,4 +8,4 @@ readonly PKGDIR=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 go test -timeout 30s "${PKGDIR}/pkg/gce-pd-csi-driver"
 # The following have no unit tests yet
 #go test -timeout 30s "${PKGDIR}/pkg/mount-manager"
-#go test -timeout 30s "${PKGDIR}/pkg/gce-cloud-provider"
+#go test -timeout 30s "${PKGDIR}/pkg/gce-cloud-provider/compute"

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -19,7 +19,8 @@ import (
 
 	sanity "github.com/kubernetes-csi/csi-test/pkg/sanity"
 	compute "google.golang.org/api/compute/v1"
-	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider"
+	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute"
+	metadataservice "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/metadata"
 	driver "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-pd-csi-driver"
 	mountmanager "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/mount-manager"
 )
@@ -46,7 +47,7 @@ func TestSanity(t *testing.T) {
 	deviceUtils := mountmanager.NewFakeDeviceUtils()
 
 	//Initialize GCE Driver
-	err = gceDriver.SetupGCEDriver(cloudProvider, mounter, deviceUtils, driverName, nodeID, vendorVersion)
+	err = gceDriver.SetupGCEDriver(cloudProvider, mounter, deviceUtils, metadataservice.NewFakeService(), driverName, nodeID, vendorVersion)
 	if err != nil {
 		t.Fatalf("Failed to initialize GCE CSI Driver: %v", err)
 	}

--- a/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/identity.go
+++ b/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/identity.go
@@ -30,13 +30,13 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("GetPluginCapabilities [Identity Service]", func() {
+var _ = DescribeSanity("GetPluginCapabilities [Identity Service]", func(sc *SanityContext) {
 	var (
 		c csi.IdentityClient
 	)
 
 	BeforeEach(func() {
-		c = csi.NewIdentityClient(conn)
+		c = csi.NewIdentityClient(sc.Conn)
 	})
 
 	It("should return appropriate capabilities", func() {
@@ -50,6 +50,7 @@ var _ = Describe("GetPluginCapabilities [Identity Service]", func() {
 		for _, cap := range res.GetCapabilities() {
 			switch cap.GetService().GetType() {
 			case csi.PluginCapability_Service_CONTROLLER_SERVICE:
+			case csi.PluginCapability_Service_ACCESSIBILITY_CONSTRAINTS:
 			default:
 				Fail(fmt.Sprintf("Unknown capability: %v\n", cap.GetService().GetType()))
 			}
@@ -59,13 +60,13 @@ var _ = Describe("GetPluginCapabilities [Identity Service]", func() {
 
 })
 
-var _ = Describe("Probe [Identity Service]", func() {
+var _ = DescribeSanity("Probe [Identity Service]", func(sc *SanityContext) {
 	var (
 		c csi.IdentityClient
 	)
 
 	BeforeEach(func() {
-		c = csi.NewIdentityClient(conn)
+		c = csi.NewIdentityClient(sc.Conn)
 	})
 
 	It("should return appropriate information", func() {
@@ -79,16 +80,21 @@ var _ = Describe("Probe [Identity Service]", func() {
 		Expect(ok).To(BeTrue())
 		Expect(serverError.Code() == codes.FailedPrecondition ||
 			serverError.Code() == codes.OK).To(BeTrue())
+
+		if res.GetReady() != nil {
+			Expect(res.GetReady().GetValue() == true ||
+				res.GetReady().GetValue() == false).To(BeTrue())
+		}
 	})
 })
 
-var _ = Describe("GetPluginInfo [Identity Server]", func() {
+var _ = DescribeSanity("GetPluginInfo [Identity Server]", func(sc *SanityContext) {
 	var (
 		c csi.IdentityClient
 	)
 
 	BeforeEach(func() {
-		c = csi.NewIdentityClient(conn)
+		c = csi.NewIdentityClient(sc.Conn)
 	})
 
 	It("should return appropriate information", func() {

--- a/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/node.go
+++ b/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/node.go
@@ -38,7 +38,6 @@ func isNodeCapabilitySupported(c csi.NodeClient,
 		&csi.NodeGetCapabilitiesRequest{})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(caps).NotTo(BeNil())
-	Expect(caps.GetCapabilities()).NotTo(BeNil())
 
 	for _, cap := range caps.GetCapabilities() {
 		Expect(cap.GetRpc()).NotTo(BeNil())
@@ -49,13 +48,33 @@ func isNodeCapabilitySupported(c csi.NodeClient,
 	return false
 }
 
-var _ = Describe("NodeGetCapabilities [Node Server]", func() {
+func isPluginCapabilitySupported(c csi.IdentityClient,
+	capType csi.PluginCapability_Service_Type,
+) bool {
+
+	caps, err := c.GetPluginCapabilities(
+		context.Background(),
+		&csi.GetPluginCapabilitiesRequest{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(caps).NotTo(BeNil())
+	Expect(caps.GetCapabilities()).NotTo(BeNil())
+
+	for _, cap := range caps.GetCapabilities() {
+		Expect(cap.GetService()).NotTo(BeNil())
+		if cap.GetService().GetType() == capType {
+			return true
+		}
+	}
+	return false
+}
+
+var _ = DescribeSanity("NodeGetCapabilities [Node Server]", func(sc *SanityContext) {
 	var (
 		c csi.NodeClient
 	)
 
 	BeforeEach(func() {
-		c = csi.NewNodeClient(conn)
+		c = csi.NewNodeClient(sc.Conn)
 	})
 
 	It("should return appropriate capabilities", func() {
@@ -66,7 +85,6 @@ var _ = Describe("NodeGetCapabilities [Node Server]", func() {
 		By("checking successful response")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(caps).NotTo(BeNil())
-		Expect(caps.GetCapabilities()).NotTo(BeNil())
 
 		for _, cap := range caps.GetCapabilities() {
 			Expect(cap.GetRpc()).NotTo(BeNil())
@@ -81,13 +99,13 @@ var _ = Describe("NodeGetCapabilities [Node Server]", func() {
 	})
 })
 
-var _ = Describe("NodeGetId [Node Server]", func() {
+var _ = DescribeSanity("NodeGetId [Node Server]", func(sc *SanityContext) {
 	var (
 		c csi.NodeClient
 	)
 
 	BeforeEach(func() {
-		c = csi.NewNodeClient(conn)
+		c = csi.NewNodeClient(sc.Conn)
 	})
 
 	It("should return appropriate values", func() {
@@ -101,7 +119,36 @@ var _ = Describe("NodeGetId [Node Server]", func() {
 	})
 })
 
-var _ = Describe("NodePublishVolume [Node Server]", func() {
+var _ = DescribeSanity("NodeGetInfo [Node Server]", func(sc *SanityContext) {
+	var (
+		c                                csi.NodeClient
+		i                                csi.IdentityClient
+		accessibilityConstraintSupported bool
+	)
+
+	BeforeEach(func() {
+		c = csi.NewNodeClient(sc.Conn)
+		i = csi.NewIdentityClient(sc.Conn)
+		accessibilityConstraintSupported = isPluginCapabilitySupported(i, csi.PluginCapability_Service_ACCESSIBILITY_CONSTRAINTS)
+	})
+
+	It("should return approproate values", func() {
+		ninfo, err := c.NodeGetInfo(
+			context.Background(),
+			&csi.NodeGetInfoRequest{})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ninfo).NotTo(BeNil())
+		Expect(ninfo.GetNodeId()).NotTo(BeEmpty())
+		Expect(ninfo.GetMaxVolumesPerNode()).NotTo(BeNumerically("<", 0))
+
+		if accessibilityConstraintSupported {
+			Expect(ninfo.GetAccessibleTopology()).NotTo(BeNil())
+		}
+	})
+})
+
+var _ = DescribeSanity("NodePublishVolume [Node Server]", func(sc *SanityContext) {
 	var (
 		s                          csi.ControllerClient
 		c                          csi.NodeClient
@@ -110,14 +157,14 @@ var _ = Describe("NodePublishVolume [Node Server]", func() {
 	)
 
 	BeforeEach(func() {
-		s = csi.NewControllerClient(conn)
-		c = csi.NewNodeClient(conn)
+		s = csi.NewControllerClient(sc.Conn)
+		c = csi.NewNodeClient(sc.Conn)
 		controllerPublishSupported = isControllerCapabilitySupported(
 			s,
 			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME)
 		nodeStageSupported = isNodeCapabilitySupported(c, csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME)
 		if nodeStageSupported {
-			err := createMountTargetLocation(config.StagingPath)
+			err := createMountTargetLocation(sc.Config.StagingPath)
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})
@@ -126,8 +173,8 @@ var _ = Describe("NodePublishVolume [Node Server]", func() {
 
 		req := &csi.NodePublishVolumeRequest{}
 
-		if secrets != nil {
-			req.NodePublishSecrets = secrets.NodePublishVolumeSecret
+		if sc.Secrets != nil {
+			req.NodePublishSecrets = sc.Secrets.NodePublishVolumeSecret
 		}
 
 		_, err := c.NodePublishVolume(context.Background(), req)
@@ -144,8 +191,8 @@ var _ = Describe("NodePublishVolume [Node Server]", func() {
 			VolumeId: "id",
 		}
 
-		if secrets != nil {
-			req.NodePublishSecrets = secrets.NodePublishVolumeSecret
+		if sc.Secrets != nil {
+			req.NodePublishSecrets = sc.Secrets.NodePublishVolumeSecret
 		}
 
 		_, err := c.NodePublishVolume(context.Background(), req)
@@ -160,11 +207,11 @@ var _ = Describe("NodePublishVolume [Node Server]", func() {
 
 		req := &csi.NodePublishVolumeRequest{
 			VolumeId:   "id",
-			TargetPath: config.TargetPath,
+			TargetPath: sc.Config.TargetPath,
 		}
 
-		if secrets != nil {
-			req.NodePublishSecrets = secrets.NodePublishVolumeSecret
+		if sc.Secrets != nil {
+			req.NodePublishSecrets = sc.Secrets.NodePublishVolumeSecret
 		}
 
 		_, err := c.NodePublishVolume(context.Background(), req)
@@ -176,11 +223,11 @@ var _ = Describe("NodePublishVolume [Node Server]", func() {
 	})
 
 	It("should return appropriate values (no optional values added)", func() {
-		testFullWorkflowSuccess(s, c, controllerPublishSupported, nodeStageSupported)
+		testFullWorkflowSuccess(sc, s, c, controllerPublishSupported, nodeStageSupported)
 	})
 })
 
-var _ = Describe("NodeUnpublishVolume [Node Server]", func() {
+var _ = DescribeSanity("NodeUnpublishVolume [Node Server]", func(sc *SanityContext) {
 	var (
 		s                          csi.ControllerClient
 		c                          csi.NodeClient
@@ -189,14 +236,14 @@ var _ = Describe("NodeUnpublishVolume [Node Server]", func() {
 	)
 
 	BeforeEach(func() {
-		s = csi.NewControllerClient(conn)
-		c = csi.NewNodeClient(conn)
+		s = csi.NewControllerClient(sc.Conn)
+		c = csi.NewNodeClient(sc.Conn)
 		controllerPublishSupported = isControllerCapabilitySupported(
 			s,
 			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME)
 		nodeStageSupported = isNodeCapabilitySupported(c, csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME)
 		if nodeStageSupported {
-			err := createMountTargetLocation(config.StagingPath)
+			err := createMountTargetLocation(sc.Config.StagingPath)
 			Expect(err).NotTo(HaveOccurred())
 		}
 	})
@@ -228,12 +275,12 @@ var _ = Describe("NodeUnpublishVolume [Node Server]", func() {
 	})
 
 	It("should return appropriate values (no optional values added)", func() {
-		testFullWorkflowSuccess(s, c, controllerPublishSupported, nodeStageSupported)
+		testFullWorkflowSuccess(sc, s, c, controllerPublishSupported, nodeStageSupported)
 	})
 })
 
 // TODO: Tests for NodeStageVolume/NodeUnstageVolume
-func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controllerPublishSupported, nodeStageSupported bool) {
+func testFullWorkflowSuccess(sc *SanityContext, s csi.ControllerClient, c csi.NodeClient, controllerPublishSupported, nodeStageSupported bool) {
 	// Create Volume First
 	By("creating a single node writer volume")
 	name := "sanity"
@@ -251,8 +298,8 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 		},
 	}
 
-	if secrets != nil {
-		req.ControllerCreateSecrets = secrets.CreateVolumeSecret
+	if sc.Secrets != nil {
+		req.ControllerCreateSecrets = sc.Secrets.CreateVolumeSecret
 	}
 
 	vol, err := s.CreateVolume(context.Background(), req)
@@ -283,11 +330,12 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
 				},
 			},
-			Readonly: false,
+			VolumeAttributes: vol.GetVolume().GetAttributes(),
+			Readonly:         false,
 		}
 
-		if secrets != nil {
-			pubReq.ControllerPublishSecrets = secrets.ControllerPublishVolumeSecret
+		if sc.Secrets != nil {
+			pubReq.ControllerPublishSecrets = sc.Secrets.ControllerPublishVolumeSecret
 		}
 
 		conpubvol, err = s.ControllerPublishVolume(context.Background(), pubReq)
@@ -307,13 +355,14 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
 				},
 			},
-			StagingTargetPath: config.StagingPath,
+			StagingTargetPath: sc.Config.StagingPath,
+			VolumeAttributes:  vol.GetVolume().GetAttributes(),
 		}
 		if controllerPublishSupported {
 			nodeStageVolReq.PublishInfo = conpubvol.GetPublishInfo()
 		}
-		if secrets != nil {
-			nodeStageVolReq.NodeStageSecrets = secrets.NodeStageVolumeSecret
+		if sc.Secrets != nil {
+			nodeStageVolReq.NodeStageSecrets = sc.Secrets.NodeStageVolumeSecret
 		}
 		nodestagevol, err := c.NodeStageVolume(
 			context.Background(), nodeStageVolReq)
@@ -324,7 +373,7 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 	By("publishing the volume on a node")
 	nodepubvolRequest := &csi.NodePublishVolumeRequest{
 		VolumeId:   vol.GetVolume().GetId(),
-		TargetPath: config.TargetPath,
+		TargetPath: sc.Config.TargetPath,
 		VolumeCapability: &csi.VolumeCapability{
 			AccessType: &csi.VolumeCapability_Mount{
 				Mount: &csi.VolumeCapability_MountVolume{},
@@ -333,15 +382,16 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
 			},
 		},
+		VolumeAttributes: vol.GetVolume().GetAttributes(),
 	}
 	if nodeStageSupported {
-		nodepubvolRequest.StagingTargetPath = config.StagingPath
+		nodepubvolRequest.StagingTargetPath = sc.Config.StagingPath
 	}
 	if controllerPublishSupported {
 		nodepubvolRequest.PublishInfo = conpubvol.GetPublishInfo()
 	}
-	if secrets != nil {
-		nodepubvolRequest.NodePublishSecrets = secrets.NodePublishVolumeSecret
+	if sc.Secrets != nil {
+		nodepubvolRequest.NodePublishSecrets = sc.Secrets.NodePublishVolumeSecret
 	}
 	nodepubvol, err := c.NodePublishVolume(context.Background(), nodepubvolRequest)
 	Expect(err).NotTo(HaveOccurred())
@@ -353,7 +403,7 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 		context.Background(),
 		&csi.NodeUnpublishVolumeRequest{
 			VolumeId:   vol.GetVolume().GetId(),
-			TargetPath: config.TargetPath,
+			TargetPath: sc.Config.TargetPath,
 		})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(nodeunpubvol).NotTo(BeNil())
@@ -364,7 +414,7 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 			context.Background(),
 			&csi.NodeUnstageVolumeRequest{
 				VolumeId:          vol.GetVolume().GetId(),
-				StagingTargetPath: config.StagingPath,
+				StagingTargetPath: sc.Config.StagingPath,
 			},
 		)
 		Expect(err).NotTo(HaveOccurred())
@@ -379,8 +429,8 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 			NodeId:   nid.GetNodeId(),
 		}
 
-		if secrets != nil {
-			unpubReq.ControllerUnpublishSecrets = secrets.ControllerUnpublishVolumeSecret
+		if sc.Secrets != nil {
+			unpubReq.ControllerUnpublishSecrets = sc.Secrets.ControllerUnpublishVolumeSecret
 		}
 
 		controllerunpubvol, err := s.ControllerUnpublishVolume(context.Background(), unpubReq)
@@ -394,15 +444,15 @@ func testFullWorkflowSuccess(s csi.ControllerClient, c csi.NodeClient, controlle
 		VolumeId: vol.GetVolume().GetId(),
 	}
 
-	if secrets != nil {
-		delReq.ControllerDeleteSecrets = secrets.DeleteVolumeSecret
+	if sc.Secrets != nil {
+		delReq.ControllerDeleteSecrets = sc.Secrets.DeleteVolumeSecret
 	}
 
 	_, err = s.DeleteVolume(context.Background(), delReq)
 	Expect(err).NotTo(HaveOccurred())
 }
 
-var _ = Describe("NodeStageVolume [Node Server]", func() {
+var _ = DescribeSanity("NodeStageVolume [Node Server]", func(sc *SanityContext) {
 	var (
 		s                          csi.ControllerClient
 		c                          csi.NodeClient
@@ -412,15 +462,15 @@ var _ = Describe("NodeStageVolume [Node Server]", func() {
 	)
 
 	BeforeEach(func() {
-		s = csi.NewControllerClient(conn)
-		c = csi.NewNodeClient(conn)
+		s = csi.NewControllerClient(sc.Conn)
+		c = csi.NewNodeClient(sc.Conn)
 		device = "/dev/mock"
 		controllerPublishSupported = isControllerCapabilitySupported(
 			s,
 			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME)
 		nodeStageSupported = isNodeCapabilitySupported(c, csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME)
 		if nodeStageSupported {
-			err := createMountTargetLocation(config.StagingPath)
+			err := createMountTargetLocation(sc.Config.StagingPath)
 			Expect(err).NotTo(HaveOccurred())
 		} else {
 			Skip("NodeStageVolume not supported")
@@ -430,7 +480,7 @@ var _ = Describe("NodeStageVolume [Node Server]", func() {
 	It("should fail when no volume id is provided", func() {
 
 		req := &csi.NodeStageVolumeRequest{
-			StagingTargetPath: config.StagingPath,
+			StagingTargetPath: sc.Config.StagingPath,
 			VolumeCapability: &csi.VolumeCapability{
 				AccessType: &csi.VolumeCapability_Mount{
 					Mount: &csi.VolumeCapability_MountVolume{},
@@ -444,8 +494,8 @@ var _ = Describe("NodeStageVolume [Node Server]", func() {
 			},
 		}
 
-		if secrets != nil {
-			req.NodeStageSecrets = secrets.NodeStageVolumeSecret
+		if sc.Secrets != nil {
+			req.NodeStageSecrets = sc.Secrets.NodeStageVolumeSecret
 		}
 
 		_, err := c.NodeStageVolume(context.Background(), req)
@@ -473,8 +523,8 @@ var _ = Describe("NodeStageVolume [Node Server]", func() {
 			},
 		}
 
-		if secrets != nil {
-			req.NodeStageSecrets = secrets.NodeStageVolumeSecret
+		if sc.Secrets != nil {
+			req.NodeStageSecrets = sc.Secrets.NodeStageVolumeSecret
 		}
 
 		_, err := c.NodeStageVolume(context.Background(), req)
@@ -489,14 +539,14 @@ var _ = Describe("NodeStageVolume [Node Server]", func() {
 
 		req := &csi.NodeStageVolumeRequest{
 			VolumeId:          "id",
-			StagingTargetPath: config.StagingPath,
+			StagingTargetPath: sc.Config.StagingPath,
 			PublishInfo: map[string]string{
 				"device": device,
 			},
 		}
 
-		if secrets != nil {
-			req.NodeStageSecrets = secrets.NodeStageVolumeSecret
+		if sc.Secrets != nil {
+			req.NodeStageSecrets = sc.Secrets.NodeStageVolumeSecret
 		}
 
 		_, err := c.NodeStageVolume(context.Background(), req)
@@ -508,11 +558,11 @@ var _ = Describe("NodeStageVolume [Node Server]", func() {
 	})
 
 	It("should return appropriate values (no optional values added)", func() {
-		testFullWorkflowSuccess(s, c, controllerPublishSupported, nodeStageSupported)
+		testFullWorkflowSuccess(sc, s, c, controllerPublishSupported, nodeStageSupported)
 	})
 })
 
-var _ = Describe("NodeUnstageVolume [Node Server]", func() {
+var _ = DescribeSanity("NodeUnstageVolume [Node Server]", func(sc *SanityContext) {
 	var (
 		s                          csi.ControllerClient
 		c                          csi.NodeClient
@@ -521,14 +571,14 @@ var _ = Describe("NodeUnstageVolume [Node Server]", func() {
 	)
 
 	BeforeEach(func() {
-		s = csi.NewControllerClient(conn)
-		c = csi.NewNodeClient(conn)
+		s = csi.NewControllerClient(sc.Conn)
+		c = csi.NewNodeClient(sc.Conn)
 		controllerPublishSupported = isControllerCapabilitySupported(
 			s,
 			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME)
 		nodeStageSupported = isNodeCapabilitySupported(c, csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME)
 		if nodeStageSupported {
-			err := createMountTargetLocation(config.StagingPath)
+			err := createMountTargetLocation(sc.Config.StagingPath)
 			Expect(err).NotTo(HaveOccurred())
 		} else {
 			Skip("NodeUnstageVolume not supported")
@@ -540,7 +590,7 @@ var _ = Describe("NodeUnstageVolume [Node Server]", func() {
 		_, err := c.NodeUnstageVolume(
 			context.Background(),
 			&csi.NodeUnstageVolumeRequest{
-				StagingTargetPath: config.StagingPath,
+				StagingTargetPath: sc.Config.StagingPath,
 			})
 		Expect(err).To(HaveOccurred())
 
@@ -564,6 +614,6 @@ var _ = Describe("NodeUnstageVolume [Node Server]", func() {
 	})
 
 	It("should return appropriate values (no optional values added)", func() {
-		testFullWorkflowSuccess(s, c, controllerPublishSupported, nodeStageSupported)
+		testFullWorkflowSuccess(sc, s, c, controllerPublishSupported, nodeStageSupported)
 	})
 })

--- a/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/sanity.go
+++ b/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/sanity.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"sync"
 	"testing"
 
 	"github.com/kubernetes-csi/csi-test/utils"
@@ -40,16 +39,12 @@ type CSISecrets struct {
 	ControllerUnpublishVolumeSecret map[string]string `yaml:"ControllerUnpublishVolumeSecret"`
 	NodeStageVolumeSecret           map[string]string `yaml:"NodeStageVolumeSecret"`
 	NodePublishVolumeSecret         map[string]string `yaml:"NodePublishVolumeSecret"`
+	CreateSnapshotSecret            map[string]string `yaml:"CreateSnapshotSecret"`
+	DeleteSnapshotSecret            map[string]string `yaml:"DeleteSnapshotSecret"`
 }
 
-var (
-	config  *Config
-	conn    *grpc.ClientConn
-	lock    sync.Mutex
-	secrets *CSISecrets
-)
-
-// Config provides the configuration for the sanity tests
+// Config provides the configuration for the sanity tests. It
+// needs to be initialized by the user of the sanity package.
 type Config struct {
 	TargetPath     string
 	StagingPath    string
@@ -58,40 +53,61 @@ type Config struct {
 	TestVolumeSize int64
 }
 
-// Test will test the CSI driver at the specified address
-func Test(t *testing.T, reqConfig *Config) {
-	lock.Lock()
-	defer lock.Unlock()
+// SanityContext holds the variables that each test can depend on. It
+// gets initialized before each test block runs.
+type SanityContext struct {
+	Config  *Config
+	Conn    *grpc.ClientConn
+	Secrets *CSISecrets
+}
 
-	config = reqConfig
+// Test will test the CSI driver at the specified address by
+// setting up a Ginkgo suite and running it.
+func Test(t *testing.T, reqConfig *Config) {
+	sc := &SanityContext{
+		Config: reqConfig,
+	}
+
+	registerTestsInGinkgo(sc)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CSI Driver Test Suite")
 }
 
-var _ = BeforeSuite(func() {
+func GinkgoTest(reqConfig *Config) {
+	sc := &SanityContext{
+		Config: reqConfig,
+	}
+
+	registerTestsInGinkgo(sc)
+}
+
+func (sc *SanityContext) setup() {
 	var err error
 
-	if len(config.SecretsFile) > 0 {
-		secrets, err = loadSecrets(config.SecretsFile)
+	if len(sc.Config.SecretsFile) > 0 {
+		sc.Secrets, err = loadSecrets(sc.Config.SecretsFile)
 		Expect(err).NotTo(HaveOccurred())
 	}
 
 	By("connecting to CSI driver")
-	conn, err = utils.Connect(config.Address)
+	sc.Conn, err = utils.Connect(sc.Config.Address)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("creating mount and staging directories")
-	err = createMountTargetLocation(config.TargetPath)
+	err = createMountTargetLocation(sc.Config.TargetPath)
 	Expect(err).NotTo(HaveOccurred())
-	if len(config.StagingPath) > 0 {
-		err = createMountTargetLocation(config.StagingPath)
+	if len(sc.Config.StagingPath) > 0 {
+		err = createMountTargetLocation(sc.Config.StagingPath)
 		Expect(err).NotTo(HaveOccurred())
 	}
-})
+}
 
-var _ = AfterSuite(func() {
-	conn.Close()
-})
+func (sc *SanityContext) teardown() {
+	if sc.Conn != nil {
+		sc.Conn.Close()
+		sc.Conn = nil
+	}
+}
 
 func createMountTargetLocation(targetPath string) error {
 	fileInfo, err := os.Stat(targetPath)

--- a/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/tests.go
+++ b/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/tests.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2018 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sanity
+
+import (
+	. "github.com/onsi/ginkgo"
+)
+
+type test struct {
+	text string
+	body func(*SanityContext)
+}
+
+var tests []test
+
+// DescribeSanity must be used instead of the usual Ginkgo Describe to
+// register a test block. The difference is that the body function
+// will be called multiple times with the right context (when
+// setting up a Ginkgo suite or a testing.T test, with the right
+// configuration).
+func DescribeSanity(text string, body func(*SanityContext)) bool {
+	tests = append(tests, test{text, body})
+	return true
+}
+
+// registerTestsInGinkgo invokes the actual Gingko Describe
+// for the tests registered earlier with DescribeSanity.
+func registerTestsInGinkgo(sc *SanityContext) {
+	for _, test := range tests {
+		Describe(test.text, func() {
+
+			BeforeEach(func() {
+				sc.setup()
+			})
+
+			AfterEach(func() {
+				sc.teardown()
+			})
+
+			test.body(sc)
+		})
+	}
+}


### PR DESCRIPTION
The driver will return the node toplogy on `GetNodeInfo` and supports simple `Requisite` topology specification on the create volume call.

Also the testing infrastructure was changed to support topology.

Fixes: #13

/assign @msau42 
/assign @verult