### PR TITLE
Enable hostNetwork for workload identity

### DIFF
--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -13,6 +13,11 @@ spec:
       labels:
         app: gcp-compute-persistent-disk-csi-driver
     spec:
+      # Host network must be used for interaction with Workload Identity in GKE
+      # since it replaces GCE Metadata Server with GKE Metadata Server. Remove
+      # this requirement when issue is resolved and before any exposure of
+      # metrics ports
+      hostNetwork: true 
       serviceAccountName: csi-gce-pd-controller-sa
       priorityClassName: csi-gce-pd-controller
       containers:

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -12,6 +12,11 @@ spec:
       labels:
         app: gcp-compute-persistent-disk-csi-driver
     spec:
+      # Host network must be used for interaction with Workload Identity in GKE
+      # since it replaces GCE Metadata Server with GKE Metadata Server. Remove
+      # this requirement when issue is resolved and before any exposure of
+      # metrics ports.
+      hostNetwork: true
       priorityClassName: csi-gce-pd-node
       serviceAccountName: csi-gce-pd-node-sa
       containers:


### PR DESCRIPTION
/kind bug
/assign @msau42 
/cc @saad-ali @hilliao

Fixes #421 

```release-note
Changed deployment of Controller and Node components to use hostNetwork for compatibility with GKE Workload Identity
```
