### PR TITLE
Support UNSPECIFIED zone and project in volume ID. Static driver name. To prep for migration

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,8 +34,11 @@ func init() {
 
 var (
 	endpoint      = flag.String("endpoint", "unix:/tmp/csi.sock", "CSI endpoint")
-	driverName    = flag.String("drivername", "com.google.csi.gcepd", "name of the driver")
 	vendorVersion string
+)
+
+const (
+	driverName = "com.google.csi.gcepd"
 )
 
 func main() {
@@ -67,7 +70,7 @@ func handle() {
 		glog.Fatalf("Failed to set up metadata service: %v", err)
 	}
 
-	err = gceDriver.SetupGCEDriver(cloudProvider, mounter, deviceUtils, ms, *driverName, vendorVersion)
+	err = gceDriver.SetupGCEDriver(cloudProvider, mounter, deviceUtils, ms, driverName, vendorVersion)
 	if err != nil {
 		glog.Fatalf("Failed to initialize GCE CSI Driver: %v", err)
 	}

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -26,4 +26,6 @@ const (
 
 	// VolumeAttributes for Partition
 	VolumeAttributePartition = "partition"
+
+	UnspecifiedValue = "UNSPECIFIED"
 )

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -27,7 +27,9 @@ import (
 const (
 	// Volume ID Expected Format
 	// "projects/{projectName}/zones/{zoneName}/disks/{diskName}"
+	volIDZonalFmt = "projects/%s/zones/%s/disks/%s"
 	// "projects/{projectName}/regions/{regionName}/disks/{diskName}"
+	volIDRegionalFmt   = "projects/%s/regions/%s/disks/%s"
 	volIDToplogyKey    = 2
 	volIDToplogyValue  = 3
 	volIDDiskNameValue = 5
@@ -69,6 +71,13 @@ func VolumeIDToKey(id string) (*meta.Key, error) {
 	} else {
 		return nil, fmt.Errorf("could not get id components, expected either zones or regions, got: %v", splitId[volIDToplogyKey])
 	}
+}
+
+func GenerateUnderspecifiedVolumeID(diskName string, isZonal bool) string {
+	if isZonal {
+		return fmt.Sprintf(volIDZonalFmt, UnspecifiedValue, UnspecifiedValue, diskName)
+	}
+	return fmt.Sprintf(volIDRegionalFmt, UnspecifiedValue, UnspecifiedValue, diskName)
 }
 
 func SnapshotIDToKey(id string) (string, error) {

--- a/pkg/gce-cloud-provider/compute/cloud-disk.go
+++ b/pkg/gce-cloud-provider/compute/cloud-disk.go
@@ -123,3 +123,14 @@ func (d *CloudDisk) GetSizeGb() int64 {
 		return -1
 	}
 }
+
+func (d *CloudDisk) GetZone() string {
+	switch d.Type() {
+	case Zonal:
+		return d.ZonalDisk.Zone
+	case Regional:
+		return d.RegionalDisk.Zone
+	default:
+		return ""
+	}
+}

--- a/pkg/gce-cloud-provider/compute/gce.go
+++ b/pkg/gce-cloud-provider/compute/gce.go
@@ -51,6 +51,8 @@ type CloudProvider struct {
 	betaService *beta.Service
 	project     string
 	zone        string
+
+	zonesCache map[string]([]string)
 }
 
 var _ GCECompute = &CloudProvider{}
@@ -76,6 +78,7 @@ func CreateCloudProvider(vendorVersion string) (*CloudProvider, error) {
 		betaService: betasvc,
 		project:     project,
 		zone:        zone,
+		zonesCache:  make(map[string]([]string)),
 	}, nil
 
 }

--- a/pkg/gce-pd-csi-driver/gce-pd-driver_test.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver_test.go
@@ -21,10 +21,10 @@ import (
 	metadataservice "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/metadata"
 )
 
-func initGCEDriver(t *testing.T) *GCEDriver {
+func initGCEDriver(t *testing.T, cloudDisks []*gce.CloudDisk) *GCEDriver {
 	vendorVersion := "test-vendor"
 	gceDriver := GetGCEDriver()
-	fakeCloudProvider, err := gce.FakeCreateCloudProvider(project, zone)
+	fakeCloudProvider, err := gce.FakeCreateCloudProvider(project, zone, cloudDisks)
 	if err != nil {
 		t.Fatalf("Failed to create fake cloud provider: %v", err)
 	}

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -37,7 +37,7 @@ func TestSanity(t *testing.T) {
 	// Set up driver and env
 	gceDriver := driver.GetGCEDriver()
 
-	cloudProvider, err := gce.FakeCreateCloudProvider(project, zone)
+	cloudProvider, err := gce.FakeCreateCloudProvider(project, zone, nil)
 	if err != nil {
 		t.Fatalf("Failed to get cloud provider: %v", err)
 	}


### PR DESCRIPTION
When using Kubernetes does migration it may not have access to zone or region of the disk when translating to CSI. This is because k8s GCE PD object uniquely (sort of) identifies disks by PD Name only. We need to support this functionality so in case of an unspecified zone the driver will try to find out where it is by querying all zones.

In the case that the same PD Name is defined in multiple zones, the behavior is undefined. This is consistent with behavior inside Kubernetes and so is sufficient for Migration.

The driver name must also be a well-known name.

/assign @msau42 
/cc @saad-ali 