### PR TITLE
Move all RePD compute API calls to v1 from v1beta

### DIFF
--- a/pkg/gce-cloud-provider/compute/cloud-disk.go
+++ b/pkg/gce-cloud-provider/compute/cloud-disk.go
@@ -15,13 +15,12 @@ limitations under the License.
 package gcecloudprovider
 
 import (
-	computebeta "google.golang.org/api/compute/v0.beta"
-	compute "google.golang.org/api/compute/v1"
+	computev1 "google.golang.org/api/compute/v1"
 )
 
 type CloudDisk struct {
-	ZonalDisk    *compute.Disk
-	RegionalDisk *computebeta.Disk
+	ZonalDisk    *computev1.Disk
+	RegionalDisk *computev1.Disk
 }
 
 type CloudDiskType string
@@ -35,13 +34,13 @@ const (
 	Global = "global"
 )
 
-func ZonalCloudDisk(disk *compute.Disk) *CloudDisk {
+func ZonalCloudDisk(disk *computev1.Disk) *CloudDisk {
 	return &CloudDisk{
 		ZonalDisk: disk,
 	}
 }
 
-func RegionalCloudDisk(disk *computebeta.Disk) *CloudDisk {
+func RegionalCloudDisk(disk *computev1.Disk) *CloudDisk {
 	return &CloudDisk{
 		RegionalDisk: disk,
 	}

--- a/test/e2e/tests/multi_zone_e2e_test.go
+++ b/test/e2e/tests/multi_zone_e2e_test.go
@@ -105,7 +105,7 @@ var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 		Expect(err).To(BeNil(), "CreateVolume failed with error: %v", err)
 
 		// Validate Disk Created
-		cloudDisk, err := betaComputeService.RegionDisks.Get(p, region, volName).Do()
+		cloudDisk, err := computeService.RegionDisks.Get(p, region, volName).Do()
 		Expect(err).To(BeNil(), "Could not get disk from cloud directly")
 		Expect(cloudDisk.Type).To(ContainSubstring(standardDiskType))
 		Expect(cloudDisk.Status).To(Equal(readyState))
@@ -125,7 +125,7 @@ var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 			Expect(err).To(BeNil(), "DeleteVolume failed")
 
 			// Validate Disk Deleted
-			_, err = betaComputeService.RegionDisks.Get(p, region, volName).Do()
+			_, err = computeService.RegionDisks.Get(p, region, volName).Do()
 			Expect(gce.IsGCEError(err, "notFound")).To(BeTrue(), "Expected disk to not be found")
 		}()
 

--- a/test/e2e/tests/setup_e2e_test.go
+++ b/test/e2e/tests/setup_e2e_test.go
@@ -25,7 +25,6 @@ import (
 	cloudkms "cloud.google.com/go/kms/apiv1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	computebeta "google.golang.org/api/compute/v0.beta"
 	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog"
 	testutils "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/test/e2e/utils"
@@ -38,10 +37,9 @@ var (
 	runInProw       = flag.Bool("run-in-prow", false, "If true, use a Boskos loaned project and special CI service accounts and ssh keys")
 	deleteInstances = flag.Bool("delete-instances", false, "Delete the instances after tests run")
 
-	testContexts       = []*remote.TestContext{}
-	computeService     *compute.Service
-	betaComputeService *computebeta.Service
-	kmsClient          *cloudkms.KeyManagementClient
+	testContexts   = []*remote.TestContext{}
+	computeService *compute.Service
+	kmsClient      *cloudkms.KeyManagementClient
 )
 
 func init() {
@@ -65,9 +63,6 @@ var _ = BeforeSuite(func() {
 	rand.Seed(time.Now().UnixNano())
 
 	computeService, err = remote.GetComputeClient()
-	Expect(err).To(BeNil())
-
-	betaComputeService, err = remote.GetBetaComputeClient()
 	Expect(err).To(BeNil())
 
 	// Create the KMS client.

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -193,7 +193,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		Expect(err).To(BeNil(), "CreateVolume failed with error: %v", err)
 
 		// Validate Disk Created
-		cloudDisk, err := betaComputeService.RegionDisks.Get(p, region, volName).Do()
+		cloudDisk, err := computeService.RegionDisks.Get(p, region, volName).Do()
 		Expect(err).To(BeNil(), "Could not get disk from cloud directly")
 		Expect(cloudDisk.Type).To(ContainSubstring(standardDiskType))
 		Expect(cloudDisk.Status).To(Equal(readyState))
@@ -213,7 +213,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 			Expect(err).To(BeNil(), "DeleteVolume failed")
 
 			// Validate Disk Deleted
-			_, err = betaComputeService.RegionDisks.Get(p, region, volName).Do()
+			_, err = computeService.RegionDisks.Get(p, region, volName).Do()
 			Expect(gce.IsGCEError(err, "notFound")).To(BeTrue(), "Expected disk to not be found")
 		}()
 	})
@@ -486,7 +486,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		Expect(err).To(BeNil(), "CreateVolume failed with error: %v", err)
 
 		// Validate Disk Created
-		cloudDisk, err := betaComputeService.RegionDisks.Get(p, region, volName).Do()
+		cloudDisk, err := computeService.RegionDisks.Get(p, region, volName).Do()
 		Expect(err).To(BeNil(), "Could not get disk from cloud directly")
 		Expect(cloudDisk.Type).To(ContainSubstring(standardDiskType))
 		Expect(cloudDisk.Status).To(Equal(readyState))
@@ -527,7 +527,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 			Expect(err).To(BeNil(), "DeleteVolume failed")
 
 			// Validate Disk Deleted
-			_, err = betaComputeService.RegionDisks.Get(p, region, volName).Do()
+			_, err = computeService.RegionDisks.Get(p, region, volName).Do()
 			Expect(gce.IsGCEError(err, "notFound")).To(BeTrue(), "Expected disk to not be found")
 
 			// Delete Snapshot

--- a/test/remote/instance.go
+++ b/test/remote/instance.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"golang.org/x/oauth2/google"
-	computebeta "google.golang.org/api/compute/v0.beta"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -273,36 +272,6 @@ func GetComputeClient() (*compute.Service, error) {
 		}
 
 		cs, err = compute.New(client)
-		if err != nil {
-			continue
-		}
-		return cs, nil
-	}
-	return nil, err
-}
-
-func GetBetaComputeClient() (*computebeta.Service, error) {
-	const retries = 10
-	const backoff = time.Second * 6
-
-	klog.V(4).Infof("Getting compute client...")
-
-	// Setup the gce client for provisioning instances
-	// Getting credentials on gce jenkins is flaky, so try a couple times
-	var err error
-	var cs *computebeta.Service
-	for i := 0; i < retries; i++ {
-		if i > 0 {
-			time.Sleep(backoff)
-		}
-
-		var client *http.Client
-		client, err = google.DefaultClient(context.Background(), computebeta.ComputeScope)
-		if err != nil {
-			continue
-		}
-
-		cs, err = computebeta.New(client)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
Could probably refactor out `CloudDisk` as well as that was an artifact of having different objects of disks from different APIs. We could probably also consolidate a lot of the zonal/regional codepaths now that we don't need to use entirely different compute APIs.

However, I've refrained from making large changes here in the interest of stability. Also I think theres a possibility we'd need to use different APIs again in the future so I've left the option for that open.

Fixes: #213 

/kind cleanup
/assign @msau42 
```release-note
NONE
```
