### PR TITLE
Add SupportedMountOptions to external pd test config to start mount options tests

### DIFF
--- a/test/k8s-integration/config/test-config-template.in
+++ b/test/k8s-integration/config/test-config-template.in
@@ -19,3 +19,6 @@ DriverInfo:
     block: true
     # dataSource: true
     # RWX: true
+  SupportedMountOption:
+    debug:
+    nouid32:


### PR DESCRIPTION
Fixes: #263

/assign @msau42 

/kind cleanup

```release-note
NONE
```
