### PR TITLE
Updating image paths to gke.gcr.io

### DIFF
--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: csi-controller-sa
       containers:
         - name: csi-provisioner
-          image: gcr.io/gke-release/csi-provisioner
+          image: gke.gcr.io/csi-provisioner
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
@@ -25,7 +25,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-attacher
-          image: gcr.io/gke-release/csi-attacher
+          image: gke.gcr.io/csi-attacher
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
@@ -33,7 +33,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: gce-pd-driver
-          image: gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver
+          image: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
           args:
             - "--v=5"
             - "--endpoint=unix:/csi/csi.sock"

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: csi-node-sa
       containers:
         - name: csi-driver-registrar
-          image: gcr.io/gke-release/csi-node-driver-registrar
+          image: gke.gcr.io/csi-node-driver-registrar
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
@@ -37,7 +37,7 @@ spec:
         - name: gce-pd-driver
           securityContext:
             privileged: true
-          image: gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver
+          image: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
           args:
             - "--v=5"
             - "--endpoint=unix:/csi/csi.sock"

--- a/deploy/kubernetes/overlays/alpha/controller_add_snapshotter.yaml
+++ b/deploy/kubernetes/overlays/alpha/controller_add_snapshotter.yaml
@@ -8,7 +8,7 @@ spec:
       containers:
         - name: csi-snapshotter
           imagePullPolicy: Always
-          image: gcr.io/gke-release/csi-snapshotter:v1.0.1-gke.0
+          image: gke.gcr.io/csi-snapshotter:v1.0.1-gke.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"

--- a/deploy/kubernetes/overlays/dev/kustomization.yaml
+++ b/deploy/kubernetes/overlays/dev/kustomization.yaml
@@ -7,6 +7,6 @@ patches:
 - node_always_pull.yaml
 images:
 # Replace this with your private image names and tags
-- name: gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver
+- name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   newName: gcr.io/REPLACEME/gcp-compute-persistent-disk-csi-driver
   newTag: "latest"

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-head/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-head/kustomization.yaml
@@ -3,15 +3,15 @@ kind: Kustomization
 bases:
 - ../../base
 images:
-- name: gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver
+- name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   newName: gcr.io/gke-release-staging/gcp-compute-persistent-disk-csi-driver
   newTag: "latest"
-- name: gcr.io/gke-release/csi-provisioner
+- name: gke.gcr.io/csi-provisioner
   newName: gcr.io/gke-release-staging/csi-provisioner
   newTag: "latest"
-- name: gcr.io/gke-release/csi-attacher
+- name: gke.gcr.io/csi-attacher
   newName: gcr.io/gke-release-staging/csi-attacher
   newTag: "latest"
-- name: gcr.io/gke-release/csi-node-driver-registrar
+- name: gke.gcr.io/csi-node-driver-registrar
   newName: gcr.io/gke-release-staging/csi-node-driver-registrar
   newTag: "latest"

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc/kustomization.yaml
@@ -3,15 +3,15 @@ kind: Kustomization
 bases:
 - ../../base
 images:
-- name: gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver
+- name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   newName: gcr.io/gke-release-staging/gcp-compute-persistent-disk-csi-driver
   newTag: "v0.5.0-rc1"
-- name: gcr.io/gke-release/csi-provisioner
+- name: gke.gcr.io/csi-provisioner
   newName: gcr.io/gke-release-staging/csi-provisioner
   newTag: "v1.2.0-gke.0"
-- name: gcr.io/gke-release/csi-attacher
+- name: gke.gcr.io/csi-attacher
   newName: gcr.io/gke-release-staging/csi-attacher
   newTag: "v1.1.0-gke.0"
-- name: gcr.io/gke-release/csi-node-driver-registrar
+- name: gke.gcr.io/csi-node-driver-registrar
   newName: gcr.io/gke-release-staging/csi-node-driver-registrar
   newTag: "v1.1.0-gke.0"

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -3,15 +3,15 @@ kind: Kustomization
 bases:
 - ../../base
 images:
-- name: gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver
-  newName: gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver
+- name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
+  newName: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   newTag: "v0.5.0-gke.0"
-- name: gcr.io/gke-release/csi-provisioner
-  newName: gcr.io/gke-release/csi-provisioner
+- name: gke.gcr.io/csi-provisioner
+  newName: gke.gcr.io/csi-provisioner
   newTag: "v1.2.0-gke.0"
-- name: gcr.io/gke-release/csi-attacher
-  newName: gcr.io/gke-release/csi-attacher
+- name: gke.gcr.io/csi-attacher
+  newName: gke.gcr.io/csi-attacher
   newTag: "v1.1.0-gke.0"
-- name: gcr.io/gke-release/csi-node-driver-registrar
-  newName: gcr.io/gke-release/csi-node-driver-registrar
+- name: gke.gcr.io/csi-node-driver-registrar
+  newName: gke.gcr.io/csi-node-driver-registrar
   newTag: "v1.1.0-gke.0"


### PR DESCRIPTION
gcr.io/gke-releases is only available in the US, while gke.gcr.io is available in multiple regions.

/assign @davidz627 
/cc @msau42 