### PR TITLE
Update the test runner to spit out logs at level 10 for debuggability

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -330,10 +330,12 @@ func runTestsWithConfig(k8sBinDir, gceZone, testFocus, testConfigArg string) err
 
 	cmd := exec.Command("./ginkgo",
 		"-p",
+		"-v",
 		testFocusArg,
 		"-skip=\\[Disruptive\\]|\\[Serial\\]|\\[Feature:.+\\]",
 		"e2e.test",
 		"--",
+		"-v=10",
 		reportArg,
 		"-provider=gce",
 		"-node-os-distro=cos",


### PR DESCRIPTION
/assign @msau42 
Is this too many logs? Maybe. But also it would help with my current debugging...


```release-note
NONE
```
