### PR TITLE
[Cherry-pick] Deploy driver with hostNetwork to fix interaction with GKE Workload Identity

### DIFF
--- a/deploy/kubernetes/base/controller.yaml
+++ b/deploy/kubernetes/base/controller.yaml
@@ -13,6 +13,11 @@ spec:
       labels:
         app: gcp-compute-persistent-disk-csi-driver
     spec:
+      # Host network must be used for interaction with Workload Identity in GKE
+      # since it replaces GCE Metadata Server with GKE Metadata Server. Remove
+      # this requirement when issue is resolved and before any exposure of
+      # metrics ports
+      hostNetwork: true
       serviceAccountName: csi-controller-sa
       priorityClassName: gce-pd-csi-driver-controller
       containers:

--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -12,6 +12,11 @@ spec:
       labels:
         app: gcp-compute-persistent-disk-csi-driver
     spec:
+      # Host network must be used for interaction with Workload Identity in GKE
+      # since it replaces GCE Metadata Server with GKE Metadata Server. Remove
+      # this requirement when issue is resolved and before any exposure of
+      # metrics ports
+      hostNetwork: true
       priorityClassName: gce-pd-csi-driver-node
       serviceAccountName: csi-node-sa
       containers:


### PR DESCRIPTION
/kind bug
/assign @msau42 
/cc @saad-ali

#421 

```release-note
Changed deployment of Controller and Node components to use hostNetwork for compatibility with GKE Workload Identity
```
