### PR TITLE
Update csi-attacher to v.1.2.1 for fix to not ignore ControllerUnpublishErrors

### DIFF
--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -13,7 +13,7 @@ images:
   newTag: "v1.2.1-gke.0"
 - name: gke.gcr.io/csi-attacher
   newName: gke.gcr.io/csi-attacher
-  newTag: "v1.2.0-gke.0"
+  newTag: "v1.2.1-gke.0"
 - name: gke.gcr.io/csi-node-driver-registrar
   newName: gke.gcr.io/csi-node-driver-registrar
   newTag: "v1.1.0-gke.0"


### PR DESCRIPTION
/kind bug

/assign @msau42 

Hope this might actually fix some flakes in the tests :)

```release-note
Updated CSI Attacher to v1.2.1 to stop ignoring errors from ControllerUnpublish
```
