### PR TITLE
Cherry-Pick: GKE Integration Support into Release-0.5.X

### DIFF
--- a/test/run-k8s-integration-local.sh
+++ b/test/run-k8s-integration-local.sh
@@ -5,6 +5,8 @@ set -o errexit
 
 readonly PKGDIR=${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 readonly deployment_strategy=${DEPLOYMENT_STRATEGY:-gce}
+readonly gke_cluster_version=${GKE_CLUSTER_VERSION:-latest}
+readonly kube_version=${KUBE_VERSION:-master}
 
 source "${PKGDIR}/deploy/common.sh"
 
@@ -17,7 +19,8 @@ make -C ${PKGDIR} test-k8s-integration
 # --staging-image=${GCE_PD_CSI_STAGING_IMAGE} --service-account-file=${GCE_PD_SA_DIR}/cloud-sa.json \
 # --deploy-overlay-name=dev --storageclass-file=sc-standard.yaml \
 # --test-focus="External.Storage" --gce-zone="us-central1-b" \
-# --deployment-strategy=${deployment_strategy}
+# --deployment-strategy=${deployment_strategy} --gke-cluster-version=${gke_cluster_version} \
+# --kube-version=${kube_version}
 
 # This version of the command does not build the driver or K8s, points to a
 # local K8s repo to get the e2e.test binary, and does not bring up or down the cluster
@@ -26,4 +29,5 @@ ${PKGDIR}/bin/k8s-integration-test --kube-version=master --run-in-prow=false \
 --staging-image=${GCE_PD_CSI_STAGING_IMAGE} --service-account-file=${GCE_PD_SA_DIR}/cloud-sa.json \
 --deploy-overlay-name=dev --bringup-cluster=false --teardown-cluster=false --local-k8s-dir=$KTOP \
 --storageclass-file=sc-standard.yaml --do-driver-build=true  --test-focus="External.Storage" \
---gce-zone="us-central1-b"
+--gce-zone="us-central1-b" --gke-cluster-version=${gke_cluster_version} \
+--kube-version=${kube_version}

--- a/test/run-k8s-integration-local.sh
+++ b/test/run-k8s-integration-local.sh
@@ -4,6 +4,8 @@ set -o nounset
 set -o errexit
 
 readonly PKGDIR=${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+readonly deployment_strategy=${DEPLOYMENT_STRATEGY:-gce}
+
 source "${PKGDIR}/deploy/common.sh"
 
 ensure_var GCE_PD_CSI_STAGING_IMAGE
@@ -14,7 +16,8 @@ make -C ${PKGDIR} test-k8s-integration
 # ${PKGDIR}/bin/k8s-integration-test --kube-version=master --run-in-prow=false \
 # --staging-image=${GCE_PD_CSI_STAGING_IMAGE} --service-account-file=${GCE_PD_SA_DIR}/cloud-sa.json \
 # --deploy-overlay-name=dev --storageclass-file=sc-standard.yaml \
-# --test-focus="External.Storage" --gce-zone="us-central1-b"
+# --test-focus="External.Storage" --gce-zone="us-central1-b" \
+# --deployment-strategy=${deployment_strategy}
 
 # This version of the command does not build the driver or K8s, points to a
 # local K8s repo to get the e2e.test binary, and does not bring up or down the cluster

--- a/test/run-k8s-integration.sh
+++ b/test/run-k8s-integration.sh
@@ -13,10 +13,12 @@ readonly PKGDIR=${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 readonly overlay_name="${GCE_PD_OVERLAY_NAME:-stable}"
 readonly boskos_resource_type="${GCE_PD_BOSKOS_RESOURCE_TYPE:-gce-project}"
 readonly do_driver_build="${GCE_PD_DO_DRIVER_BUILD:-true}"
+readonly deployment_strategy=${DEPLOYMENT_STRATEGY:-gce}
 export GCE_PD_VERBOSITY=9
 
 make -C ${PKGDIR} test-k8s-integration
 ${PKGDIR}/bin/k8s-integration-test --kube-version=${GCE_PD_KUBE_VERSION:-master} \
 --run-in-prow=true --deploy-overlay-name=${overlay_name} --service-account-file=${E2E_GOOGLE_APPLICATION_CREDENTIALS} \
 --do-driver-build=${do_driver_build} --boskos-resource-type=${boskos_resource_type} \
---storageclass-file=sc-standard.yaml --test-focus="External.Storage" --gce-zone="us-central1-b"
+--storageclass-file=sc-standard.yaml --test-focus="External.Storage" --gce-zone="us-central1-b" \
+--deployment-strategy=${deployment_strategy}

--- a/test/run-k8s-integration.sh
+++ b/test/run-k8s-integration.sh
@@ -14,6 +14,9 @@ readonly overlay_name="${GCE_PD_OVERLAY_NAME:-stable}"
 readonly boskos_resource_type="${GCE_PD_BOSKOS_RESOURCE_TYPE:-gce-project}"
 readonly do_driver_build="${GCE_PD_DO_DRIVER_BUILD:-true}"
 readonly deployment_strategy=${DEPLOYMENT_STRATEGY:-gce}
+readonly gke_cluster_version=${GKE_CLUSTER_VERSION:-latest}
+readonly kube_version=${KUBE_VERSION:-master}
+
 export GCE_PD_VERBOSITY=9
 
 make -C ${PKGDIR} test-k8s-integration
@@ -21,4 +24,5 @@ ${PKGDIR}/bin/k8s-integration-test --kube-version=${GCE_PD_KUBE_VERSION:-master}
 --run-in-prow=true --deploy-overlay-name=${overlay_name} --service-account-file=${E2E_GOOGLE_APPLICATION_CREDENTIALS} \
 --do-driver-build=${do_driver_build} --boskos-resource-type=${boskos_resource_type} \
 --storageclass-file=sc-standard.yaml --test-focus="External.Storage" --gce-zone="us-central1-b" \
---deployment-strategy=${deployment_strategy}
+--deployment-strategy=${deployment_strategy} --gke-cluster-version=${gke_cluster_version} \
+--kube-version=${kube_version}


### PR DESCRIPTION
allows the user to boot a specific cluster version on gke when running integration tests

```release-note
NONE
```