### PR TITLE
Add test skipping based on cluster version since some tests added are fixing bugs in newer versions

### DIFF
--- a/test/k8s-integration/cluster.go
+++ b/test/k8s-integration/cluster.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"k8s.io/klog"
 )
@@ -229,4 +231,29 @@ func getGKEKubeTestArgs(gceZone, gceRegion string) ([]string, error) {
 	}
 
 	return args, nil
+}
+
+func getNormalizedVersion(kubeVersion, gkeVersion string) (string, error) {
+	if kubeVersion != "" && gkeVersion != "" {
+		return "", fmt.Errorf("both kube version (%s) and gke version (%s) specified", kubeVersion, gkeVersion)
+	}
+	if kubeVersion == "" && gkeVersion == "" {
+		return "", errors.New("neither kube verison nor gke verison specified")
+	}
+	var v string
+	if kubeVersion != "" {
+		v = kubeVersion
+	} else if gkeVersion != "" {
+		v = gkeVersion
+	}
+	if v == "master" || v == "latest" {
+		// Ugh
+		return v, nil
+	}
+	toks := strings.Split(v, ".")
+	if len(toks) < 2 || len(toks) > 3 {
+		return "", fmt.Errorf("got unexpected number of tokens in version string %s - wanted 2 or 3", v)
+	}
+	return strings.Join(toks[:2], "."), nil
+
 }

--- a/test/k8s-integration/cluster_test.go
+++ b/test/k8s-integration/cluster_test.go
@@ -1,0 +1,71 @@
+package main
+
+import "testing"
+
+func TestGetNormalizedVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		kubeV     string
+		gkeV      string
+		expectV   string
+		expectErr bool
+	}{
+		{
+			name:    "kube",
+			kubeV:   "1.13.5",
+			expectV: "1.13",
+		},
+		{
+			name:    "kube master",
+			kubeV:   "master",
+			expectV: "master",
+		},
+		{
+			name:    "gke",
+			gkeV:    "1.14.3",
+			expectV: "1.14",
+		},
+		{
+			name:    "gke minor",
+			gkeV:    "1.14",
+			expectV: "1.14",
+		},
+		{
+			name:    "gke latest",
+			gkeV:    "latest",
+			expectV: "latest",
+		},
+		{
+			name:    "kube minor",
+			kubeV:   "1.13",
+			expectV: "1.13",
+		},
+		{
+			name:      "kube err",
+			kubeV:     "1",
+			expectErr: true,
+		},
+		{
+			name:      "neither err",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotV, err := getNormalizedVersion(tc.kubeV, tc.gkeV)
+			if err != nil {
+				if !tc.expectErr {
+					t.Fatalf("Got unexpected err: %v", err)
+				}
+				return
+			}
+			if err == nil && tc.expectErr {
+				t.Fatal("Got no error but expected one")
+			}
+			if gotV != tc.expectV {
+				t.Errorf("Got version: %s, expected: %s", gotV, tc.expectV)
+			}
+		})
+	}
+}


### PR DESCRIPTION
/kind failing-test
/assign @msau42 

```release-note
NONE
```
