### PR TITLE
Adding linux node selector; adding new volumeattachment RBAC rule

### DIFF
--- a/deploy/kubernetes/base/node.yaml
+++ b/deploy/kubernetes/base/node.yaml
@@ -67,6 +67,8 @@ spec:
               mountPath: /run/udev
             - name: sys
               mountPath: /sys
+      nodeSelector:
+        kubernetes.io/os: linux
       volumes:
         - name: registration-dir
           hostPath:

--- a/deploy/kubernetes/base/setup-cluster.yaml
+++ b/deploy/kubernetes/base/setup-cluster.yaml
@@ -70,7 +70,9 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch", "update", "patch"]
-
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
 ---
 
 kind: ClusterRoleBinding


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**: 
The DaemonSet will fail if its replicas are scheduled on Windows nodes.

The new RBAC rule is added in anticipation of this change: https://github.com/kubernetes-csi/external-attacher/pull/200/files#diff-59021f01acbcbd85d054c17acc3e26c8R37

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/assign @msau42 