### PR TITLE
Bump versions of external-resizer and external-snapshotter for CVE fix

### DIFF
--- a/deploy/kubernetes/overlays/alpha/controller_add_resizer.yaml
+++ b/deploy/kubernetes/overlays/alpha/controller_add_resizer.yaml
@@ -8,7 +8,7 @@ spec:
       containers:
         - name: csi-resizer
           imagePullPolicy: Always
-          image: gke.gcr.io/csi-resizer:v0.2.0-gke.0
+          image: gke.gcr.io/csi-resizer:v0.3.0-gke.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"

--- a/deploy/kubernetes/overlays/alpha/controller_add_snapshotter.yaml
+++ b/deploy/kubernetes/overlays/alpha/controller_add_snapshotter.yaml
@@ -8,7 +8,7 @@ spec:
       containers:
         - name: csi-snapshotter
           imagePullPolicy: Always
-          image: gke.gcr.io/csi-snapshotter:v1.2.0-gke.0
+          image: gke.gcr.io/csi-snapshotter:v1.2.2-gke.0
           args:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"


### PR DESCRIPTION
… https://groups.google.com/g/kubernetes-security-announce/c/aXiYN0q4uIw
/kind bug

Fixes #432 

/assign @msau42 
/cc @verult 

```release-note
Bump external-snapshotter to v1.2.2 and external-resizer to v0.3.0 to pick up fixes for CVE CVE-2019-11255
```
