### PR TITLE
v0.3.0 Release Docs and YAML updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@
 STAGINGIMAGE=${GCE_PD_CSI_STAGING_IMAGE}
 STAGINGVERSION=${GCE_PD_CSI_STAGING_VERSION}
 
-PRODIMAGE=gcr.io/google-containers/volume-csi/gcp-compute-persistent-disk-csi-driver
-PRODVERSION=v0.2.0.beta
+PRODIMAGE=gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver
+PRODVERSION=v0.3.0
 
 all: gce-pd-driver
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
-WARNING: This driver is alpha and may not be compatible between driver versions
-or Kubernetes versions
+WARNING: This driver is beta and should not be used in performance critical applications
 
 DISCLAIMER: This is not an officially supported Google product
-
-Kubernetes Note: setup-cluster.yaml depends on the existence of cluster-roles
-system:csi-external-attacher and system:csi-external-provisioner which are in
-Kubernetes version 1.10.5+
 
 # GCP Compute Persistent Disk CSI Driver
 
@@ -15,18 +10,19 @@ Specification compliant driver used by Container Orchestrators to manage the
 lifecycle of Google Compute Engine Persistent Disks.
 
 ## Project Status
-Status: Alpha
-Latest stable image: `gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver:v0.2.0-gke.0`
+Status: Beta
+Latest stable image: `gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver:v0.3.0-gke.0`
 
 ### CSI Compatibility
-This plugin is compatible with CSI versions [v0.2.0](https://github.com/container-storage-interface/spec/blob/v0.2.0/spec.md) and [v0.3.0](https://github.com/container-storage-interface/spec/blob/v0.3.0/spec.md)
+This plugin is compatible with CSI versions [v1.0.0](https://github.com/container-storage-interface/spec/blob/v1.0.0/spec.md)
 
 ### Kubernetes Compatibility
-| GCE PD CSI Driver\Kubernetes Version | 1.10.5 - 1.11 | 1.12+ |
-|--------------------------------------|---------------|------|
-| v0.1.0.alpha                         | yes           | no   |
-| v0.2.0 (alpha)                       | no            | yes  |
-| dev                                  | no            | yes  |
+| GCE PD CSI Driver\Kubernetes Version | 1.10.5 - 1.11 | 1.12 | 1.13+ | 
+|--------------------------------------|---------------|------|-------|
+| v0.1.0.alpha                         | yes           | no   | no    |
+| v0.2.0 (alpha)                       | no            | yes  | no    |
+| v0.3.0 (beta)                        | no            | no   | yes   |
+| dev                                  | no            | no   | yes   |
 
 ### Known Issues
 See Github [Issues](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues)

--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -19,7 +19,6 @@ spec:
           image: MUSTPATCHWITHKUSTOMIZE
           args:
             - "--v=5"
-            - "--provisioner=pd.csi.storage.gke.io"
             - "--csi-address=/csi/csi.sock"
           volumeMounts:
             - name: socket-dir

--- a/deploy/kubernetes/overlays/dev/controller_images.yaml
+++ b/deploy/kubernetes/overlays/dev/controller_images.yaml
@@ -7,9 +7,9 @@ spec:
     spec:
       containers:
         - name: csi-provisioner
-          image: gcr.io/gke-release/csi-provisioner:v0.4.1-gke.0
+          image: gcr.io/gke-release/csi-provisioner:v1.0.0-gke.0
         - name: csi-attacher
-          image: gcr.io/gke-release/csi-attacher:v0.4.1-gke.0
+          image: gcr.io/gke-release/csi-attacher:v1.0.0-gke.0
         - name: csi-snapshotter
           imagePullPolicy: Always
           image: quay.io/k8scsi/csi-snapshotter:v0.4.0

--- a/deploy/kubernetes/overlays/dev/node_images.yaml
+++ b/deploy/kubernetes/overlays/dev/node_images.yaml
@@ -10,4 +10,4 @@ spec:
           imagePullPolicy: Always
           image: gcr.io/dyzz-csi-staging/csi/gce-pd-driver:latest
         - name: csi-driver-registrar
-          image: gcr.io/gke-release/csi-driver-registrar:v0.4.1-gke.0
+          image: gcr.io/gke-release/csi-driver-registrar:v1.0.0-gke.0

--- a/deploy/kubernetes/overlays/stable/controller_images.yaml
+++ b/deploy/kubernetes/overlays/stable/controller_images.yaml
@@ -7,8 +7,8 @@ spec:
     spec:
       containers:
         - name: csi-provisioner
-          image: gcr.io/gke-release/csi-provisioner:v0.4.1-gke.0
+          image: gcr.io/gke-release/csi-provisioner:v1.0.0-gke.0
         - name: csi-attacher
-          image: gcr.io/gke-release/csi-attacher:v0.4.1-gke.0
+          image: gcr.io/gke-release/csi-attacher:v1.0.0-gke.0
         - name: gce-pd-driver
-          image: gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver:v0.2.0-gke.0
+          image: gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver:v0.3.0-gke.0

--- a/deploy/kubernetes/overlays/stable/node_images.yaml
+++ b/deploy/kubernetes/overlays/stable/node_images.yaml
@@ -7,6 +7,6 @@ spec:
     spec:
       containers:
         - name: csi-driver-registrar
-          image: gcr.io/gke-release/csi-driver-registrar:v0.4.1-gke.0
+          image: gcr.io/gke-release/csi-driver-registrar:v1.0.0-gke.0
         - name: gce-pd-driver
-          image: gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver:v0.2.0-gke.0
+          image: gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver:v0.3.0-gke.0


### PR DESCRIPTION
/hold
until https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/172 goes in and soaks for a while
and release images are cut for all external components and GCE PD Driver

/assign @msau42 