### PR TITLE
Bump CSI External Components to v0.3.0+ and turn on Kubelet Registration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,9 @@ gce-pd-driver:
 	go build -ldflags "-X main.vendorVersion=${STAGINGVERSION}" -o bin/gce-pd-csi-driver ./cmd/
 
 build-container:
-	ifndef GCE_PD_CSI_STAGING_IMAGE
-		$(error "Must set environment variable GCE_PD_CSI_STAGING_IMAGE to staging image repository")
-	endif
+ifndef GCE_PD_CSI_STAGING_IMAGE
+	$(error "Must set environment variable GCE_PD_CSI_STAGING_IMAGE to staging image repository")
+endif
 	docker build --build-arg TAG=$(STAGINGVERSION) -t $(STAGINGIMAGE):$(STAGINGVERSION) .
 
 push-container: build-container

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 WARNING: This driver is in ALPHA currently. This means that there may be
 potentially backwards compatability breaking changes moving forward. Do NOT use
-this drive in a production environment in its current state.
+this driver in a production environment in its current state.
+
+WARNING: The ALPHA driver is NOT compatible with Kubernetes versions 1.12+.
 
 DISCLAIMER: This is not an officially supported Google product
 
@@ -23,7 +25,10 @@ Latest image: `gcr.io/google-containers/volume-csi/gcp-compute-persistent-disk-c
 This plugin is compatible with CSI versions [v0.2.0](https://github.com/container-storage-interface/spec/blob/v0.2.0/spec.md) and [v0.3.0](https://github.com/container-storage-interface/spec/blob/v0.3.0/spec.md)
 
 ### Kubernetes Compatibility
-This plugin can be used as-is beginning with Kubernetes v1.10.5
+| GCE PD CSI Driver\Kubernetes Version | 1.10.5 - 1.11 | 1.12+ |
+|--------------------------------------|---------------|------|
+| v0.1.0.alpha (stable)                | yes           | no   |
+| dev                                  | no            | yes  |
 
 ### Known Issues
 See Github [Issues](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues)

--- a/deploy/kubernetes/dev/controller.yaml
+++ b/deploy/kubernetes/dev/controller.yaml
@@ -17,10 +17,10 @@ spec:
       containers:
         - name: csi-provisioner
           imagePullPolicy: Always
-          image: quay.io/k8scsi/csi-provisioner:v0.2.0
+          image: quay.io/k8scsi/csi-provisioner:v0.3.1
           args:
             - "--v=5"
-            - "--provisioner=csi-gce-pd"
+            - "--provisioner=com.google.csi.gcepd"
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
@@ -30,7 +30,7 @@ spec:
               mountPath: /csi
         - name: csi-attacher
           imagePullPolicy: Always
-          image: quay.io/k8scsi/csi-attacher:v0.2.0
+          image: quay.io/k8scsi/csi-attacher:v0.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/deploy/kubernetes/dev/node.yaml
+++ b/deploy/kubernetes/dev/node.yaml
@@ -16,22 +16,23 @@ spec:
       containers:
         - name: csi-driver-registrar
           imagePullPolicy: Always
-          image: quay.io/k8scsi/driver-registrar:v0.2.0
+          image: quay.io/k8scsi/driver-registrar:v0.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=/var/lib/kubelet/plugins/com.google.csi.gcepd/csi.sock"
           env:
             - name: ADDRESS
-              value: /csi/csi.sock
+              value: /var/lib/kubelet/plugins/com.google.csi.gcepd/csi.sock
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
             - name: plugin-dir
-              mountPath: /csi
-          #  - name: registrar-socket-dir
-          #    mountPath: /var/lib/csi/sockets/
+              mountPath: /var/lib/kubelet/plugins/com.google.csi.gcepd/
+            - name: registration-dir
+              mountPath: /registration
         - name: gce-pd-driver
           securityContext:
             privileged: true
@@ -52,11 +53,10 @@ spec:
             - name: device-dir
               mountPath: /host/dev
       volumes:
-        # TODO(#92): this will work when kublet registrar functionality exists
-        #- name: registrar-socket-dir
-        #  hostPath:
-        #    path: /var/lib/kubelet/device-plugins/
-        #    type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/
+            type: Directory
         - name: kubelet-dir
           hostPath:
             path: /var/lib/kubelet

--- a/examples/kubernetes/demo-regional-sc.yaml
+++ b/examples/kubernetes/demo-regional-sc.yaml
@@ -2,7 +2,7 @@ apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
 metadata:
   name: csi-gce-pd
-provisioner: csi-gce-pd
+provisioner: com.google.csi.gcepd
 parameters:
   type: pd-standard
   replication-type: regional-pd

--- a/examples/kubernetes/demo-zonal-sc.yaml
+++ b/examples/kubernetes/demo-zonal-sc.yaml
@@ -2,7 +2,7 @@ apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
 metadata:
   name: csi-gce-pd
-provisioner: csi-gce-pd
+provisioner: com.google.csi.gcepd
 parameters:
   type: pd-standard
 volumeBindingMode: Immediate


### PR DESCRIPTION
Fixes: #116 
Fixes: #92 

Turns on Kubelet Registration which is required for interop with Kubernetes 1.12+

/assign @msau42 
