### PR TITLE
Tolerate legacy 'fstype' parameter

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -22,6 +22,9 @@ const (
 	ParameterKeyReplicationType      = "replication-type"
 	ParameterKeyDiskEncryptionKmsKey = "disk-encryption-kms-key"
 
+	// Ignored legacy Storage Class Parameters
+	ParameterKeyFsType = "fstype"
+
 	// Keys for Topology. This key will be shared amongst drivers from GCP
 	TopologyKeyZone = "topology.gke.io/zone"
 

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -106,6 +106,14 @@ func (gceCS *GCEControllerServer) CreateVolume(ctx context.Context, req *csi.Cre
 		case common.ParameterKeyDiskEncryptionKmsKey:
 			// Resource names (e.g. "keyRings", "cryptoKeys", etc.) are case sensitive, so do not change case
 			diskEncryptionKmsKey = v
+		case common.ParameterKeyFsType:
+			// We have to support seeing the "fstype" parameter to support
+			// migrated volumes with legacy storage classes that contain
+			// "fstype". "fstype" through volume parameters will not be
+			// supported.The actual fstype should have been translated by the
+			// external provisioner into the volume capabilities and this driver
+			// will interact with fstype through volume capabilities.
+			continue
 		default:
 			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("CreateVolume invalid option %q", k))
 		}


### PR DESCRIPTION
Migration scenario storage classes may have "fstype" parameter set that gets passed directly through external provisioner to the driver (while also translating it). We need to tolerate this on the driver side.

/assign @msau42 