### PR TITLE
Wrap all GRPC errors in status, fix semantics of NotFound errors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -118,15 +118,15 @@
   version = "v0.6.1"
 
 [[projects]]
-  digest = "1:2af9c947430dba1b6895a8c552d5b915d95dc401ab78c1e017fae86905236fd3"
+  digest = "1:a56295e19bdcc1777d448e95df77ccd4378a963ccb0aac2c93c0b03d9d4f024a"
   name = "github.com/kubernetes-csi/csi-test"
   packages = [
     "pkg/sanity",
     "utils",
   ]
   pruneopts = "NUT"
-  revision = "6738ab2206eac88874f0a3ede59b40f680f59f43"
-  version = "v2.0.1"
+  revision = "82b05190c167c52bb6d5aaf2e1d7c833fa539783"
+  version = "v2.2.0"
 
 [[projects]]
   digest = "1:3c46171ee5eee66086897e1efca67b84bf552b1f80039d421068c90684868194"
@@ -540,6 +540,7 @@
     "github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta",
     "github.com/container-storage-interface/spec/lib/go/csi",
     "github.com/golang/protobuf/ptypes",
+    "github.com/google/uuid",
     "github.com/kubernetes-csi/csi-lib-utils/protosanitizer",
     "github.com/kubernetes-csi/csi-test/pkg/sanity",
     "github.com/onsi/ginkgo",
@@ -566,6 +567,7 @@
     "k8s.io/kubernetes/pkg/util/resizefs",
     "k8s.io/test-infra/boskos/client",
     "k8s.io/test-infra/boskos/common",
+    "k8s.io/utils/exec",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -47,7 +47,7 @@
 
 [[constraint]]
   name = "github.com/kubernetes-csi/csi-test"
-  version = "v2.0.1"
+  version = "2.2.0"
 
 [[constraint]]
   branch = "master"

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -144,3 +144,7 @@ func GetDeviceName(volKey *meta.Key) (string, error) {
 func CreateNodeID(project, zone, name string) string {
 	return fmt.Sprintf(nodeIDFmt, project, zone, name)
 }
+
+func CreateZonalVolumeID(project, zone, name string) string {
+	return fmt.Sprintf(volIDZonalFmt, project, zone, name)
+}

--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -375,7 +375,7 @@ func (cloud *FakeCloudProvider) ResizeDisk(ctx context.Context, volKey *meta.Key
 
 	disk.setSizeGb(common.BytesToGb(requestBytes))
 
-	return requestBytes, nil
+	return common.BytesToGb(requestBytes), nil
 
 }
 

--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -75,7 +75,7 @@ func (cloud *FakeCloudProvider) RepairUnderspecifiedVolumeKey(ctx context.Contex
 				return volumeKey, nil
 			}
 		}
-		return nil, fmt.Errorf("Couldn't repair unspecified volume information")
+		return nil, notFoundError()
 	case meta.Regional:
 		if volumeKey.Region != common.UnspecifiedValue {
 			return volumeKey, nil

--- a/pkg/gce-cloud-provider/compute/gce.go
+++ b/pkg/gce-cloud-provider/compute/gce.go
@@ -17,12 +17,13 @@ package gcecloudprovider
 import (
 	"context"
 	"fmt"
-	"golang.org/x/oauth2/google"
-	"gopkg.in/gcfg.v1"
 	"net/http"
 	"os"
 	"runtime"
 	"time"
+
+	"golang.org/x/oauth2/google"
+	"gopkg.in/gcfg.v1"
 
 	"cloud.google.com/go/compute/metadata"
 	"golang.org/x/oauth2"
@@ -241,4 +242,10 @@ func IsGCEError(err error, reason string) bool {
 		}
 	}
 	return false
+}
+
+// IsGCENotFoundError returns true if the error is a googleapi.Error with
+// notFound reason
+func IsGCENotFoundError(err error) bool {
+	return IsGCEError(err, "notFound")
 }

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -224,6 +224,8 @@ func (gceCS *GCEControllerServer) DeleteVolume(ctx context.Context, req *csi.Del
 
 	volKey, err := common.VolumeIDToKey(volumeID)
 	if err != nil {
+		// Cannot find volume associated with this ID because VolumeID is not in
+		// correct format, this is a success according to the Spec
 		klog.Warningf("Treating volume as deleted because volume id %s is invalid: %v", volumeID, err)
 		return &csi.DeleteVolumeResponse{}, nil
 	}

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -224,14 +224,14 @@ func (gceCS *GCEControllerServer) DeleteVolume(ctx context.Context, req *csi.Del
 
 	volKey, err := common.VolumeIDToKey(volumeID)
 	if err != nil {
-		// Cannot find volume associated with this ID because can't even get the name or zone
-		// This is a success according to the spec
+		klog.Warningf("Treating volume as deleted because volume id %s is invalid: %v", volumeID, err)
 		return &csi.DeleteVolumeResponse{}, nil
 	}
 
 	volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, volKey)
 	if err != nil {
-		return nil, status.Error(codes.NotFound, fmt.Sprintf("Could not find volume with ID %v: %v", volumeID, err))
+		klog.Warningf("Treating volume as deleted because cannot find volume %v: %v", volKey.String(), err)
+		return &csi.DeleteVolumeResponse{}, nil
 	}
 
 	if acquired := gceCS.volumeLocks.TryAcquire(volumeID); !acquired {
@@ -267,7 +267,7 @@ func (gceCS *GCEControllerServer) ControllerPublishVolume(ctx context.Context, r
 
 	volKey, err := common.VolumeIDToKey(volumeID)
 	if err != nil {
-		return nil, status.Error(codes.NotFound, fmt.Sprintf("Could not find volume with ID %v: %v", volumeID, err))
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("ControllerPublishVolume volume ID is invalid: %v", err))
 	}
 
 	volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, volKey)
@@ -294,7 +294,7 @@ func (gceCS *GCEControllerServer) ControllerPublishVolume(ctx context.Context, r
 
 	_, err = gceCS.CloudProvider.GetDisk(ctx, volKey)
 	if err != nil {
-		if gce.IsGCEError(err, "notFound") {
+		if gce.IsGCENotFoundError(err) {
 			return nil, status.Error(codes.NotFound, fmt.Sprintf("Could not find disk %v: %v", volKey.String(), err))
 		}
 		return nil, status.Error(codes.Internal, fmt.Sprintf("Unknown get disk error: %v", err))
@@ -305,7 +305,7 @@ func (gceCS *GCEControllerServer) ControllerPublishVolume(ctx context.Context, r
 	}
 	instance, err := gceCS.CloudProvider.GetInstanceOrError(ctx, instanceZone, instanceName)
 	if err != nil {
-		if gce.IsGCEError(err, "notFound") {
+		if gce.IsGCENotFoundError(err) {
 			return nil, status.Error(codes.NotFound, fmt.Sprintf("Could not find instance %v: %v", nodeID, err))
 		}
 		return nil, status.Error(codes.Internal, fmt.Sprintf("Unknown get instance error: %v", err))
@@ -365,7 +365,7 @@ func (gceCS *GCEControllerServer) ControllerUnpublishVolume(ctx context.Context,
 
 	volKey, err := common.VolumeIDToKey(volumeID)
 	if err != nil {
-		return nil, err
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("ControllerUnpublishVolume Volume ID is invalid: %v", err))
 	}
 
 	// Acquires the lock for the volume on that node only, because we need to support the ability
@@ -382,7 +382,12 @@ func (gceCS *GCEControllerServer) ControllerUnpublishVolume(ctx context.Context,
 	}
 	instance, err := gceCS.CloudProvider.GetInstanceOrError(ctx, instanceZone, instanceName)
 	if err != nil {
-		return nil, err
+		if gce.IsGCENotFoundError(err) {
+			// Node not existing on GCE means that disk has been detached
+			klog.Warningf("Treating volume %v as unpublished because node %v could not be found", volKey.String(), instanceName)
+			return &csi.ControllerUnpublishVolumeResponse{}, nil
+		}
+		return nil, status.Error(codes.Internal, fmt.Sprintf("error getting instance: %v", err))
 	}
 
 	deviceName, err := common.GetDeviceName(volKey)
@@ -420,7 +425,7 @@ func (gceCS *GCEControllerServer) ValidateVolumeCapabilities(ctx context.Context
 	}
 	volKey, err := common.VolumeIDToKey(volumeID)
 	if err != nil {
-		return nil, status.Error(codes.NotFound, fmt.Sprintf("Volume ID is of improper format, got %v", volumeID))
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("ValidateVolumeCapabilities Volume ID is invalid: %v", err))
 	}
 
 	if acquired := gceCS.volumeLocks.TryAcquire(volumeID); !acquired {
@@ -430,7 +435,7 @@ func (gceCS *GCEControllerServer) ValidateVolumeCapabilities(ctx context.Context
 
 	_, err = gceCS.CloudProvider.GetDisk(ctx, volKey)
 	if err != nil {
-		if gce.IsGCEError(err, "notFound") {
+		if gce.IsGCENotFoundError(err) {
 			return nil, status.Error(codes.NotFound, fmt.Sprintf("Could not find disk %v: %v", volKey.Name, err))
 		}
 		return nil, status.Error(codes.Internal, fmt.Sprintf("Unknown get disk error: %v", err))
@@ -532,7 +537,7 @@ func (gceCS *GCEControllerServer) CreateSnapshot(ctx context.Context, req *csi.C
 	}
 	volKey, err := common.VolumeIDToKey(volumeID)
 	if err != nil {
-		return nil, status.Error(codes.NotFound, fmt.Sprintf("Could not find volume with ID %v: %v", volumeID, err))
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("CreateSnapshot Volume ID is invalid: %v", err))
 	}
 
 	if acquired := gceCS.volumeLocks.TryAcquire(volumeID); !acquired {
@@ -670,7 +675,7 @@ func (gceCS *GCEControllerServer) ControllerExpandVolume(ctx context.Context, re
 
 	volKey, err := common.VolumeIDToKey(volumeID)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("ControllerExpandVolume volume ID is invalid: %v", err))
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("ControllerExpandVolume Volume ID is invalid: %v", err))
 	}
 
 	resizedGb, err := gceCS.CloudProvider.ResizeDisk(ctx, volKey, reqBytes)

--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -90,8 +90,7 @@ func (ns *GCENodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePub
 
 	notMnt, err := ns.Mounter.Interface.IsLikelyNotMountPoint(targetPath)
 	if err != nil && !os.IsNotExist(err) {
-		klog.Errorf("cannot validate mount point: %s %v", targetPath, err)
-		return nil, err
+		return nil, status.Error(codes.Internal, fmt.Sprintf("cannot validate mount point: %s %v", targetPath, err))
 	}
 	if !notMnt {
 		// TODO(#95): check if mount is compatible. Return OK if it is, or appropriate error.
@@ -129,8 +128,7 @@ func (ns *GCENodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePub
 		sourcePath = stagingTargetPath
 
 		if err := ns.Mounter.Interface.MakeDir(targetPath); err != nil {
-			klog.Errorf("mkdir failed on disk %s (%v)", targetPath, err)
-			return nil, err
+			return nil, status.Error(codes.Internal, fmt.Sprintf("mkdir failed on disk %s (%v)", targetPath, err))
 		}
 	} else if blk := volumeCapability.GetBlock(); blk != nil {
 		klog.V(4).Infof("NodePublishVolume with block volume mode")
@@ -245,7 +243,7 @@ func (ns *GCENodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStage
 
 	volumeKey, err := common.VolumeIDToKey(volumeID)
 	if err != nil {
-		return nil, err
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("NodeStageVolume Volume ID is invalid: %v", err))
 	}
 
 	// Part 1: Get device path of attached device
@@ -387,7 +385,7 @@ func (ns *GCENodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpa
 
 	volKey, err := common.VolumeIDToKey(volumeID)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("ControllerExpandVolume volume ID is invalid: %v", err))
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("ControllerExpandVolume Volume ID is invalid: %v", err))
 	}
 
 	devicePath, err := ns.getDevicePath(volumeID, "")

--- a/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/cleanup.go
+++ b/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/cleanup.go
@@ -19,6 +19,7 @@ package sanity
 import (
 	"context"
 	"log"
+	"sync"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 
@@ -36,7 +37,7 @@ type VolumeInfo struct {
 }
 
 // Cleanup keeps track of resources, in particular volumes, which need
-// to be freed when testing is done.
+// to be freed when testing is done. All methods can be called concurrently.
 type Cleanup struct {
 	Context                    *SanityContext
 	ControllerClient           csi.ControllerClient
@@ -47,11 +48,14 @@ type Cleanup struct {
 	// Maps from volume name to the node ID for which the volume
 	// is published and the volume ID.
 	volumes map[string]VolumeInfo
+	mutex   sync.Mutex
 }
 
 // RegisterVolume adds or updates an entry for the volume with the
 // given name.
 func (cl *Cleanup) RegisterVolume(name string, info VolumeInfo) {
+	cl.mutex.Lock()
+	defer cl.mutex.Unlock()
 	if cl.volumes == nil {
 		cl.volumes = make(map[string]VolumeInfo)
 	}
@@ -69,6 +73,11 @@ func (cl *Cleanup) MaybeRegisterVolume(name string, vol *csi.CreateVolumeRespons
 // UnregisterVolume removes the entry for the volume with the
 // given name, thus preventing all cleanup operations for it.
 func (cl *Cleanup) UnregisterVolume(name string) {
+	cl.mutex.Lock()
+	defer cl.mutex.Unlock()
+	cl.unregisterVolume(name)
+}
+func (cl *Cleanup) unregisterVolume(name string) {
 	if cl.volumes != nil {
 		delete(cl.volumes, name)
 	}
@@ -76,6 +85,8 @@ func (cl *Cleanup) UnregisterVolume(name string) {
 
 // DeleteVolumes stops using the registered volumes and tries to delete all of them.
 func (cl *Cleanup) DeleteVolumes() {
+	cl.mutex.Lock()
+	defer cl.mutex.Unlock()
 	if cl.volumes == nil {
 		return
 	}
@@ -88,7 +99,7 @@ func (cl *Cleanup) DeleteVolumes() {
 			ctx,
 			&csi.NodeUnpublishVolumeRequest{
 				VolumeId:   info.VolumeID,
-				TargetPath: cl.Context.TargetPath,
+				TargetPath: cl.Context.TargetPath + "/target",
 			},
 		); err != nil {
 			logger.Printf("warning: NodeUnpublishVolume: %s", err)
@@ -129,6 +140,6 @@ func (cl *Cleanup) DeleteVolumes() {
 			logger.Printf("error: DeleteVolume: %s", err)
 		}
 
-		cl.UnregisterVolume(name)
+		cl.unregisterVolume(name)
 	}
 }

--- a/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/identity.go
+++ b/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/identity.go
@@ -47,7 +47,6 @@ var _ = DescribeSanity("Identity Service", func(sc *SanityContext) {
 			Expect(res).NotTo(BeNil())
 
 			By("checking successful response")
-			Expect(res.GetCapabilities()).NotTo(BeNil())
 			for _, cap := range res.GetCapabilities() {
 				switch cap.GetType().(type) {
 				case *csi.PluginCapability_Service_:

--- a/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/sanity.go
+++ b/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/sanity.go
@@ -65,7 +65,10 @@ type Config struct {
 	ControllerAddress string
 	SecretsFile       string
 
-	TestVolumeSize            int64
+	TestVolumeSize int64
+
+	// Target size for ExpandVolume requests. If not specified it defaults to TestVolumeSize + 1 GB
+	TestVolumeExpandSize      int64
 	TestVolumeParametersFile  string
 	TestVolumeParameters      map[string]string
 	TestNodeVolumeAttachLimit bool
@@ -117,6 +120,11 @@ type Config struct {
 	RemoveStagingPathCmd string
 	// Timeout for the executed commands for path removal.
 	RemovePathCmdTimeout int
+
+	// IDGen is an optional interface for callers to provide a generator for
+	// valid Volume and Node IDs. Defaults to DefaultIDGenerator which generates
+	// generic string IDs
+	IDGen IDGenerator
 }
 
 // SanityContext holds the variables that each test can depend on. It
@@ -148,6 +156,10 @@ func Test(t *testing.T, reqConfig *Config) {
 		if err != nil {
 			panic(fmt.Sprintf("error unmarshaling yaml: %v", err))
 		}
+	}
+
+	if reqConfig.IDGen == nil {
+		reqConfig.IDGen = &DefaultIDGenerator{}
 	}
 
 	sc := &SanityContext{

--- a/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/util.go
+++ b/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/util.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sanity
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// IDGenerator generates valid and invalid Volume and Node IDs to be used in
+// tests
+type IDGenerator interface {
+	// GenerateUniqueValidVolumeID must generate a unique Volume ID that the CSI
+	// Driver considers in valid form
+	GenerateUniqueValidVolumeID() string
+
+	// GenerateInvalidVolumeID must output a Volume ID that the CSI Driver MAY
+	// consider invalid. Some drivers may not have requirements on IDs in which
+	// case this method should output any non-empty ID
+	GenerateInvalidVolumeID() string
+
+	// GenerateUniqueValidNodeID must generate a unique Node ID that the CSI
+	// Driver considers in valid form
+	GenerateUniqueValidNodeID() string
+
+	// GenerateInvalidNodeID must output a Node ID that the CSI Driver MAY
+	// consider invalid. Some drivers may not have requirements on IDs in which
+	// case this method should output any non-empty ID
+	GenerateInvalidNodeID() string
+}
+
+var _ IDGenerator = &DefaultIDGenerator{}
+
+type DefaultIDGenerator struct {
+}
+
+func (d DefaultIDGenerator) GenerateUniqueValidVolumeID() string {
+	return fmt.Sprintf("fake-vol-id-%s", uuid.New().String()[:10])
+}
+
+func (d DefaultIDGenerator) GenerateInvalidVolumeID() string {
+	return "fake-vol-id"
+}
+
+func (d DefaultIDGenerator) GenerateUniqueValidNodeID() string {
+	return fmt.Sprintf("fake-node-id-%s", uuid.New().String()[:10])
+}
+
+func (d DefaultIDGenerator) GenerateInvalidNodeID() string {
+	return "fake-node-id"
+}


### PR DESCRIPTION
Fixes: #367 
/assign @msau42 @jsafrane 
/cc @jingxu97 

/kind bug
/kind cleanup

```release-note
ControllerUnpublishVolume now returns success when the Node is GCE API NotFound.
Invalid format VolumeID is now GRPC InvalidArgument error instead of GRPC NotFound.
Underspecified disks not found in any zone now return GRPC NotFound.
```
