### PR TITLE
Add psp to allow deploying csi-gce-pd-node

### DIFF
--- a/deploy/kubernetes/base/setup-cluster.yaml
+++ b/deploy/kubernetes/base/setup-cluster.yaml
@@ -138,3 +138,56 @@ roleRef:
   kind: ClusterRole
   name: csi-gce-pd-resizer-role
   apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: csi-gce-pd-node-psp
+spec:
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  volumes:
+  - '*'
+  hostNetwork: true
+  allowedHostPaths:
+  - pathPrefix: "/var/lib/kubelet/plugins_registry/"
+  - pathPrefix: "/var/lib/kubelet"
+  - pathPrefix: "/var/lib/kubelet/plugins/pd.csi.storage.gke.io/"
+  - pathPrefix: "/dev"
+  - pathPrefix: "/etc/udev"
+  - pathPrefix: "/lib/udev"
+  - pathPrefix: "/run/udev"
+  - pathPrefix: "/sys"
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-gce-pd-node-deploy
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+    - csi-gce-pd-node-psp
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-gce-pd-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-gce-pd-node-deploy
+subjects:
+- kind: ServiceAccount
+  name: csi-gce-pd-node-sa


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

In case of a cluster with `PodSecurityPolicies` enabled using kustomization base will not be enough to deploy `csi-gce-pd-node` and we have to also create the psp resource with local manifests. This PR is adding the missing psp that we used to deploy `csi-gce-pd-node`.
Since `podsecuritypolicy` is a kube resource available to all clusters regardless if the feature is enabled or not this will not impact users that do not use policies.

**Does this PR introduce a user-facing change?**:
Users that patch psps locally will have to drop their patches and use the base, others shall not be affected.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
remove existing local podsecuritypolicies manifests for `csi-gce-pd-node
```
