### PR TITLE
Stop regional PD test from failing silently and fix verification path to use correct name

### DIFF
--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -528,7 +528,7 @@ func (ns *GCENodeServer) getDevicePath(volumeID string, partition string) (strin
 	}
 
 	devicePaths := ns.DeviceUtils.GetDiskByIdPaths(deviceName, partition)
-	devicePath, err := ns.DeviceUtils.VerifyDevicePath(devicePaths, volumeKey.Name)
+	devicePath, err := ns.DeviceUtils.VerifyDevicePath(devicePaths, deviceName)
 
 	if err != nil {
 		return "", fmt.Errorf("error verifying GCE PD (%q) is attached: %v", volumeKey.Name, err)

--- a/test/e2e/tests/multi_zone_e2e_test.go
+++ b/test/e2e/tests/multi_zone_e2e_test.go
@@ -136,7 +136,8 @@ var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 			if i >= 1 {
 				readOnly = true
 			}
-			testAttachWriteReadDetach(volID, volName, testContext.Instance, testContext.Client, readOnly)
+			err = testAttachWriteReadDetach(volID, volName, testContext.Instance, testContext.Client, readOnly)
+			Expect(err).To(BeNil(), "failed volume lifecycle checks")
 			i = i + 1
 		}
 	})


### PR DESCRIPTION
/kind bug
/kind failing-test

Fixes #476 
/assign @msau42 

Good news is this was not broken in any actual releases. The bug was introduced when fixing the `udevadm` stuff a couple of weeks ago and was not caught because of the silent failure of the test.

```release-note
NONE
```
