### PR TITLE
Backport test skip from master

### DIFF
--- a/test/k8s-integration/cluster.go
+++ b/test/k8s-integration/cluster.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"k8s.io/klog"
 )
@@ -229,4 +231,28 @@ func getGKEKubeTestArgs(gceZone, gceRegion string) ([]string, error) {
 	}
 
 	return args, nil
+}
+
+func getNormalizedVersion(kubeVersion, gkeVersion string) (string, error) {
+	if kubeVersion != "" && gkeVersion != "" {
+		return "", fmt.Errorf("both kube version (%s) and gke version (%s) specified", kubeVersion, gkeVersion)
+	}
+	if kubeVersion == "" && gkeVersion == "" {
+		return "", errors.New("neither kube version nor gke version specified")
+	}
+	var v string
+	if kubeVersion != "" {
+		v = kubeVersion
+	} else if gkeVersion != "" {
+		v = gkeVersion
+	}
+	if v == "master" || v == "latest" {
+		// Ugh
+		return v, nil
+	}
+	toks := strings.Split(v, ".")
+	if len(toks) < 2 || len(toks) > 3 {
+		return "", fmt.Errorf("got unexpected number of tokens in version string %s - wanted 2 or 3", v)
+	}
+	return strings.Join(toks[:2], "."), nil
 }

--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -292,11 +292,17 @@ func handle() error {
 		}
 	}
 
+	normalizedVersion, err := getNormalizedVersion(*kubeVersion, *gkeClusterVer)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster minor version: %v", err)
+	}
+
+	testSkip := generateTestSkip(normalizedVersion)
 	// Run the tests using the testDir kubernetes
 	if len(*storageClassFile) != 0 {
-		err = runCSITests(pkgDir, testDir, *testFocus, *storageClassFile, cloudProviderArgs)
+		err = runCSITests(pkgDir, testDir, *testFocus, testSkip, *storageClassFile, cloudProviderArgs)
 	} else if *migrationTest {
-		err = runMigrationTests(pkgDir, testDir, *testFocus, cloudProviderArgs)
+		err = runMigrationTests(pkgDir, testDir, *testFocus, testSkip, cloudProviderArgs)
 	} else {
 		return fmt.Errorf("did not run either CSI or Migration test")
 	}
@@ -306,6 +312,30 @@ func handle() error {
 	}
 
 	return nil
+}
+
+func generateTestSkip(normalizedVersion string) string {
+	skipString := "\\[Disruptive\\]|\\[Serial\\]|\\[Feature:.+\\]"
+	switch normalizedVersion {
+	// Fall-through versioning since all test cases we want to skip in 1.15
+	// should also be skipped in 1.14
+	case "1.13":
+		fallthrough
+	case "1.14":
+		fallthrough
+	case "1.15":
+		// "volumeMode should not mount / map unused volumes in a pod" tests a
+		// bug-fix introduced in 1.16
+		// (https://github.com/kubernetes/kubernetes/pull/81163)
+		skipString = skipString + "|volumeMode\\sshould\\snot\\smount\\s/\\smap\\sunused\\svolumes\\sin\\sa\\spod"
+		fallthrough
+	case "1.16":
+	case "1.17":
+	case "latest":
+	case "master":
+	default:
+	}
+	return skipString
 }
 
 func setEnvProject(project string) error {
@@ -321,20 +351,20 @@ func setEnvProject(project string) error {
 	return nil
 }
 
-func runMigrationTests(pkgDir, testDir, testFocus string, cloudProviderArgs []string) error {
-	return runTestsWithConfig(testDir, testFocus, "--storage.migratedPlugins=kubernetes.io/gce-pd", cloudProviderArgs)
+func runMigrationTests(pkgDir, testDir, testFocus, testSkip string, cloudProviderArgs []string) error {
+	return runTestsWithConfig(testDir, testFocus, testSkip, "--storage.migratedPlugins=kubernetes.io/gce-pd", cloudProviderArgs)
 }
 
-func runCSITests(pkgDir, testDir, testFocus, storageClassFile string, cloudProviderArgs []string) error {
+func runCSITests(pkgDir, testDir, testFocus, testSkip, storageClassFile string, cloudProviderArgs []string) error {
 	testDriverConfigFile, err := generateDriverConfigFile(pkgDir, storageClassFile)
 	if err != nil {
 		return err
 	}
 	testConfigArg := fmt.Sprintf("--storage.testdriver=%s", testDriverConfigFile)
-	return runTestsWithConfig(testDir, testFocus, testConfigArg, cloudProviderArgs)
+	return runTestsWithConfig(testDir, testFocus, testSkip, testConfigArg, cloudProviderArgs)
 }
 
-func runTestsWithConfig(testDir, testFocus, testConfigArg string, cloudProviderArgs []string) error {
+func runTestsWithConfig(testDir, testFocus, testSkip, testConfigArg string, cloudProviderArgs []string) error {
 	err := os.Chdir(testDir)
 	if err != nil {
 		return err
@@ -348,7 +378,7 @@ func runTestsWithConfig(testDir, testFocus, testConfigArg string, cloudProviderA
 
 	testArgs := fmt.Sprintf("--ginkgo.focus=%s --ginkgo.skip=%s %s %s",
 		testFocus,
-		"\\[Disruptive\\]|\\[Serial\\]|\\[Feature:.+\\]",
+		testSkip,
 		testConfigArg,
 		reportArg)
 


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
Backport test skip to 0.6 release for pre-1.16 clusters.

```release-note
NONE
```
