### PR TITLE
update the bin path if not using docker to build for test k8s

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -57,9 +57,10 @@ var (
 )
 
 const (
-	pdImagePlaceholder = "gke.gcr.io/gcp-compute-persistent-disk-csi-driver"
-	k8sBuildBinDir     = "_output/dockerized/bin/linux/amd64"
-	gkeTestClusterName = "gcp-pd-csi-driver-test-cluster"
+	pdImagePlaceholder        = "gke.gcr.io/gcp-compute-persistent-disk-csi-driver"
+	k8sInDockerBuildBinDir    = "_output/dockerized/bin/linux/amd64"
+	k8sOutOfDockerBuildBinDir = "_output/bin"
+	gkeTestClusterName        = "gcp-pd-csi-driver-test-cluster"
 )
 
 func init() {
@@ -181,6 +182,7 @@ func handle() error {
 	k8sDir := filepath.Join(k8sParentDir, "kubernetes")
 	testParentDir := generateUniqueTmpDir()
 	testDir := filepath.Join(testParentDir, "kubernetes")
+	k8sBuildBinDir := k8sInDockerBuildBinDir
 	defer removeDir(k8sParentDir)
 	defer removeDir(testParentDir)
 
@@ -214,6 +216,7 @@ func handle() error {
 		if err != nil {
 			return fmt.Errorf("failed to build Gingko: %v", err)
 		}
+		k8sBuildBinDir = k8sOutOfDockerBuildBinDir
 	} else {
 		testDir = k8sDir
 	}
@@ -269,12 +272,13 @@ func handle() error {
 	}
 
 	// Run the tests using the testDir kubernetes
+	fullK8sBuildBinPath := filepath.Join(testDir, k8sBuildBinDir)
 	if len(*storageClassFile) != 0 {
-		err = runCSITests(pkgDir, testDir, *testFocus, *storageClassFile, *gceZone)
+		err = runCSITests(pkgDir, fullK8sBuildBinPath, *testFocus, *storageClassFile, *gceZone)
 	} else if *migrationTest {
-		err = runMigrationTests(pkgDir, testDir, *testFocus, *gceZone)
+		err = runMigrationTests(pkgDir, fullK8sBuildBinPath, *testFocus, *gceZone)
 	} else {
-		return fmt.Errorf("Did not run either CSI or Migration test")
+		return fmt.Errorf("did not run either CSI or Migration test")
 	}
 
 	if err != nil {
@@ -297,21 +301,21 @@ func setEnvProject(project string) error {
 	return nil
 }
 
-func runMigrationTests(pkgDir, k8sDir, testFocus, gceZone string) error {
-	return runTestsWithConfig(pkgDir, k8sDir, gceZone, testFocus, "-storage.migratedPlugins=kubernetes.io/gce-pd")
+func runMigrationTests(pkgDir, k8sBinDir, testFocus, gceZone string) error {
+	return runTestsWithConfig(k8sBinDir, gceZone, testFocus, "-storage.migratedPlugins=kubernetes.io/gce-pd")
 }
 
-func runCSITests(pkgDir, k8sDir, testFocus, storageClassFile, gceZone string) error {
+func runCSITests(pkgDir, k8sBinDir, testFocus, storageClassFile, gceZone string) error {
 	testDriverConfigFile, err := generateDriverConfigFile(pkgDir, storageClassFile)
 	if err != nil {
 		return err
 	}
 	testConfigArg := fmt.Sprintf("-storage.testdriver=%s", testDriverConfigFile)
-	return runTestsWithConfig(pkgDir, k8sDir, gceZone, testFocus, testConfigArg)
+	return runTestsWithConfig(k8sBinDir, gceZone, testFocus, testConfigArg)
 }
 
-func runTestsWithConfig(pkgDir, k8sDir, gceZone, testFocus, testConfigArg string) error {
-	err := os.Chdir(k8sDir)
+func runTestsWithConfig(k8sBinDir, gceZone, testFocus, testConfigArg string) error {
+	err := os.Chdir(k8sBinDir)
 	if err != nil {
 		return err
 	}
@@ -324,11 +328,11 @@ func runTestsWithConfig(pkgDir, k8sDir, gceZone, testFocus, testConfigArg string
 
 	testFocusArg := fmt.Sprintf("-focus=%s", testFocus)
 
-	cmd := exec.Command(filepath.Join(k8sBuildBinDir, "ginkgo"),
+	cmd := exec.Command("./ginkgo",
 		"-p",
 		testFocusArg,
 		"-skip=\\[Disruptive\\]|\\[Serial\\]|\\[Feature:.+\\]",
-		filepath.Join(k8sBuildBinDir, "e2e.test"),
+		"e2e.test",
 		"--",
 		reportArg,
 		"-provider=gce",


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
When booting the cluster on GKE, we use a seprate k8s build that only builds the e2e tests and ginkgo. However this does not require docker, so its just build without using docker and thus the output location is different from a docker build (`_output/bin` vs `_output/dockerized/bin/linux/amd64`). Before this fix, the integration test always looks for ginkgo at `_output/dockerized/bin/linux/amd64` which causes it to not be able to find it.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
This must be cherry-picked along with all GKE integration test support into release-0.5.X per #337 

**Does this PR introduce a user-facing change?**:
```release-note
None
```
