### PR TITLE
increase node size for gke

### DIFF
--- a/test/k8s-integration/cluster.go
+++ b/test/k8s-integration/cluster.go
@@ -21,7 +21,7 @@ func clusterDownGCE(k8sDir string) error {
 
 func clusterDownGKE(gceZone string) error {
 	cmd := exec.Command("gcloud", "container", "clusters", "delete", gkeTestClusterName,
-		"--zone", gceZone, "--quiet")
+		"--zone", gceZone, "--quiet", "--machine-type", "n1-standard-2")
 	err := runCommand("Bringing Down E2E Cluster on GKE", cmd)
 	if err != nil {
 		return fmt.Errorf("failed to bring down kubernetes e2e cluster on gke: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Increases the default machine type for GKe to be the same as GCE: n1-standard-2

**Which issue(s) this PR fixes**:
Drivers are sometimes not able to schedule on the node with the controller due to insufficient CPU. This causes flaky tests on GKE clusters. 

**Special notes for your reviewer**:
@davidz627 @jingxu97 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
