### PR TITLE
Pass ARTIFACTS to k8s e2e

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -205,8 +205,15 @@ func runTests(k8sDir string) error {
 	if err != nil {
 		return err
 	}
-	testArgs := "--test_args=--ginkgo.focus=CSI.*gcePD-external --ginkgo.skip=BlockVolume|\\[Serial\\]|kubelet.*down"
-	cmd := exec.Command("go", "run", "hack/e2e.go", "--", "--check-version-skew=false", "--test", "--ginkgo-parallel", testArgs)
+	artifactsDir, _ := os.LookupEnv("ARTIFACTS")
+	reportArg := fmt.Sprintf("--report-dir=%s", artifactsDir)
+	testArgs := fmt.Sprintf("--test_args=--ginkgo.focus=CSI.*gcePD-external --ginkgo.skip=\\[Serial\\]|kubelet.*down %s", reportArg)
+	cmd := exec.Command("go", "run", "hack/e2e.go",
+		"--",
+		"--check-version-skew=false",
+		"--test",
+		"--ginkgo-parallel",
+		testArgs)
 	err = runCommand("Running Tests", cmd)
 	if err != nil {
 		return fmt.Errorf("failed to run tests on e2e cluster: %v", err)


### PR DESCRIPTION
Prow will pick up the test logs and parse them and make them available.

Also enable block tests now that the feature is beta.