### PR TITLE
Update volume limits for new machine types: https://cloud.google.com/compute/docs/machine-types

### DIFF
--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -505,16 +505,16 @@ func (ns *GCENodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpa
 }
 
 func (ns *GCENodeServer) GetVolumeLimits() (int64, error) {
-	var volumeLimits int64
-
 	// Machine-type format: n1-type-CPUS or custom-CPUS-RAM or f1/g1-type
 	machineType := ns.MetadataService.GetMachineType()
-	if strings.HasPrefix(machineType, "n1-") || strings.HasPrefix(machineType, "custom-") {
-		volumeLimits = volumeLimitBig
-	} else {
-		volumeLimits = volumeLimitSmall
+
+	smallMachineTypes := []string{"f1-micro", "g1-small", "e2-micro", "e2-small", "e2-medium"}
+	for _, st := range smallMachineTypes {
+		if machineType == st {
+			return volumeLimitSmall, nil
+		}
 	}
-	return volumeLimits, nil
+	return volumeLimitBig, nil
 }
 
 func (ns *GCENodeServer) getDevicePath(volumeID string, partition string) (string, error) {

--- a/pkg/gce-pd-csi-driver/node_test.go
+++ b/pkg/gce-pd-csi-driver/node_test.go
@@ -165,6 +165,11 @@ func TestNodeGetVolumeLimits(t *testing.T) {
 			machineType:    "custom-2-4096",
 			expVolumeLimit: volumeLimitBig,
 		},
+		{
+			name:           "Predifined e2 machine",
+			machineType:    "e2-micro",
+			expVolumeLimit: volumeLimitSmall,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
/kind bug
/kind cleanup

Fixes #445 

/assign @msau42 

```release-note
Set volume limits to 15 only for machine-types: "f1-micro", "g1-small", "e2-micro", "e2-small", "e2-medium". Limit is 127 for all others
```
