### PR TITLE
Add kubernetes failure domain as a valid topology key for zone

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -23,7 +23,8 @@ const (
 	ParameterKeyDiskEncryptionKmsKey = "disk-encryption-kms-key"
 
 	// Keys for Topology. This key will be shared amongst drivers from GCP
-	TopologyKeyZone = "topology.gke.io/zone"
+	TopologyKeyZone           = "topology.gke.io/zone"
+	KubernetesTopologyKeyZone = "failure-domain.beta.kubernetes.io/zone"
 
 	// VolumeAttributes for Partition
 	VolumeAttributePartition = "partition"

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -809,6 +809,8 @@ func getZoneFromSegment(seg map[string]string) (string, error) {
 		switch k {
 		case common.TopologyKeyZone:
 			zone = v
+		case common.KubernetesTopologyKeyZone:
+			zone = v
 		default:
 			return "", fmt.Errorf("topology segment has unknown key %v", k)
 		}


### PR DESCRIPTION
/assign @msau42 

In-tree storage classes use Kubernetes failure domain as zone topology keys. 