### PR TITLE
Export kubectl path to test

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -214,12 +214,16 @@ func handle() error {
 		}
 		err = buildKubernetes(testDir, "WHAT=test/e2e/e2e.test")
 		if err != nil {
-			return fmt.Errorf("failed to build Kubernetes: %v", err)
+			return fmt.Errorf("failed to build Kubernetes e2e: %v", err)
 		}
-		// kubetest relies on ginkgo already built in the test k8s directory
+		// kubetest relies on ginkgo and kubectl already built in the test k8s directory
 		err = buildKubernetes(testDir, "ginkgo")
 		if err != nil {
 			return fmt.Errorf("failed to build gingko: %v", err)
+		}
+		err = buildKubernetes(testDir, "kubectl")
+		if err != nil {
+			return fmt.Errorf("failed to build kubectl: %v", err)
 		}
 	} else {
 		testDir = k8sDir


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
We previous had a PR to export the kubectl path https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/352 that was closed in favor of another PR https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/358, but oddly the kubectl path fix was never actually included in that second PR. This adds the fix.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
