### PR TITLE
Fix kubelet socket path

### DIFF
--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -61,7 +61,7 @@ spec:
       volumes:
         - name: registration-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/
+            path: /var/lib/kubelet/plugins_registry/
             type: Directory
         - name: kubelet-dir
           hostPath:


### PR DESCRIPTION
Kubernetes/kubernetes PR #70494 changed the kubelet plugin watcher
directory from #70494 `{kubelet_root_dir}/plugins/` to
`{kubelet_root_dir}/plugins_registry/`. This PR fixes the deployment
manifests for the GCE PD CSI Driver.