### PR TITLE
Bump snapshotter to v1.2.2 for CVE fix

### DIFF
--- a/deploy/kubernetes/overlays/alpha/controller_add_snapshotter.yaml
+++ b/deploy/kubernetes/overlays/alpha/controller_add_snapshotter.yaml
@@ -8,7 +8,7 @@ spec:
       containers:
         - name: csi-snapshotter
           imagePullPolicy: Always
-          image: gke.gcr.io/csi-snapshotter:v1.2.0-gke.0
+          image: gke.gcr.io/csi-snapshotter:v1.2.2-gke.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"


### PR DESCRIPTION
/kind bug
/assign @msau42 

Should we bump versions in previous releases too?

Fixes #432 

```release-note
Bump external-snapshotter version to v1.2.2 for fix of CVE-2019-11255
```
