### PR TITLE
Update scripts to be compatible with project ids that include the org…

### DIFF
--- a/deploy/kubernetes/deploy-driver.sh
+++ b/deploy/kubernetes/deploy-driver.sh
@@ -50,8 +50,7 @@ function check_service_account()
 	# Using bash magic to parse JSON for IAM
 	# Grepping for a line with client email returning anything quoted after the colon
 	readonly IAM_NAME=$(grep -Po '"client_email": *\K"[^"]*"' ${GCE_PD_SA_DIR}/cloud-sa.json | tr -d '"')
-	# Grepping anything after the @ tell the first . as the project name
-	readonly PROJECT=$(grep -Po '.*@\K[^.]+'<<<${IAM_NAME})
+	readonly PROJECT=$(grep -Po '"project_id": *\K"[^"]*"' ${GCE_PD_SA_DIR}/cloud-sa.json | tr -d '"')
 	readonly GOTTEN_BIND_ROLES=$(gcloud projects get-iam-policy ${PROJECT} --flatten="bindings[].members" --format='table(bindings.role)' --filter="bindings.members:${IAM_NAME}")
 	readonly BIND_ROLES=$(get_needed_roles)
 	MISSING_ROLES=false

--- a/deploy/setup-project.sh
+++ b/deploy/setup-project.sh
@@ -25,9 +25,19 @@ ensure_var PROJECT
 ensure_var GCE_PD_SA_NAME
 ensure_var GCE_PD_SA_DIR
 
+# If the project id includes the org name in the format "org-name:project", the
+# gCloud api will format the project part of the iam email domain as
+# "project.org-name"
+if [[ $PROJECT == *":"* ]]; then
+  IFS=':' read -ra SPLIT <<< "$PROJECT"
+  readonly IAM_PROJECT="${SPLIT[1]}.${SPLIT[0]}"
+else
+  readonly IAM_PROJECT="${PROJECT}"
+fi
+
 readonly KUBEDEPLOY="${PKGDIR}/deploy/kubernetes"
 readonly BIND_ROLES=$(get_needed_roles)
-readonly IAM_NAME="${GCE_PD_SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+readonly IAM_NAME="${GCE_PD_SA_NAME}@${IAM_PROJECT}.iam.gserviceaccount.com"
 
 # Check if SA exists
 CREATE_SA=true


### PR DESCRIPTION
Some project ids are of the format `<org-name>:<project>`. For this case, the gCloud IAM ServiceAccount create function creates a service account email of the format `<service-account-name>@<project>.<org-name>.iam.serviceaccount.com`, which is incompatible with how our script expects the email. This PR adds a special cases that provides to correct formatting.