### PR TITLE
Don't FS Type Parameter

### DIFF
--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -80,8 +80,6 @@ func (gceCS *GCEControllerServer) CreateVolume(ctx context.Context, req *csi.Cre
 
 	// TODO(#94): Validate volume capabilities
 
-	// TODO(#93): Support fs type parameter
-
 	// Apply Parameters (case-insensitive). We leave validation of
 	// the values to the cloud provider.
 	diskType := "pd-standard"


### PR DESCRIPTION
No need to support FS Type parameter, it is already supported as a first class field in CSI through volume capabilities.

This PR just removes the TODO
Fixes: #93 

/assign @msau42 