### PR TITLE
Skip snapshot test for GKE latest.

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -333,11 +333,14 @@ func generateTestSkip(normalizedVersion string) string {
 		// bug-fix introduced in 1.17
 		// (https://github.com/kubernetes/kubernetes/pull/81163)
 		skipString = skipString + "|volumeMode\\sshould\\snot\\smount\\s/\\smap\\sunused\\svolumes\\sin\\sa\\spod"
-		// Skip Snapshot tests pre 1.17
+		fallthrough
+	case "latest":
+		// "latest" is passed only for GKE deployment strategy. Skip snapshot tests pre 1.17.
+		// TODO: When "latest" GKE upgrades to 1.17 and higher, remove the skipString for snapshot tests
+		// from "latest" can capture it only in 1.16.
 		skipString = skipString + "|snapshot"
 		fallthrough
 	case "1.17":
-	case "latest":
 	case "master":
 	default:
 	}


### PR DESCRIPTION
GKE latest currently points to pre 1.17, which means we need to skip
External storage snapshot tests for "latest" GKE (until latest points to
1.17 or higher)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
Guard against running snapshot test for "latest" GKE.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #457 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Guard against running snapshot tests for "latest" GKE.
```
