### PR TITLE
Remove cross validation of access modes, multiple access modes can be specified that represent all the capabilities of the volume

### DIFF
--- a/pkg/gce-pd-csi-driver/utils.go
+++ b/pkg/gce-pd-csi-driver/utils.go
@@ -72,31 +72,6 @@ func validateVolumeCapabilities(vcs []*csi.VolumeCapability) error {
 			return err
 		}
 	}
-	if err := crossValidateAccessModes(vcs); err != nil {
-		return err
-	}
-	return nil
-}
-
-func crossValidateAccessModes(vcs []*csi.VolumeCapability) error {
-	m := map[csi.VolumeCapability_AccessMode_Mode]bool{}
-
-	for _, vc := range vcs {
-		m[vc.GetAccessMode().GetMode()] = true
-	}
-
-	hasWriter := m[csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER]
-	hasSingleReader := m[csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY]
-	hasMultiReader := m[csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY]
-
-	if hasWriter && (hasSingleReader || hasMultiReader) {
-		return fmt.Errorf("both SINGLE_NODE_WRITER and READER_ONLY access mode specified")
-	}
-
-	if hasSingleReader && hasMultiReader {
-		return fmt.Errorf("both SINGLE_NODE_READER_ONLY and MULTI_NODE_READY_ONLY specified")
-	}
-
 	return nil
 }
 

--- a/pkg/gce-pd-csi-driver/utils_test.go
+++ b/pkg/gce-pd-csi-driver/utils_test.go
@@ -140,20 +140,18 @@ func TestValidateVolumeCapabilities(t *testing.T) {
 			expErr: true,
 		},
 		{
-			name: "fail with reader + writer capabilities",
+			name: "success with reader + writer capabilities",
 			vc: []*csi.VolumeCapability{
 				createVolumeCapability(csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY),
 				createVolumeCapability(csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
 			},
-			expErr: true,
 		},
 		{
-			name: "fail with different reader capabilities",
+			name: "success with different reader capabilities",
 			vc: []*csi.VolumeCapability{
 				createVolumeCapability(csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY),
 				createVolumeCapability(csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY),
 			},
-			expErr: true,
 		},
 	}
 


### PR DESCRIPTION
/assign @msau42 @saad-ali 

Needs to be cherry-picked to release-0.5.0 and new release version to be cut.

Also we should identify why none of the tests specify more than one access mode...