### PR TITLE
[Cherry-Pick] Amend volume limits returned by the driver to documented-1 since node boot disk is attachable disk

### DIFF
--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -44,11 +44,14 @@ type GCENodeServer struct {
 var _ csi.NodeServer = &GCENodeServer{}
 
 // The constants are used to map from the machine type to the limit of
-// persistent disks that can be attached to an instance. Please refer to gcloud doc
-// https://cloud.google.com/compute/docs/disks/#pdnumberlimits
+// persistent disks that can be attached to an instance. Please refer to gcloud
+// doc https://cloud.google.com/compute/docs/disks/#pdnumberlimits
+// These constants are all the documented attach limit minus one because the
+// node boot disk is considered an attachable disk so effective attach limit is
+// one less.
 const (
-	volumeLimit16  int64 = 16
-	volumeLimit128 int64 = 128
+	volumeLimitSmall int64 = 15
+	volumeLimitBig   int64 = 127
 )
 
 func (ns *GCENodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
@@ -327,9 +330,9 @@ func (ns *GCENodeServer) GetVolumeLimits() (int64, error) {
 	// Machine-type format: n1-type-CPUS or custom-CPUS-RAM or f1/g1-type
 	machineType := ns.MetadataService.GetMachineType()
 	if strings.HasPrefix(machineType, "n1-") || strings.HasPrefix(machineType, "custom-") {
-		volumeLimits = volumeLimit128
+		volumeLimits = volumeLimitBig
 	} else {
-		volumeLimits = volumeLimit16
+		volumeLimits = volumeLimitSmall
 	}
 	return volumeLimits, nil
 }

--- a/pkg/gce-pd-csi-driver/node_test.go
+++ b/pkg/gce-pd-csi-driver/node_test.go
@@ -52,27 +52,27 @@ func TestNodeGetVolumeLimits(t *testing.T) {
 		{
 			name:           "Predifined standard machine",
 			machineType:    "n1-standard-1",
-			expVolumeLimit: volumeLimit128,
+			expVolumeLimit: volumeLimitBig,
 		},
 		{
 			name:           "Predifined micro machine",
 			machineType:    "f1-micro",
-			expVolumeLimit: volumeLimit16,
+			expVolumeLimit: volumeLimitSmall,
 		},
 		{
 			name:           "Predifined small machine",
 			machineType:    "g1-small",
-			expVolumeLimit: volumeLimit16,
+			expVolumeLimit: volumeLimitSmall,
 		},
 		{
 			name:           "Custom machine with 1GiB Mem",
 			machineType:    "custom-1-1024",
-			expVolumeLimit: volumeLimit128,
+			expVolumeLimit: volumeLimitBig,
 		},
 		{
 			name:           "Custom machine with 4GiB Mem",
 			machineType:    "custom-2-4096",
-			expVolumeLimit: volumeLimit128,
+			expVolumeLimit: volumeLimitBig,
 		},
 	}
 

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -42,7 +42,7 @@ const (
 	readyState               = "READY"
 	standardDiskType         = "pd-standard"
 	ssdDiskType              = "pd-ssd"
-	defaultVolumeLimit int64 = 128
+	defaultVolumeLimit int64 = 127
 )
 
 var _ = Describe("GCE PD CSI Driver", func() {


### PR DESCRIPTION
Parent: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/361

/assign @jsafrane @msau42 

```release-note
Reduces node attach limits by 1 since the node boot disk is considered an attachable disk
```
