### PR TITLE
Add build rule for Windows container

### DIFF
--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -1,0 +1,9 @@
+ARG BASE_IMAGE
+ARG BASE_IMAGE_TAG
+
+FROM mcr.microsoft.com/windows/${BASE_IMAGE}:${BASE_IMAGE_TAG}
+LABEL description="PD CSI driver"
+COPY bin/gce-pd-csi-driver.exe /gce-pd-csi-driver.exe
+
+USER ContainerAdministrator
+ENTRYPOINT ["/gce-pd-csi-driver.exe"]

--- a/init-buildx.sh
+++ b/init-buildx.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#!/usr/bin/env bash
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit -o nounset -o pipefail
+
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+# Ensure we use a builder that can leverage it (the default on linux will not)
+docker buildx rm windows-builder || true
+docker buildx create --use --name=windows-builder


### PR DESCRIPTION
Add build rule for windows container. Here we try to enable buildx for
buiding windows container image on a linux VM

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adds new build rules using docker buildx feature for allowing to build windows container image on either windows or linux node.
```
