### PR TITLE
Fix project setup script

### DIFF
--- a/deploy/kubernetes/delete-driver.sh
+++ b/deploy/kubernetes/delete-driver.sh
@@ -11,7 +11,7 @@ set -o nounset
 set -o errexit
 
 readonly DEPLOY_VERSION="${GCE_PD_DRIVER_VERSION:-stable}"
-readonly PKGDIR="${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
+readonly PKGDIR="${GOPATH}/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver"
 source "${PKGDIR}/deploy/common.sh"
 
 ensure_kustomize

--- a/deploy/kubernetes/deploy-driver.sh
+++ b/deploy/kubernetes/deploy-driver.sh
@@ -18,7 +18,7 @@ set -x
 
 readonly NAMESPACE="${GCE_PD_DRIVER_NAMESPACE:-default}"
 readonly DEPLOY_VERSION="${GCE_PD_DRIVER_VERSION:-stable}"
-readonly PKGDIR="${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
+readonly PKGDIR="${GOPATH}/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver"
 source "${PKGDIR}/deploy/common.sh"
 
 print_usage()

--- a/deploy/kubernetes/install-kustomize.sh
+++ b/deploy/kubernetes/install-kustomize.sh
@@ -7,7 +7,7 @@
 set -o nounset
 set -o errexit
 
-readonly INSTALL_DIR="${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/bin"
+readonly INSTALL_DIR="${GOPATH}/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/bin"
 readonly KUSTOMIZE_PATH="${INSTALL_DIR}/kustomize"
 
 if [ ! -f "${KUSTOMIZE_PATH}" ]; then

--- a/deploy/setup-project.sh
+++ b/deploy/setup-project.sh
@@ -17,7 +17,7 @@
 set -o nounset
 set -o errexit
 
-readonly PKGDIR="${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
+readonly PKGDIR="${GOPATH}/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver"
 
 source "${PKGDIR}/deploy/common.sh"
 


### PR DESCRIPTION
Project setup script kept failing for me without these changes with:

```
./setup-project.sh: line 22: /usr/local/.../go/src/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/deploy/common.sh: No such file or directory
```