### PR TITLE
bring back the handle call

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -111,6 +111,11 @@ func main() {
 		ensureVariable(kubeVersion, false, "Cannot set a kube version when using a local k8s dir.")
 		ensureVariable(testVersion, false, "Cannot set a test version when using a local k8s dir.")
 	}
+
+	err := handle()
+	if err != nil {
+		klog.Fatalf("Failed to run integration test: %v", err)
+	}
 }
 
 func handle() error {


### PR DESCRIPTION
I accidentally removed the function call in the integration tests that actually runs all the tests. This brings it back.

```release-note
None
```
