### PR TITLE
Move CSI socket directory out of the deprecated plugin registration dir

### DIFF
--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -20,7 +20,7 @@ spec:
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
-            - "--kubelet-registration-path=/var/lib/kubelet/plugins/pd.csi.storage.gke.io/csi.sock"
+            - "--kubelet-registration-path=/var/lib/kubelet/plugins_pd.csi.storage.gke.io/csi.sock"
           lifecycle:
             preStop:
               exec:
@@ -31,7 +31,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
-            - name: plugin-dir
+            - name: csi-dir
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
@@ -48,7 +48,7 @@ spec:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet
               mountPropagation: "Bidirectional"
-            - name: plugin-dir
+            - name: csi-dir
               mountPath: /csi
             - name: device-dir
               mountPath: /dev
@@ -71,9 +71,12 @@ spec:
           hostPath:
             path: /var/lib/kubelet
             type: Directory
-        - name: plugin-dir
+        - name: csi-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/pd.csi.storage.gke.io/
+          # Specifically not placed in deprecated plugin directory
+          # /var/lib/kubelet/plugin/ to avoid Kubelet plugin watcher mistaking
+          # the CSI Socket as a Registration Socket
+            path: /var/lib/kubelet/plugins_pd.csi.storage.gke.io/
             type: DirectoryOrCreate
         - name: device-dir
           hostPath:


### PR DESCRIPTION
Kubelet plugin watcher would trigger periodic "Registration" RPCs on this socket since it was in the "well known deprecated registration dir". Moving it out makes plugin watcher not watch it since this is actually the socket we use for CSI.

This change will orphan the old CSI socket if deployed over an existing older PD deployment (since socket removal isn't working). This can be fixed with manual intervention (but in reality it doesn't cause any issues - plugin watcher continues to attempt to interrogate the old socket and failing just like it used to).


/assign @msau42 @saad-ali @verult 
/kind bug
/kind cleanup

```release-note
Changed the location of the socket used for CSI communication with Kubelet in the Node deployment.
Action Required: During driver upgrade this has the potential to orphan the old socket at /var/lib/kubelet/plugins/pd.csi.storage.gke.io/csi.sock. It is recommended to manually remove the /var/lib/kubelet/plugins/pd.csi.storage.gke.io/ directory and it's contents. 
```
