### PR TITLE
Set MaxVolumesPerNode in NodeGetInfo

### DIFF
--- a/pkg/gce-cloud-provider/metadata/fake.go
+++ b/pkg/gce-cloud-provider/metadata/fake.go
@@ -26,6 +26,8 @@ const (
 	FakeProject    = "test-project"
 )
 
+var FakeMachineType = "n1-standard-1"
+
 func NewFakeService() MetadataService {
 	return &fakeServiceManager{}
 }
@@ -40,4 +42,12 @@ func (manager *fakeServiceManager) GetProject() string {
 
 func (manager *fakeServiceManager) GetName() string {
 	return "test-name"
+}
+
+func (manager *fakeServiceManager) GetMachineType() string {
+	return FakeMachineType
+}
+
+func SetMachineType(s string) {
+	FakeMachineType = s
 }

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -37,14 +37,23 @@ import (
 const (
 	testNamePrefix = "gcepd-csi-e2e-"
 
-	defaultSizeGb     int64 = 5
-	defaultRepdSizeGb int64 = 200
-	readyState              = "READY"
-	standardDiskType        = "pd-standard"
-	ssdDiskType             = "pd-ssd"
+	defaultSizeGb      int64 = 5
+	defaultRepdSizeGb  int64 = 200
+	readyState               = "READY"
+	standardDiskType         = "pd-standard"
+	ssdDiskType              = "pd-ssd"
+	defaultVolumeLimit int64 = 128
 )
 
 var _ = Describe("GCE PD CSI Driver", func() {
+
+	It("Should get reasonable volume limits from nodes with NodeGetInfo", func() {
+		testContext := getRandomTestContext()
+		resp, err := testContext.Client.NodeGetInfo()
+		Expect(err).To(BeNil())
+		volumeLimit := resp.GetMaxVolumesPerNode()
+		Expect(volumeLimit).To(Equal(defaultVolumeLimit))
+	})
 
 	It("Should create->attach->stage->mount volume and check if it is writable, then unmount->unstage->detach->delete and check disk is deleted", func() {
 		testContext := getRandomTestContext()


### PR DESCRIPTION
Fixed: [#19](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/19)
Get volume limits by sending HTTP request to Google metadata server
Tested for several different machine types. But don't know how to integrate it into the current e2e test, and don't know if it is necessary.
@davidz627 @msau42 