### PR TITLE
Expand test focus of migration tests

### DIFF
--- a/test/run-k8s-integration-migration-local.sh
+++ b/test/run-k8s-integration-migration-local.sh
@@ -4,6 +4,7 @@ set -o nounset
 set -o errexit
 
 readonly PKGDIR=${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+readonly GCE_PD_TEST_FOCUS="\s[V|v]olume\sexpand|\[sig-storage\]\sIn-tree\sVolumes\s\[Driver:\sgcepd\]\s\[Testpattern:\sDynamic\sPV|allowedTopologies|Pod\sDisks|PersistentVolumes\sDefault"
 source "${PKGDIR}/deploy/common.sh"
 
 ensure_var GCE_PD_CSI_STAGING_IMAGE
@@ -12,7 +13,7 @@ ensure_var GCE_PD_SA_DIR
 make -C ${PKGDIR} test-k8s-integration
 ${PKGDIR}/bin/k8s-integration-test --kube-version=master --run-in-prow=false \
 --staging-image=${GCE_PD_CSI_STAGING_IMAGE} --service-account-file=${GCE_PD_SA_DIR}/cloud-sa.json \
---deploy-overlay-name=dev --test-focus="\[sig-storage\]\sIn-tree\sVolumes\s\[Driver:\sgcepd\].*" \
+--deploy-overlay-name=dev --test-focus=${GCE_PD_TEST_FOCUS} \
 --kube-feature-gates="CSIMigration=true,CSIMigrationGCE=true" --migration-test=true --gce-zone="us-central1-b"
 
 # This version of the command does not build the driver or K8s, points to a
@@ -21,6 +22,6 @@ ${PKGDIR}/bin/k8s-integration-test --kube-version=master --run-in-prow=false \
 # ensure_var GCE_PD_ZONE
 # ${PKGDIR}/bin/k8s-integration-test --kube-version=master --run-in-prow=false \
 # --staging-image=${GCE_PD_CSI_STAGING_IMAGE} --service-account-file=${GCE_PD_SA_DIR}/cloud-sa.json \
-# --deploy-overlay-name=dev --test-focus="\[sig-storage\]\sIn-tree\sVolumes\s\[Driver:\sgcepd\].*" \
+# --deploy-overlay-name=dev --test-focus=${GCE_PD_TEST_FOCUS} \
 # --bringup-cluster=false --teardown-cluster=false --local-k8s-dir=$KTOP --migration-test=true \
-# --do-driver-build=false --gce-zone=${GCE_PD_ZONE}
+# --do-driver-build=true --gce-zone=${GCE_PD_ZONE}

--- a/test/run-k8s-integration-migration.sh
+++ b/test/run-k8s-integration-migration.sh
@@ -14,11 +14,21 @@ readonly overlay_name="${GCE_PD_OVERLAY_NAME:-stable}"
 readonly boskos_resource_type="${GCE_PD_BOSKOS_RESOURCE_TYPE:-gce-project}"
 readonly do_driver_build="${GCE_PD_DO_DRIVER_BUILD:-true}"
 export GCE_PD_VERBOSITY=9
+readonly GCE_PD_TEST_FOCUS="\s[V|v]olume\sexpand|\[sig-storage\]\sIn-tree\sVolumes\s\[Driver:\sgcepd\]\s\[Testpattern:\sDynamic\sPV|allowedTopologies|Pod\sDisks|PersistentVolumes\sDefault"
+
+# TODO(#167): Enable reconstructions tests
+# TODO: Enabled inline volume tests
+# TODO: Fix and enable the following tests. They all exhibit the same testing infra error:
+# PersistentVolumes\sGCEPD|\[sig-storage\]\sIn-tree\sVolumes\s\[Driver:\sgcepd\]\s\[Testpattern:.*
+
+# The Error: "PV Create API error: persistentvolumes "gce-" is forbidden: error
+# querying GCE PD volume : can not fetch disk, zone is specified
+# ("us-central1-b"), but disk name is empty"
 
 make -C ${PKGDIR} test-k8s-integration
 ${PKGDIR}/bin/k8s-integration-test --kube-version=${GCE_PD_KUBE_VERSION:-master} \
 --kube-feature-gates="CSIMigration=true,CSIMigrationGCE=true" --run-in-prow=true \
 --deploy-overlay-name=${overlay_name} --service-account-file=${E2E_GOOGLE_APPLICATION_CREDENTIALS} \
 --do-driver-build=${do_driver_build} --boskos-resource-type=${boskos_resource_type} \
---migration-test=true --test-focus="\[sig-storage\]\sIn-tree\sVolumes\s\[Driver:\sgcepd\]\s\[Testpattern:\sDynamic\sPV.*" \
+--migration-test=true --test-focus=${GCE_PD_TEST_FOCUS} \
 --gce-zone="us-central1-b"


### PR DESCRIPTION
/assign @msau42 

Added all reasonable PD tests to the migration test set.

I've added TODO's for the remaining tests as more investigation is required. Those tests are not failing because of the PD driver, there is something going on in the tests themselves which tries to create a PV with an invalid spec so I would prefer not to muddy our "signal" for now.