### PR TITLE
Provide optional flags to run PD CSI driver snapshot tests

### DIFF
--- a/test/k8s-integration/config/pd-volumesnapshotclass.yaml
+++ b/test/k8s-integration/config/pd-volumesnapshotclass.yaml
@@ -1,0 +1,6 @@
+apiVersion: snapshot.storage.k8s.io/v1beta1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-gce-pd-snapshot-class
+driver: pd.csi.storage.gke.io
+deletionPolicy: Delete

--- a/test/k8s-integration/config/test-config-template.in
+++ b/test/k8s-integration/config/test-config-template.in
@@ -1,5 +1,9 @@
 StorageClass:
   FromFile: {{.StorageClassFile}}
+{{if .SnapshotClassFile }}
+SnapshotClass:
+  FromFile: {{ .SnapshotClassFile }}
+{{end}}
 DriverInfo:
   Name: csi-gcepd
   SupportedFsType:

--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -47,6 +47,7 @@ var (
 	// Test infrastructure flags
 	boskosResourceType = flag.String("boskos-resource-type", "gce-project", "name of the boskos resource type to reserve")
 	storageClassFile   = flag.String("storageclass-file", "", "name of storageclass yaml file to use for test relative to test/k8s-integration/config")
+	snapshotClassFile  = flag.String("snapshotclass-file", "", "name of snapshotclass yaml file to use for test relative to test/k8s-integration/config")
 	inProw             = flag.Bool("run-in-prow", false, "is the test running in PROW")
 
 	// Driver flags
@@ -300,10 +301,9 @@ func handle() error {
 	}
 
 	testSkip := generateTestSkip(normalizedVersion)
-
 	// Run the tests using the testDir kubernetes
 	if len(*storageClassFile) != 0 {
-		err = runCSITests(pkgDir, testDir, *testFocus, testSkip, *storageClassFile, cloudProviderArgs, *deploymentStrat)
+		err = runCSITests(pkgDir, testDir, *testFocus, testSkip, *storageClassFile, *snapshotClassFile, cloudProviderArgs, *deploymentStrat)
 	} else if *migrationTest {
 		err = runMigrationTests(pkgDir, testDir, *testFocus, testSkip, cloudProviderArgs)
 	} else {
@@ -318,7 +318,7 @@ func handle() error {
 }
 
 func generateTestSkip(normalizedVersion string) string {
-	skipString := "\\[Disruptive\\]|\\[Serial\\]|\\[Feature:.+\\]"
+	skipString := "\\[Disruptive\\]|\\[Serial\\]"
 	switch normalizedVersion {
 	// Fall-through versioning since all test cases we want to skip in 1.15
 	// should also be skipped in 1.14
@@ -333,6 +333,8 @@ func generateTestSkip(normalizedVersion string) string {
 		// bug-fix introduced in 1.17
 		// (https://github.com/kubernetes/kubernetes/pull/81163)
 		skipString = skipString + "|volumeMode\\sshould\\snot\\smount\\s/\\smap\\sunused\\svolumes\\sin\\sa\\spod"
+		// Skip Snapshot tests pre 1.17
+		skipString = skipString + "|snapshot"
 		fallthrough
 	case "1.17":
 	case "latest":
@@ -359,8 +361,8 @@ func runMigrationTests(pkgDir, testDir, testFocus, testSkip string, cloudProvide
 	return runTestsWithConfig(testDir, testFocus, testSkip, "--storage.migratedPlugins=kubernetes.io/gce-pd", cloudProviderArgs)
 }
 
-func runCSITests(pkgDir, testDir, testFocus, testSkip, storageClassFile string, cloudProviderArgs []string, deploymentStrat string) error {
-	testDriverConfigFile, err := generateDriverConfigFile(pkgDir, storageClassFile, deploymentStrat)
+func runCSITests(pkgDir, testDir, testFocus, testSkip, storageClassFile, snapshotClassFile string, cloudProviderArgs []string, deploymentStrat string) error {
+	testDriverConfigFile, err := generateDriverConfigFile(pkgDir, storageClassFile, snapshotClassFile, deploymentStrat)
 	if err != nil {
 		return err
 	}

--- a/test/run-k8s-integration-local.sh
+++ b/test/run-k8s-integration-local.sh
@@ -46,6 +46,16 @@ make -C ${PKGDIR} test-k8s-integration
 # --gce-region="us-central1" --num-nodes=${NUM_NODES:-3} --gke-cluster-version="latest" --deployment-strategy="gke" \
 # --test-version="master"
 
+# This version of the command builds and deploys the GCE PD CSI driver.
+# Points to a local K8s repository to get the e2e test binary, does not bring up
+# or tear down the kubernetes cluster. In addition, it runs External Storage
+# snapshot tests for the PD CSI driver.
+#${PKGDIR}/bin/k8s-integration-test --run-in-prow=false \
+#--staging-image=${GCE_PD_CSI_STAGING_IMAGE} --service-account-file=${GCE_PD_SA_DIR}/cloud-sa.json \
+#--deploy-overlay-name=prow-gke-release-staging-head --bringup-cluster=false --teardown-cluster=false --test-focus="External.*Storage.*snapshot" --local-k8s-dir=$KTOP \
+#--storageclass-file=sc-standard.yaml --snapshotclass-file=pd-volumesnapshotclass.yaml --do-driver-build=true \
+#--gce-zone="us-central1-b" --num-nodes=${NUM_NODES:-3}
+
 # This version of the command does not build the driver or K8s, points to a
 # local K8s repo to get the e2e.test binary, and does not bring up or down the cluster
 

--- a/test/run-k8s-integration.sh
+++ b/test/run-k8s-integration.sh
@@ -44,4 +44,8 @@ else
   base_cmd="${base_cmd} --gce-region=${gce_region}"
 fi
 
+if [[ "$overlay_name" =~ .*"gke-release-staging".* ]]; then
+  base_cmd="${base_cmd} --snapshotclass-file=pd-volumesnapshotclass.yaml"
+fi
+
 eval $base_cmd


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
Summary of changes:
1. Added a snapshot-class option to pass VolumeSnapshotClass.
2. Added a default VolumeSnapshotClass definition, which uses PD CSI as a snapshot driver.
3. Remove “Feature:” tag from skipString, since snapshot tests have a [Feature:VolumeSnapshotDataSource] tag.
4. Prevent snapshot tests from running pre 1.17 kubernetes version.
5. Allow snapshot tests run only in release-staging-head and release-staging-rc overlays, since the snapshotter is not yet enabled in stable.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #457 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Enable PD CSI snapshot tests for release-staging-head and release-staging-rc
```
