### PR TITLE
Add logging to debug why test skip isn't effective

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -296,8 +296,10 @@ func handle() error {
 	if err != nil {
 		return fmt.Errorf("failed to get cluster minor version: %v", err)
 	}
+	klog.Infof("using cluster version %s", normalizedVersion)
 
 	testSkip := generateTestSkip(normalizedVersion)
+	klog.Infof("using test skip %s", testSkip)
 	// Run the tests using the testDir kubernetes
 	if len(*storageClassFile) != 0 {
 		err = runCSITests(pkgDir, testDir, *testFocus, testSkip, *storageClassFile, cloudProviderArgs)


### PR DESCRIPTION
/kind bug

Adds logging code to the k8s-integration driver to debug why test skips aren't happening as expected.

```release-note
None
```
