### PR TITLE
Bump debian-base-amd64 version for fix of CVE-2017-14062

### DIFF
--- a/CHANGELOG-0.6.md
+++ b/CHANGELOG-0.6.md
@@ -1,5 +1,9 @@
 # Changes since v0.6.0
 
+## Security Fixes
+
+- Bumped `gcr.io/google-containers/debian-base-amd64` to `v2.0.0` for security fix of CVE-2017-14062
+
 ## Bug Fixes
 
 - Changed deployment of Controller and Node components to use hostNetwork for compatibility with GKE Workload Identity ([#437](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/437), [@davidz627](https://github.com/davidz627))

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ARG TAG
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-X main.vendorVersion='"${TAG:-latest}"' -extldflags "-static"' -o bin/gce-pd-csi-driver ./cmd/
 
 # Start from Google Debian base
-FROM gcr.io/google-containers/debian-base-amd64:v1.0.0
+FROM gcr.io/google-containers/debian-base-amd64:v2.0.0
 COPY --from=builder /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/bin/gce-pd-csi-driver /gce-pd-csi-driver
 
 # Install necessary dependencies

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc/kustomization.yaml
@@ -5,7 +5,7 @@ bases:
 images:
 - name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   newName: gcr.io/gke-release-staging/gcp-compute-persistent-disk-csi-driver
-  newTag: "v0.6.0-rc2"
+  newTag: "v0.6.2-rc2"
 - name: gke.gcr.io/csi-provisioner
   newName: gcr.io/gke-release-staging/csi-provisioner
   newTag: "v1.4.0-gke.0"

--- a/deploy/kubernetes/overlays/stable/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable/kustomization.yaml
@@ -7,7 +7,7 @@ images:
   # Don't change stable image without changing pdImagePlaceholder in
   # test/k8s-integration/main.go
   newName: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
-  newTag: "v0.6.1-gke.0"
+  newTag: "v0.6.2-gke.0"
 - name: gke.gcr.io/csi-provisioner
   newName: gke.gcr.io/csi-provisioner
   newTag: "v1.4.0-gke.0"


### PR DESCRIPTION
/kind bug
/assign @msau42 

After release we should:
- [ ] Update version used in Kubernetes tests
- [ ] Update version on master of PD Driver

```release-note
NONE
```
