### PR TITLE
Staging RC overlay: Bump all sidecar versions to latest

### DIFF
--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc/kustomization.yaml
@@ -8,16 +8,16 @@ images:
   newTag: "v0.7.0-gke.0"
 - name: gke.gcr.io/csi-provisioner
   newName: gcr.io/gke-release-staging/csi-provisioner
-  newTag: "v1.5.0-gke.0"
+  newTag: "v1.6.0-gke.0"
 - name: gke.gcr.io/csi-attacher
   newName: gcr.io/gke-release-staging/csi-attacher
-  newTag: "v2.1.1-gke.0"
+  newTag: "v2.2.0-gke.0"
 - name: gke.gcr.io/csi-node-driver-registrar
   newName: gcr.io/gke-release-staging/csi-node-driver-registrar
-  newTag: "v1.2.0-gke.0"
+  newTag: "v1.3.0-gke.0"
 - name: gke.gcr.io/csi-resizer
   newName: gcr.io/gke-release-staging/csi-resizer
-  newTag: "v0.4.0-gke.0"
+  newTag: "v0.5.0-gke.0"
 
 patchesJson6902:
 - target:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**: Make sure latest sidecar releases remain compatible with the PD CSI driver.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/assign @msau42 @saad-ali 