### PR TITLE
Add option to deploy GKE managed PD CSI driver for integration tests

### DIFF
--- a/test/k8s-integration/utils.go
+++ b/test/k8s-integration/utils.go
@@ -79,3 +79,9 @@ func shredFile(filePath string) {
 		klog.V(4).Infof("Failed to remove service account file %s: %v", filePath, err)
 	}
 }
+
+func ensureVariableVal(v *string, val string, msgOnError string) {
+	if *v != val {
+		klog.Fatal(msgOnError)
+	}
+}

--- a/test/run-k8s-integration-local.sh
+++ b/test/run-k8s-integration-local.sh
@@ -10,7 +10,6 @@ readonly test_version=${TEST_VERSION:-master}
 
 source "${PKGDIR}/deploy/common.sh"
 
-ensure_var GCE_PD_CSI_STAGING_IMAGE
 ensure_var GCE_PD_SA_DIR
 
 make -C ${PKGDIR} test-k8s-integration
@@ -55,6 +54,15 @@ make -C ${PKGDIR} test-k8s-integration
 #--deploy-overlay-name=prow-gke-release-staging-head --bringup-cluster=false --teardown-cluster=false --test-focus="External.*Storage.*snapshot" --local-k8s-dir=$KTOP \
 #--storageclass-file=sc-standard.yaml --snapshotclass-file=pd-volumesnapshotclass.yaml --do-driver-build=true \
 #--gce-zone="us-central1-b" --num-nodes=${NUM_NODES:-3}
+
+# This version of the command brings up (and subsequently tears down) a GKE
+# cluster with managed GCE PersistentDisk CSI driver add-on enabled, and points to
+# the local K8s repository to get the e2e test binary.
+# ${PKGDIR}/bin/k8s-integration-test --run-in-prow=false --service-account-file=${GCE_PD_SA_DIR}/cloud-sa.json \
+# --test-focus="External.*Storage.*snapshot" --local-k8s-dir=$KTOP --storageclass-file=sc-standard.yaml \
+# --snapshotclass-file=pd-volumesnapshotclass.yaml --do-driver-build=false --teardown-driver=false \
+# --gce-zone="us-central1-c" --num-nodes=${NUM_NODES:-3} --gke-cluster-version="latest" --deployment-strategy="gke" \
+# --use-gke-managed-driver=true
 
 # This version of the command does not build the driver or K8s, points to a
 # local K8s repo to get the e2e.test binary, and does not bring up or down the cluster

--- a/test/run-k8s-integration.sh
+++ b/test/run-k8s-integration.sh
@@ -20,6 +20,8 @@ readonly test_version=${TEST_VERSION:-master}
 readonly gce_zone=${GCE_CLUSTER_ZONE:-us-central1-b}
 readonly gce_region=${GCE_CLUSTER_REGION:-}
 readonly image_type=${IMAGE_TYPE:-cos}
+readonly use_gke_managed_driver=${GCE_PD_USE_MANAGED_DRIVER:-false}
+readonly teardown_driver=${GCE_PD_TEARDOWN_DRIVER:-true}
 
 export GCE_PD_VERBOSITY=9
 
@@ -27,10 +29,10 @@ make -C ${PKGDIR} test-k8s-integration
 
 base_cmd="${PKGDIR}/bin/k8s-integration-test \
             --run-in-prow=true --deploy-overlay-name=${overlay_name} --service-account-file=${E2E_GOOGLE_APPLICATION_CREDENTIALS} \
-            --do-driver-build=${do_driver_build} --boskos-resource-type=${boskos_resource_type} \
+            --do-driver-build=${do_driver_build} --teardown-driver=${teardown_driver} --boskos-resource-type=${boskos_resource_type} \
             --storageclass-file=sc-standard.yaml --snapshotclass-file=pd-volumesnapshotclass.yaml --test-focus="External.Storage" \
             --deployment-strategy=${deployment_strategy} --test-version=${test_version} --num-nodes=3 \
-            --image-type=${image_type}"
+            --image-type=${image_type} --use-gke-managed-driver=${use_gke_managed_driver}"
 
 if [ "$deployment_strategy" = "gke" ]; then
   base_cmd="${base_cmd} --gke-cluster-version=${gke_cluster_version}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
Add hook to use GKE managed PD CSI driver for running kubernetes e2e tests

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #511 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add hook to use GKE managed PD CSI driver for running kubernetes e2e tests
```
