### PR TITLE
Implement ValidateVolumeCapabilities and refactor parameter handling for more comprehensive validation of existing disks in all cloud calls

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -17,11 +17,6 @@ limitations under the License.
 package common
 
 const (
-	// Keys for Storage Class Parameters
-	ParameterKeyType                 = "type"
-	ParameterKeyReplicationType      = "replication-type"
-	ParameterKeyDiskEncryptionKmsKey = "disk-encryption-kms-key"
-
 	// Keys for Topology. This key will be shared amongst drivers from GCP
 	TopologyKeyZone = "topology.gke.io/zone"
 

--- a/pkg/common/parameters.go
+++ b/pkg/common/parameters.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	ParameterKeyType                 = "type"
+	ParameterKeyReplicationType      = "replication-type"
+	ParameterKeyDiskEncryptionKmsKey = "disk-encryption-kms-key"
+
+	replicationTypeNone = "none"
+)
+
+// DiskParameters contains normalized and defaulted disk parameters
+type DiskParameters struct {
+	// Values: pd-standard OR pd-ssd
+	// Default: pd-standard
+	DiskType string
+	// Values: "none", regional-pd
+	// Default: "none"
+	ReplicationType string
+	// Values: {string}
+	// Default: ""
+	DiskEncryptionKMSKey string
+}
+
+// ExtractAndDefaultParameters will take the relevant parameters from a map and
+// put them into a well defined struct making sure to default unspecified fields
+func ExtractAndDefaultParameters(parameters map[string]string) (DiskParameters, error) {
+	p := DiskParameters{
+		DiskType:             "pd-standard",       // Default
+		ReplicationType:      replicationTypeNone, // Default
+		DiskEncryptionKMSKey: "",                  // Default
+	}
+	for k, v := range parameters {
+		if k == "csiProvisionerSecretName" || k == "csiProvisionerSecretNamespace" {
+			// These are hardcoded secrets keys required to function but not needed by GCE PD
+			continue
+		}
+		switch strings.ToLower(k) {
+		case ParameterKeyType:
+			if v != "" {
+				p.DiskType = strings.ToLower(v)
+			}
+		case ParameterKeyReplicationType:
+			if v != "" {
+				p.ReplicationType = strings.ToLower(v)
+			}
+		case ParameterKeyDiskEncryptionKmsKey:
+			// Resource names (e.g. "keyRings", "cryptoKeys", etc.) are case sensitive, so do not change case
+			p.DiskEncryptionKMSKey = v
+		default:
+			return p, fmt.Errorf("parameters contains invalid option %q", k)
+		}
+	}
+	return p, nil
+}

--- a/pkg/common/parameters_test.go
+++ b/pkg/common/parameters_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractAndDefaultParameters(t *testing.T) {
+	tests := []struct {
+		name         string
+		parameters   map[string]string
+		expectParams DiskParameters
+		expectErr    bool
+	}{
+		{
+			name:       "defaults",
+			parameters: map[string]string{},
+			expectParams: DiskParameters{
+				DiskType:             "pd-standard",
+				ReplicationType:      "none",
+				DiskEncryptionKMSKey: "",
+			},
+		},
+		{
+			name:       "specified empties",
+			parameters: map[string]string{ParameterKeyType: "", ParameterKeyReplicationType: "", ParameterKeyDiskEncryptionKmsKey: ""},
+			expectParams: DiskParameters{
+				DiskType:             "pd-standard",
+				ReplicationType:      "none",
+				DiskEncryptionKMSKey: "",
+			},
+		},
+		{
+			name:       "random keys",
+			parameters: map[string]string{ParameterKeyType: "", "foo": "", ParameterKeyDiskEncryptionKmsKey: ""},
+			expectErr:  true,
+		},
+		{
+			name:       "real values",
+			parameters: map[string]string{ParameterKeyType: "pd-ssd", ParameterKeyReplicationType: "regional-pd", ParameterKeyDiskEncryptionKmsKey: "foo/key"},
+			expectParams: DiskParameters{
+				DiskType:             "pd-ssd",
+				ReplicationType:      "regional-pd",
+				DiskEncryptionKMSKey: "foo/key",
+			},
+		},
+		{
+			name:       "partial spec",
+			parameters: map[string]string{ParameterKeyDiskEncryptionKmsKey: "foo/key"},
+			expectParams: DiskParameters{
+				DiskType:             "pd-standard",
+				ReplicationType:      "none",
+				DiskEncryptionKMSKey: "foo/key",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := ExtractAndDefaultParameters(tc.parameters)
+			if gotErr := err != nil; gotErr != tc.expectErr {
+				t.Fatalf("ExtractAndDefaultParameters(%+v) = %v; expectedErr: %v", tc.parameters, err, tc.expectErr)
+			}
+			if err != nil {
+				return
+			}
+
+			if !reflect.DeepEqual(p, tc.expectParams) {
+				t.Errorf("ExtractAndDefaultParameters(%+v) = %v; expected params: %v", tc.parameters, p, tc.expectParams)
+			}
+		})
+	}
+}


### PR DESCRIPTION
TODO: 
- [x] Add some unit tests for new functions :)

/kind cleanup
/kind feature
/assign @msau42 @misterikkit 

Partially does #384 (Still need to do `Node` side validation in a seperate PR)
Fixes #162 

```release-note
ValidateVolumeCapabilities validates that the given volume conforms to all capabilities in the request. Validation of existing volumes during inserts also improved to check all parameters.
```
