### PR TITLE
[WIP] RBAC roles and rolebindings for external provisioner leader election

### DIFF
--- a/deploy/kubernetes/dev/setup-cluster.yaml
+++ b/deploy/kubernetes/dev/setup-cluster.yaml
@@ -68,3 +68,28 @@ roleRef:
   kind: ClusterRole
   name: system:csi-external-provisioner
   apiGroup: rbac.authorization.k8s.io
+---
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: leader-locking-csi-external-provisioner
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: leader-locking-csi-external-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: csi-controller-sa
+    namespace: default
+roleRef:
+  kind: Role
+  name: leader-locking-csi-external-provisioner
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/kubernetes/stable/setup-cluster.yaml
+++ b/deploy/kubernetes/stable/setup-cluster.yaml
@@ -68,3 +68,29 @@ roleRef:
   kind: ClusterRole
   name: system:csi-external-provisioner
   apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: leader-locking-csi-external-provisioner
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: leader-locking-csi-external-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: csi-controller-sa
+    namespace: default
+roleRef:
+  kind: Role
+  name: leader-locking-csi-external-provisioner
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This past quarter, leader election was implemented for external-provisioner, which now requires full ReadWrite permissions for Endpoints objects. This is a bit scary since a compromised provisioner can then reroute network traffic. PR https://github.com/kubernetes-incubator/external-storage/pull/957 introduced the ability to make external-provisioner leader election. This PR is a draft of required RBAC changes if leader election were to be kept enabled.

Do we want to disable leader election? Does this RBAC role pose a risk for GCE? Or maybe the provisioner should use a different leader election technique altogether, and we could push for that in future releases and have a temporary measure for the time being.

@davidz627 @msau42 @saad-ali @jingxu97