### PR TITLE
Bump attacher to v1.2.0 to stable and provisioner v1.2.1

### DIFF
--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -10,10 +10,10 @@ images:
   newTag: "v0.5.1-gke.0"
 - name: gke.gcr.io/csi-provisioner
   newName: gke.gcr.io/csi-provisioner
-  newTag: "v1.2.0-gke.0"
+  newTag: "v1.2.1-gke.0"
 - name: gke.gcr.io/csi-attacher
   newName: gke.gcr.io/csi-attacher
-  newTag: "v1.1.0-gke.0"
+  newTag: "v1.2.0-gke.0"
 - name: gke.gcr.io/csi-node-driver-registrar
   newName: gke.gcr.io/csi-node-driver-registrar
   newTag: "v1.1.0-gke.0"


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
Pick up changes in v1.2.0 attacher
https://github.com/kubernetes-csi/external-attacher/releases/tag/v1.2.0

```release-note
Bump csi-attacher to v1.2.0 and csi-provisioner to v1.2.1 picking up support for inline volume migration and some fixes for backward compatible access modes for migration
```
