### PR TITLE
Set requests for CPU and MEM for controller containers

### DIFF
--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -25,6 +25,10 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          resources:
+            requests:
+              cpu: "25m"
+              memory: "25Mi"
         - name: csi-attacher
           image: gke.gcr.io/csi-attacher
           args:
@@ -33,6 +37,10 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          resources:
+            requests:
+              cpu: "25m"
+              memory: "25Mi"
         - name: csi-resizer
           image: gke.gcr.io/csi-resizer
           args:
@@ -41,6 +49,10 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          resources:
+            requests:
+              cpu: "25m"
+              memory: "25Mi"
         - name: gce-pd-driver
           # Don't change base image without changing pdImagePlaceholder in
           # test/k8s-integration/main.go
@@ -57,6 +69,10 @@ spec:
             - name: cloud-sa-volume
               readOnly: true
               mountPath: "/etc/cloud-sa"
+          resources:
+            requests:
+              cpu: "35m"
+              memory: "25Mi"
       volumes:
         - name: socket-dir
           emptyDir: {}


### PR DESCRIPTION
As it turns out CPU and MEM requests are container based, so I took the MAX values of each for each container throughout my test runs and set those as requests. Not sure if I should do average or something else?

Based on results from #356 

/assign @msau42 @misterikkit
/cc @verult 

/kind feature
/kind flake

```release-note
NONE
```
