### PR TITLE
Bumping all images to latest versions for 0.6.0 stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ lifecycle of Google Compute Engine Persistent Disks.
 ## Project Status
 
 Status: Beta
-Latest stable image: `gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver:v0.5.1-gke.0`
+Latest stable image: `gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver:v0.6.0-gke.0`
 
 ### Test Status
 
@@ -28,7 +28,7 @@ Latest stable image: `gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver:
 
 ### CSI Compatibility
 
-This plugin is compatible with CSI versions [v1.0.0](https://github.com/container-storage-interface/spec/blob/v1.0.0/spec.md)
+This plugin is compatible with CSI versions [v1.1.0](https://github.com/container-storage-interface/spec/blob/v1.1.0/spec.md) and [v1.0.0](https://github.com/container-storage-interface/spec/blob/v1.0.0/spec.md)
 
 ### Kubernetes Compatibility
 
@@ -39,7 +39,8 @@ This plugin is compatible with CSI versions [v1.0.0](https://github.com/containe
 | v0.3.x (beta)                        | no            | no   | yes  | yes  | yes  |
 | v0.4.x (beta)                        | no            | no   | yes  | yes  | yes  |
 | v0.5.x (beta)                        | no            | no   | no   | yes  | yes  |
-| dev                                  | no            | no   | no   | no   | yes  |
+| v0.6.x (beta)                        | no            | no   | no   | yes  | yes  |
+| dev                                  | no            | no   | no   | yes  | yes  |
 
 ### Known Issues
 

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -7,13 +7,13 @@ images:
   # Don't change stable image without changing pdImagePlaceholder in
   # test/k8s-integration/main.go
   newName: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
-  newTag: "v0.5.1-gke.0"
+  newTag: "v0.6.0-gke.0"
 - name: gke.gcr.io/csi-provisioner
   newName: gke.gcr.io/csi-provisioner
-  newTag: "v1.2.1-gke.0"
+  newTag: "v1.4.0-gke.0"
 - name: gke.gcr.io/csi-attacher
   newName: gke.gcr.io/csi-attacher
-  newTag: "v1.2.1-gke.0"
+  newTag: "v2.0.0-gke.0"
 - name: gke.gcr.io/csi-node-driver-registrar
   newName: gke.gcr.io/csi-node-driver-registrar
-  newTag: "v1.1.0-gke.0"
+  newTag: "v1.2.0-gke.0"


### PR DESCRIPTION
Sidecar images are available in gcr.io/gke-release.

```release-note
NONE
```

/assign @davidz627 @msau42 