### PR TITLE
Add Supported size range to driver info config

### DIFF
--- a/test/k8s-integration/config/test-config-template.in
+++ b/test/k8s-integration/config/test-config-template.in
@@ -23,3 +23,6 @@ DriverInfo:
   SupportedMountOption:
     debug:
     nouid32:
+  SupportedSizeRange:
+    Min: 5Gi
+    Max: 64Ti


### PR DESCRIPTION
/kind failing-test

Because of change: https://github.com/kubernetes/kubernetes/pull/78306

```release-note
NONE
```
