### PR TITLE
Qualify external-attacher 2.1.1 in RC staging; enable Prometheus metrics in attacher, provisioner, and resizer

### DIFF
--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc/enable_sidecar_metrics.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc/enable_sidecar_metrics.yaml
@@ -1,0 +1,14 @@
+# for external-provisioner
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--metrics-address=:22011"
+
+# for external-attacher
+- op: add
+  path: /spec/template/spec/containers/1/args/-
+  value: "--metrics-address=:22012"
+
+# for external-resizer
+- op: add
+  path: /spec/template/spec/containers/2/args/-
+  value: "--metrics-address=:22013"

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc/kustomization.yaml
@@ -11,10 +11,18 @@ images:
   newTag: "v1.5.0-gke.0"
 - name: gke.gcr.io/csi-attacher
   newName: gcr.io/gke-release-staging/csi-attacher
-  newTag: "v2.1.0-gke.0"
+  newTag: "v2.1.1-gke.0"
 - name: gke.gcr.io/csi-node-driver-registrar
   newName: gcr.io/gke-release-staging/csi-node-driver-registrar
   newTag: "v1.2.0-gke.0"
 - name: gke.gcr.io/csi-resizer
   newName: gke.gcr.io/gke-release-staging/csi-resizer
   newTag: "v0.4.0-gke.0"
+
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: csi-gce-pd-controller
+  path: enable_sidecar_metrics.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**: Qualify external-attacher 2.1.1 in RC staging; enable Prometheus metrics in attacher, provisioner, and resizer

```release-note
NONE
```

/assign @msau42 