### PR TITLE
Pass snapshot source when creating volumes

### DIFF
--- a/pkg/gce-cloud-provider/compute/cloud-disk.go
+++ b/pkg/gce-cloud-provider/compute/cloud-disk.go
@@ -134,3 +134,14 @@ func (d *CloudDisk) GetZone() string {
 		return ""
 	}
 }
+
+func (d *CloudDisk) GetSnapshotId() string {
+	switch d.Type() {
+	case Zonal:
+		return d.ZonalDisk.SourceSnapshotId
+	case Regional:
+		return d.RegionalDisk.SourceSnapshotId
+	default:
+		return ""
+	}
+}

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -570,6 +570,34 @@ func TestCreateVolumeArguments(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "success with data source of snapshot type",
+			req: &csi.CreateVolumeRequest{
+				Name:               "test-name",
+				CapacityRange:      stdCapRange,
+				VolumeCapabilities: stdVolCap,
+				VolumeContentSource: &csi.VolumeContentSource{
+					Type: &csi.VolumeContentSource_Snapshot{
+						Snapshot: &csi.VolumeContentSource_SnapshotSource{
+							Id: "snapshot-source",
+						},
+					},
+				},
+			},
+			expVol: &csi.Volume{
+				CapacityBytes:      common.GbToBytes(20),
+				Id:                 testVolumeId,
+				Attributes:         nil,
+				AccessibleTopology: stdTopology,
+				ContentSource: &csi.VolumeContentSource{
+					Type: &csi.VolumeContentSource_Snapshot{
+						Snapshot: &csi.VolumeContentSource_SnapshotSource{
+							Id: "snapshot-source",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	// Run test cases


### PR DESCRIPTION
This PR adds the logic to pass the snapshot source when creating the
volume so that volume can be restored from snapshot if specified.

Address comments

This commit addressed the comments related to parameter names etc.