### PR TITLE
Give project variable to test framework so it can do things like list disks

### DIFF
--- a/test/run-k8s-integration-local.sh
+++ b/test/run-k8s-integration-local.sh
@@ -12,6 +12,7 @@ source "${PKGDIR}/deploy/common.sh"
 
 ensure_var GCE_PD_CSI_STAGING_IMAGE
 ensure_var GCE_PD_SA_DIR
+ensure_var GCE_PD_PROJECT
 
 make -C ${PKGDIR} test-k8s-integration
 
@@ -23,7 +24,7 @@ make -C ${PKGDIR} test-k8s-integration
 # --deploy-overlay-name=dev --storageclass-file=sc-standard.yaml \
 # --test-focus="External.Storage" --gce-zone="us-central1-b" \
 # --deployment-strategy=gke --gke-cluster-version=${gke_cluster_version} \
-# --test-version=${test_version} --num-nodes=3
+# --test-version=${test_version} --num-nodes=3 --gce-project=${GCE_PD_PROJECT}
 
 # This version of the command creates a GCE cluster. It downloads and builds two k8s releases,
 # one for the cluster and one for the tests, unless the cluster and test versioning is the same.
@@ -33,7 +34,7 @@ make -C ${PKGDIR} test-k8s-integration
 # --deploy-overlay-name=dev --storageclass-file=sc-standard.yaml \
 # --test-focus="External.Storage" --gce-zone="us-central1-b" \
 # --deployment-strategy=gce --kube-version=${kube_version} \
-# --test-version=${test_version} --num-nodes=3
+# --test-version=${test_version} --num-nodes=3 --gce-project=${GCE_PD_PROJECT}
 
 # This version of the command does not build the driver or K8s, points to a
 # local K8s repo to get the e2e.test binary, and does not bring up or down the cluster
@@ -42,4 +43,4 @@ ${PKGDIR}/bin/k8s-integration-test --kube-version=master --run-in-prow=false \
 --staging-image=${GCE_PD_CSI_STAGING_IMAGE} --service-account-file=${GCE_PD_SA_DIR}/cloud-sa.json \
 --deploy-overlay-name=dev --bringup-cluster=false --teardown-cluster=false --local-k8s-dir=$KTOP \
 --storageclass-file=sc-standard.yaml --do-driver-build=true  --test-focus="External.Storage" \
---gce-zone="us-central1-b" --num-nodes=${NUM_NODES:-3}
+--gce-zone="us-central1-b" --num-nodes=${NUM_NODES:-3} --gce-project=${GCE_PD_PROJECT}

--- a/test/run-k8s-integration-migration-local.sh
+++ b/test/run-k8s-integration-migration-local.sh
@@ -12,6 +12,8 @@ readonly test_version=${TEST_VERSION:-master}
 
 ensure_var GCE_PD_CSI_STAGING_IMAGE
 ensure_var GCE_PD_SA_DIR
+ensure_var GCE_PD_PROJECT
+ensure_var GCE_PD_ZONE
 
 make -C ${PKGDIR} test-k8s-integration
 
@@ -19,14 +21,14 @@ ${PKGDIR}/bin/k8s-integration-test --kube-version=master --run-in-prow=false \
 --staging-image=${GCE_PD_CSI_STAGING_IMAGE} --service-account-file=${GCE_PD_SA_DIR}/cloud-sa.json \
 --deploy-overlay-name=dev --test-focus=${GCE_PD_TEST_FOCUS} \
 --kube-feature-gates="CSIMigration=true,CSIMigrationGCE=true" --migration-test=true --gce-zone="us-central1-b" \
---deployment-strategy=gce --test-version=${test_version} --num-nodes=${NUM_NODES:-3}
+--deployment-strategy=gce --test-version=${test_version} --gce-zone=${GCE_PD_ZONE} \
+--num-nodes=${NUM_NODES:-3} --gce-project=${GCE_PD_PROJECT}
 
 # This version of the command does not build the driver or K8s, points to a
 # local K8s repo to get the e2e.test binary, and does not bring up or down the cluster
-#
-# ensure_var GCE_PD_ZONE
+# 
 # ${PKGDIR}/bin/k8s-integration-test --run-in-prow=false \
 # --staging-image=${GCE_PD_CSI_STAGING_IMAGE} --service-account-file=${GCE_PD_SA_DIR}/cloud-sa.json \
 # --deploy-overlay-name=dev --test-focus=${GCE_PD_TEST_FOCUS} \
 # --bringup-cluster=false --teardown-cluster=false --local-k8s-dir=$KTOP --migration-test=true \
-# --do-driver-build=true --gce-zone=${GCE_PD_ZONE} --num-nodes=${NUM_NODES:-3}
+# --do-driver-build=true --gce-zone=${GCE_PD_ZONE} --num-nodes=${NUM_NODES:-3} --gce-project=${GCE_PD_PROJECT}

--- a/test/run-k8s-integration-migration.sh
+++ b/test/run-k8s-integration-migration.sh
@@ -9,9 +9,14 @@
 set -o nounset
 set -o errexit
 
-export GCE_PD_VERBOSITY=9
+
+
+
 
 readonly PKGDIR=${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+export GCE_PD_VERBOSITY=9
+
+source "${PKGDIR}/deploy/common.sh"
 
 readonly overlay_name="${GCE_PD_OVERLAY_NAME:-stable}"
 readonly boskos_resource_type="${GCE_PD_BOSKOS_RESOURCE_TYPE:-gce-project}"
@@ -19,6 +24,8 @@ readonly do_driver_build="${GCE_PD_DO_DRIVER_BUILD:-true}"
 readonly deployment_strategy=${DEPLOYMENT_STRATEGY:-gce}
 readonly kube_version=${GCE_PD_KUBE_VERSION:-master}
 readonly test_version=${TEST_VERSION:-master}
+
+ensure_var E2E_GOOGLE_APPLICATION_CREDENTIALS
 
 readonly GCE_PD_TEST_FOCUS="\s[V|v]olume\sexpand|\[sig-storage\]\sIn-tree\sVolumes\s\[Driver:\sgcepd\]\s\[Testpattern:\sDynamic\sPV|allowedTopologies|Pod\sDisks|PersistentVolumes\sDefault"
 

--- a/test/run-k8s-integration.sh
+++ b/test/run-k8s-integration.sh
@@ -10,6 +10,9 @@ set -o nounset
 set -o errexit
 
 readonly PKGDIR=${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+
+source "${PKGDIR}/deploy/common.sh"
+
 readonly overlay_name="${GCE_PD_OVERLAY_NAME:-stable}"
 readonly boskos_resource_type="${GCE_PD_BOSKOS_RESOURCE_TYPE:-gce-project}"
 readonly do_driver_build="${GCE_PD_DO_DRIVER_BUILD:-true}"
@@ -17,6 +20,8 @@ readonly deployment_strategy=${DEPLOYMENT_STRATEGY:-gce}
 readonly gke_cluster_version=${GKE_CLUSTER_VERSION:-latest}
 readonly kube_version=${GCE_PD_KUBE_VERSION:-master}
 readonly test_version=${TEST_VERSION:-master}
+
+ensure_var E2E_GOOGLE_APPLICATION_CREDENTIALS
 
 export GCE_PD_VERBOSITY=9
 


### PR DESCRIPTION
/kind failing-test

A lot of the older storage tests do things like listing disks on GCE directly from the test framework, the framework needs the project ID to function as it runs directly off the test client (not the server (kubernetes)).

Note: `$PROJECT` is a default env var in the test-infra

/assign @msau42 @hantaowang 

```release-note
NONE
```
