### PR TITLE
Add XFS utils and configuration to test on GKE with ubuntu image type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ FROM gcr.io/google-containers/debian-base-amd64:v2.0.0
 COPY --from=builder /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/bin/gce-pd-csi-driver /gce-pd-csi-driver
 
 # Install necessary dependencies
-RUN clean-install util-linux e2fsprogs mount ca-certificates udev
+RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs
 
 ENTRYPOINT ["/gce-pd-csi-driver"]

--- a/test/k8s-integration/config/test-config-template.in
+++ b/test/k8s-integration/config/test-config-template.in
@@ -7,9 +7,9 @@ DriverInfo:
     ext2:
     ext3:
     ext4:
+    xfs:
     # The following FS types supported by GCE PD but
-    # currently we do not test the CSI Driver on Ubuntu or Windows
-    # xfs: XFS only available on Ubuntu
+    # currently we do not test the CSI Driver on Windows
     # ntfs: NTFS only available on Windows
   Capabilities:
   {{range .Capabilities}}  {{ . }}: true


### PR DESCRIPTION
Could not figure out how to bring up a GCE Ubuntu environment so I've put that on the backburner for now. We can get the signal we need from GKE tests.

Fixes: #306 
Fixes: #305 

/assign @msau42 
/kind feature

```release-note
Add support for formatting and mounting an XFS filesystem
```
