### PR TITLE
increase wait time until driver is deployed and build ginkgo

### DIFF
--- a/test/k8s-integration/driver.go
+++ b/test/k8s-integration/driver.go
@@ -64,7 +64,7 @@ func installDriver(goPath, pkgDir, stagingImage, stagingVersion, deployOverlayNa
 	}
 
 	// TODO (#139): wait for driver to be running
-	time.Sleep(10 * time.Second)
+	time.Sleep(time.Minute)
 	statusCmd := exec.Command("kubectl", "describe", "pods", "-n", "default")
 	err = runCommand("Checking driver pods", statusCmd)
 	if err != nil {

--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -210,6 +210,10 @@ func handle() error {
 		if err != nil {
 			return fmt.Errorf("failed to build Kubernetes: %v", err)
 		}
+		err = buildKubernetes(testDir, "ginkgo")
+		if err != nil {
+			return fmt.Errorf("failed to build Gingko: %v", err)
+		}
 	} else {
 		testDir = k8sDir
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
On some tests, containers are still creating after 10 seconds but we move right onto running the test. Also, builds Ginkgo in the test directory.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
None
```
