### PR TITLE
bugfix-222 Driver should check socket parent directory before trying …

### DIFF
--- a/pkg/gce-pd-csi-driver/server.go
+++ b/pkg/gce-pd-csi-driver/server.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"google.golang.org/grpc"
@@ -90,6 +91,13 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 		addr = u.Host
 	} else {
 		klog.Fatalf("%v endpoint scheme not supported", u.Scheme)
+	}
+
+	if u.Scheme == "unix" {
+		listenDir, _ := filepath.Split(addr)
+		if _, err := os.Stat(listenDir); err != nil {
+			klog.Fatalf("Failed to stat %s, error: %s", listenDir, err.Error())
+		}
 	}
 
 	klog.V(4).Infof("Start listening with scheme %v, addr %v", u.Scheme, addr)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
if the socket parent directory does not exit, the driver does not check it and just tries to call Listen to the address. So the error message returned from Listen call does not give the clear reason why it fail. It would be better to check whether the parent directory exist or not before listening to the socket address.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #222

**Special notes for your reviewer**:
@jingxu97 
@davidz627 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Driver should check socket parent directory before trying to bind it
```
