### PR TITLE
Statically validate volume capabilities for CreateVolume, ControllerPublish, NodeStage, NodePublish

### DIFF
--- a/pkg/gce-pd-csi-driver/node_test.go
+++ b/pkg/gce-pd-csi-driver/node_test.go
@@ -108,8 +108,19 @@ func TestNodePublishVolume(t *testing.T) {
 				TargetPath:        defaultTargetPath,
 				StagingTargetPath: defaultStagingPath,
 				Readonly:          false,
-				VolumeCapability:  &csi.VolumeCapability{},
+				VolumeCapability:  stdVolCap,
 			},
+		},
+		{
+			name: "Invalid request (invalid access mode)",
+			req: &csi.NodePublishVolumeRequest{
+				VolumeId:          defaultVolumeID,
+				TargetPath:        defaultTargetPath,
+				StagingTargetPath: defaultStagingPath,
+				Readonly:          false,
+				VolumeCapability:  createVolumeCapability(csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER),
+			},
+			expErrCode: codes.InvalidArgument,
 		},
 		{
 			name: "Invalid request (No VolumeId)",
@@ -117,7 +128,7 @@ func TestNodePublishVolume(t *testing.T) {
 				TargetPath:        defaultTargetPath,
 				StagingTargetPath: defaultStagingPath,
 				Readonly:          false,
-				VolumeCapability:  &csi.VolumeCapability{},
+				VolumeCapability:  stdVolCap,
 			},
 			expErrCode: codes.InvalidArgument,
 		},
@@ -127,7 +138,7 @@ func TestNodePublishVolume(t *testing.T) {
 				VolumeId:          defaultVolumeID,
 				StagingTargetPath: defaultStagingPath,
 				Readonly:          false,
-				VolumeCapability:  &csi.VolumeCapability{},
+				VolumeCapability:  stdVolCap,
 			},
 			expErrCode: codes.InvalidArgument,
 		},
@@ -137,7 +148,7 @@ func TestNodePublishVolume(t *testing.T) {
 				VolumeId:         defaultVolumeID,
 				TargetPath:       defaultTargetPath,
 				Readonly:         false,
-				VolumeCapability: &csi.VolumeCapability{},
+				VolumeCapability: stdVolCap,
 			},
 			expErrCode: codes.InvalidArgument,
 		},
@@ -242,14 +253,23 @@ func TestNodeStageVolume(t *testing.T) {
 			req: &csi.NodeStageVolumeRequest{
 				VolumeId:          volumeID,
 				StagingTargetPath: defaultStagingPath,
-				VolumeCapability:  &csi.VolumeCapability{},
+				VolumeCapability:  stdVolCap,
 			},
+		},
+		{
+			name: "Invalid request (Bad Access Mode)",
+			req: &csi.NodeStageVolumeRequest{
+				VolumeId:          volumeID,
+				StagingTargetPath: defaultStagingPath,
+				VolumeCapability:  createVolumeCapability(csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER),
+			},
+			expErrCode: codes.InvalidArgument,
 		},
 		{
 			name: "Invalid request (No VolumeId)",
 			req: &csi.NodeStageVolumeRequest{
 				StagingTargetPath: defaultStagingPath,
-				VolumeCapability:  &csi.VolumeCapability{},
+				VolumeCapability:  stdVolCap,
 			},
 			expErrCode: codes.InvalidArgument,
 		},
@@ -257,7 +277,7 @@ func TestNodeStageVolume(t *testing.T) {
 			name: "Invalid request (No StagingTargetPath)",
 			req: &csi.NodeStageVolumeRequest{
 				VolumeId:         volumeID,
-				VolumeCapability: &csi.VolumeCapability{},
+				VolumeCapability: stdVolCap,
 			},
 			expErrCode: codes.InvalidArgument,
 		},
@@ -277,9 +297,8 @@ func TestNodeStageVolume(t *testing.T) {
 				StagingTargetPath: defaultStagingPath,
 				VolumeCapability:  cap,
 			},
-			expErrCode: codes.Unimplemented,
+			expErrCode: codes.InvalidArgument,
 		},
-		// Capability Mount. codes.Unimplemented
 	}
 	for _, tc := range testCases {
 		t.Logf("Test case: %s", tc.name)

--- a/pkg/gce-pd-csi-driver/utils_test.go
+++ b/pkg/gce-pd-csi-driver/utils_test.go
@@ -139,6 +139,22 @@ func TestValidateVolumeCapabilities(t *testing.T) {
 			},
 			expErr: true,
 		},
+		{
+			name: "fail with reader + writer capabilities",
+			vc: []*csi.VolumeCapability{
+				createVolumeCapability(csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY),
+				createVolumeCapability(csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+			},
+			expErr: true,
+		},
+		{
+			name: "fail with different reader capabilities",
+			vc: []*csi.VolumeCapability{
+				createVolumeCapability(csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY),
+				createVolumeCapability(csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY),
+			},
+			expErr: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/gce-pd-csi-driver/utils_test.go
+++ b/pkg/gce-pd-csi-driver/utils_test.go
@@ -16,3 +16,140 @@ limitations under the License.
 */
 
 package gceGCEDriver
+
+import (
+	"testing"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi"
+)
+
+var (
+	stdVolCap = &csi.VolumeCapability{
+		AccessType: &csi.VolumeCapability_Mount{
+			Mount: &csi.VolumeCapability_MountVolume{},
+		},
+		AccessMode: &csi.VolumeCapability_AccessMode{
+			Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+		},
+	}
+	stdVolCaps = []*csi.VolumeCapability{
+		stdVolCap,
+	}
+)
+
+func createVolumeCapabilities(am csi.VolumeCapability_AccessMode_Mode) []*csi.VolumeCapability {
+	return []*csi.VolumeCapability{
+		createVolumeCapability(am),
+	}
+}
+
+func createVolumeCapability(am csi.VolumeCapability_AccessMode_Mode) *csi.VolumeCapability {
+	return &csi.VolumeCapability{
+		AccessType: &csi.VolumeCapability_Mount{
+			Mount: &csi.VolumeCapability_MountVolume{},
+		},
+		AccessMode: &csi.VolumeCapability_AccessMode{
+			Mode: am,
+		},
+	}
+}
+
+func TestValidateVolumeCapabilities(t *testing.T) {
+	testCases := []struct {
+		name   string
+		vc     []*csi.VolumeCapability
+		expErr bool
+	}{
+		{
+			name: "success with empty capabilities",
+			vc:   []*csi.VolumeCapability{},
+		},
+		{
+			name: "fail with capabilities no access mode",
+			vc: []*csi.VolumeCapability{
+				{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+				},
+			},
+			expErr: true,
+		},
+		{
+			name: "fail with capabilities no mode",
+			vc: []*csi.VolumeCapability{
+				{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{},
+				},
+			},
+			expErr: true,
+		},
+		{
+			name: "fail with capabilities no access type",
+			vc: []*csi.VolumeCapability{
+				{
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+			},
+			expErr: true,
+		},
+		{
+			name: "success with mount/SINGLE_NODE_WRITER capabilities",
+			vc:   createVolumeCapabilities(csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+		},
+		{
+			name: "success with mount/SINGLE_NODE_READER_ONLY capabilities",
+			vc:   createVolumeCapabilities(csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY),
+		},
+		{
+			name: "success with mount/MULTI_NODE_READER_ONLY capabilities",
+			vc:   createVolumeCapabilities(csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY),
+		},
+		{
+			name:   "fail with mount/MULTI_NODE_SINGLE_WRITER capabilities",
+			vc:     createVolumeCapabilities(csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER),
+			expErr: true,
+		},
+		{
+			name:   "fail with mount/MULTI_NODE_MULTI_WRITER capabilities",
+			vc:     createVolumeCapabilities(csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER),
+			expErr: true,
+		},
+		{
+			name:   "fail with mount/UNKNOWN capabilities",
+			vc:     createVolumeCapabilities(csi.VolumeCapability_AccessMode_UNKNOWN),
+			expErr: true,
+		},
+		{
+			name: "fail with block capabilities",
+			vc: []*csi.VolumeCapability{
+				{
+					AccessType: &csi.VolumeCapability_Block{
+						Block: &csi.VolumeCapability_BlockVolume{},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+			},
+			expErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Logf("Running test: %v", tc.name)
+		err := validateVolumeCapabilities(tc.vc)
+		if tc.expErr && err == nil {
+			t.Fatalf("Expected error but didn't get any")
+		}
+		if !tc.expErr && err != nil {
+			t.Fatalf("Did not expect error but got: %v", err)
+		}
+	}
+
+}


### PR DESCRIPTION
Fixes: #94

/assign @msau42 @saad-ali 

```release-note
BREAKING CHANGE: The driver now enforces AccessMode validation for all calls, supported access modes are SINGLE_NODE_WRITER, SINGLE_NODE_READER_ONLY, MULTI_NODE_READER_ONLY
```