### PR TITLE
Adding k8s-specific documentation around storageclass fields

### DIFF
--- a/docs/kubernetes/user-guides/basic.md
+++ b/docs/kubernetes/user-guides/basic.md
@@ -85,3 +85,9 @@ $ kubectl get pods
 NAME                      READY     STATUS    RESTARTS   AGE
 web-server                1/1       Running   0          1m
 ```
+
+## StorageClass Fields
+
+The list of recognized StorageClass [`parameters`](https://kubernetes.io/docs/concepts/storage/storage-classes/#parameters) is the same as the list of [CSI CreateVolume parameters](../../../README.md#createvolume-parameters).
+
+The list of recognized topology keys in [`allowedTopologies`](https://kubernetes.io/docs/concepts/storage/storage-classes/#allowed-topologies) is listed [here](../../../README.md#topology)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
AFAIK the closest thing currently to a list of StorageClass parameters is the list of CreateVolume parameters. k8s users may not understand CSI lingo, so it's nice to explicitly call out StorageClass parameters separately.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
