### PR TITLE
add ability to use gcloud to boot a gke cluster for e2e integration

### DIFF
--- a/test/run-k8s-integration-local.sh
+++ b/test/run-k8s-integration-local.sh
@@ -4,6 +4,8 @@ set -o nounset
 set -o errexit
 
 readonly PKGDIR=${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+readonly deployment_strategy=${DEPLOYMENT_STRATEGY:-gce}
+
 source "${PKGDIR}/deploy/common.sh"
 
 ensure_var GCE_PD_CSI_STAGING_IMAGE
@@ -14,7 +16,8 @@ make -C ${PKGDIR} test-k8s-integration
 # ${PKGDIR}/bin/k8s-integration-test --kube-version=master --run-in-prow=false \
 # --staging-image=${GCE_PD_CSI_STAGING_IMAGE} --service-account-file=${GCE_PD_SA_DIR}/cloud-sa.json \
 # --deploy-overlay-name=dev --storageclass-file=sc-standard.yaml \
-# --test-focus="External.Storage" --gce-zone="us-central1-b"
+# --test-focus="External.Storage" --gce-zone="us-central1-b" \
+# --deployment-strategy=${deployment_strategy}
 
 # This version of the command does not build the driver or K8s, points to a
 # local K8s repo to get the e2e.test binary, and does not bring up or down the cluster

--- a/test/run-k8s-integration.sh
+++ b/test/run-k8s-integration.sh
@@ -13,10 +13,12 @@ readonly PKGDIR=${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 readonly overlay_name="${GCE_PD_OVERLAY_NAME:-stable}"
 readonly boskos_resource_type="${GCE_PD_BOSKOS_RESOURCE_TYPE:-gce-project}"
 readonly do_driver_build="${GCE_PD_DO_DRIVER_BUILD:-true}"
+readonly deployment_strategy=${DEPLOYMENT_STRATEGY:-gce}
 export GCE_PD_VERBOSITY=9
 
 make -C ${PKGDIR} test-k8s-integration
 ${PKGDIR}/bin/k8s-integration-test --kube-version=${GCE_PD_KUBE_VERSION:-master} \
 --run-in-prow=true --deploy-overlay-name=${overlay_name} --service-account-file=${E2E_GOOGLE_APPLICATION_CREDENTIALS} \
 --do-driver-build=${do_driver_build} --boskos-resource-type=${boskos_resource_type} \
---storageclass-file=sc-standard.yaml --test-focus="External.Storage" --gce-zone="us-central1-b"
+--storageclass-file=sc-standard.yaml --test-focus="External.Storage" --gce-zone="us-central1-b" \
+--deployment-strategy=${deployment_strategy}


### PR DESCRIPTION
Adds the following flags to `k8s-integration-test`:
- `deployment-strategy`: If a cluster needs to be booted up, choose if it is done on GCE through the `kube-ip.sh` script or GKE through the `gcloud` utility. The GKE option is incompatible with the migration test and must use a cluster version supported by GKE. Feature gates cannot be turned on when GKE is used. The default value is "gce", and GKE can be turned on by setting it to "gke".
- `gke-cluster-version`: If GKE is used, this flag can be set to an available cluster version, which can be checked with `gcloud container get-server-config`. Also accepted values are "latest" and "stable". The deault value is "latest".