### PR TITLE
Use new deployment strategy and version flags for k8s integration migration tests

### DIFF
--- a/test/run-k8s-integration-migration-local.sh
+++ b/test/run-k8s-integration-migration-local.sh
@@ -7,20 +7,25 @@ readonly PKGDIR=${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 readonly GCE_PD_TEST_FOCUS="\s[V|v]olume\sexpand|\[sig-storage\]\sIn-tree\sVolumes\s\[Driver:\sgcepd\]\s\[Testpattern:\sDynamic\sPV|allowedTopologies|Pod\sDisks|PersistentVolumes\sDefault"
 source "${PKGDIR}/deploy/common.sh"
 
+readonly kube_version=${GCE_PD_KUBE_VERSION:-master}
+readonly test_version=${TEST_VERSION:-master}
+
 ensure_var GCE_PD_CSI_STAGING_IMAGE
 ensure_var GCE_PD_SA_DIR
 
 make -C ${PKGDIR} test-k8s-integration
+
 ${PKGDIR}/bin/k8s-integration-test --kube-version=master --run-in-prow=false \
 --staging-image=${GCE_PD_CSI_STAGING_IMAGE} --service-account-file=${GCE_PD_SA_DIR}/cloud-sa.json \
 --deploy-overlay-name=dev --test-focus=${GCE_PD_TEST_FOCUS} \
---kube-feature-gates="CSIMigration=true,CSIMigrationGCE=true" --migration-test=true --gce-zone="us-central1-b"
+--kube-feature-gates="CSIMigration=true,CSIMigrationGCE=true" --migration-test=true --gce-zone="us-central1-b" \
+--deployment-strategy=gce --test-version=${test_version}
 
 # This version of the command does not build the driver or K8s, points to a
 # local K8s repo to get the e2e.test binary, and does not bring up or down the cluster
 #
 # ensure_var GCE_PD_ZONE
-# ${PKGDIR}/bin/k8s-integration-test --kube-version=master --run-in-prow=false \
+# ${PKGDIR}/bin/k8s-integration-test --run-in-prow=false \
 # --staging-image=${GCE_PD_CSI_STAGING_IMAGE} --service-account-file=${GCE_PD_SA_DIR}/cloud-sa.json \
 # --deploy-overlay-name=dev --test-focus=${GCE_PD_TEST_FOCUS} \
 # --bringup-cluster=false --teardown-cluster=false --local-k8s-dir=$KTOP --migration-test=true \

--- a/test/run-k8s-integration-migration.sh
+++ b/test/run-k8s-integration-migration.sh
@@ -9,12 +9,19 @@
 set -o nounset
 set -o errexit
 
+export GCE_PD_VERBOSITY=9
+
 readonly PKGDIR=${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+
 readonly overlay_name="${GCE_PD_OVERLAY_NAME:-stable}"
 readonly boskos_resource_type="${GCE_PD_BOSKOS_RESOURCE_TYPE:-gce-project}"
 readonly do_driver_build="${GCE_PD_DO_DRIVER_BUILD:-true}"
-export GCE_PD_VERBOSITY=9
+readonly deployment_strategy=${DEPLOYMENT_STRATEGY:-gce}
+readonly kube_version=${GCE_PD_KUBE_VERSION:-master}
+readonly test_version=${TEST_VERSION:-master}
+
 readonly GCE_PD_TEST_FOCUS="\s[V|v]olume\sexpand|\[sig-storage\]\sIn-tree\sVolumes\s\[Driver:\sgcepd\]\s\[Testpattern:\sDynamic\sPV|allowedTopologies|Pod\sDisks|PersistentVolumes\sDefault"
+
 
 # TODO(#167): Enable reconstructions tests
 # TODO: Enabled inline volume tests
@@ -26,9 +33,9 @@ readonly GCE_PD_TEST_FOCUS="\s[V|v]olume\sexpand|\[sig-storage\]\sIn-tree\sVolum
 # ("us-central1-b"), but disk name is empty"
 
 make -C ${PKGDIR} test-k8s-integration
-${PKGDIR}/bin/k8s-integration-test --kube-version=${GCE_PD_KUBE_VERSION:-master} \
+${PKGDIR}/bin/k8s-integration-test --kube-version=${kube_version} \
 --kube-feature-gates="CSIMigration=true,CSIMigrationGCE=true" --run-in-prow=true \
 --deploy-overlay-name=${overlay_name} --service-account-file=${E2E_GOOGLE_APPLICATION_CREDENTIALS} \
 --do-driver-build=${do_driver_build} --boskos-resource-type=${boskos_resource_type} \
 --migration-test=true --test-focus=${GCE_PD_TEST_FOCUS} \
---gce-zone="us-central1-b"
+--gce-zone="us-central1-b" --deployment-strategy=${deployment_strategy} --test-version=${test_version}


### PR DESCRIPTION
/kind failing-test

**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/323/files
added new flags for the test framework. This PR updates to use those flags for the migration tests.

/assign @msau42 @hantaowang 

```release-note
NONE
```
