### PR TITLE
Add option to deploy GKE managed PD CSI driver for integration tests

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -22,27 +22,28 @@ import (
 	"path/filepath"
 	"syscall"
 
-	testutils "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/test/e2e/utils"
-
 	"k8s.io/apimachinery/pkg/util/uuid"
+	apimachineryversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/klog"
+	testutils "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/test/e2e/utils"
 )
 
 var (
 	// Kubernetes cluster flags
-	teardownCluster  = flag.Bool("teardown-cluster", true, "teardown the cluster after the e2e test")
-	teardownDriver   = flag.Bool("teardown-driver", true, "teardown the driver after the e2e test")
-	bringupCluster   = flag.Bool("bringup-cluster", true, "build kubernetes and bringup a cluster")
-	gceZone          = flag.String("gce-zone", "", "zone that the gce k8s cluster is created/found in")
-	gceRegion        = flag.String("gce-region", "", "region that gke regional cluster should be created in")
-	kubeVersion      = flag.String("kube-version", "", "version of Kubernetes to download and use for the cluster")
-	testVersion      = flag.String("test-version", "", "version of Kubernetes to download and use for tests")
-	kubeFeatureGates = flag.String("kube-feature-gates", "", "feature gates to set on new kubernetes cluster")
-	localK8sDir      = flag.String("local-k8s-dir", "", "local prebuilt kubernetes/kubernetes directory to use for cluster and test binaries")
-	deploymentStrat  = flag.String("deployment-strategy", "gce", "choose between deploying on gce or gke")
-	gkeClusterVer    = flag.String("gke-cluster-version", "", "version of Kubernetes master and node for gke")
-	numNodes         = flag.Int("num-nodes", -1, "the number of nodes in the test cluster")
-	imageType        = flag.String("image-type", "cos", "the image type to use for the cluster")
+	teardownCluster   = flag.Bool("teardown-cluster", true, "teardown the cluster after the e2e test")
+	teardownDriver    = flag.Bool("teardown-driver", true, "teardown the driver after the e2e test")
+	bringupCluster    = flag.Bool("bringup-cluster", true, "build kubernetes and bringup a cluster")
+	gceZone           = flag.String("gce-zone", "", "zone that the gce k8s cluster is created/found in")
+	gceRegion         = flag.String("gce-region", "", "region that gke regional cluster should be created in")
+	kubeVersion       = flag.String("kube-version", "", "version of Kubernetes to download and use for the cluster")
+	testVersion       = flag.String("test-version", "", "version of Kubernetes to download and use for tests")
+	kubeFeatureGates  = flag.String("kube-feature-gates", "", "feature gates to set on new kubernetes cluster")
+	localK8sDir       = flag.String("local-k8s-dir", "", "local prebuilt kubernetes/kubernetes directory to use for cluster and test binaries")
+	deploymentStrat   = flag.String("deployment-strategy", "gce", "choose between deploying on gce or gke")
+	gkeClusterVer     = flag.String("gke-cluster-version", "", "version of Kubernetes master and node for gke")
+	numNodes          = flag.Int("num-nodes", -1, "the number of nodes in the test cluster")
+	imageType         = flag.String("image-type", "cos", "the image type to use for the cluster")
+	gkeReleaseChannel = flag.String("gke-release-channel", "", "GKE release channel to be used for cluster deploy. One of 'rapid', 'stable' or 'regular'")
 
 	// Test infrastructure flags
 	boskosResourceType = flag.String("boskos-resource-type", "gce-project", "name of the boskos resource type to reserve")
@@ -51,10 +52,11 @@ var (
 	inProw             = flag.Bool("run-in-prow", false, "is the test running in PROW")
 
 	// Driver flags
-	stagingImage      = flag.String("staging-image", "", "name of image to stage to")
-	saFile            = flag.String("service-account-file", "", "path of service account file")
-	deployOverlayName = flag.String("deploy-overlay-name", "", "which kustomize overlay to deploy the driver with")
-	doDriverBuild     = flag.Bool("do-driver-build", true, "building the driver from source")
+	stagingImage        = flag.String("staging-image", "", "name of image to stage to")
+	saFile              = flag.String("service-account-file", "", "path of service account file")
+	deployOverlayName   = flag.String("deploy-overlay-name", "", "which kustomize overlay to deploy the driver with")
+	doDriverBuild       = flag.Bool("do-driver-build", true, "building the driver from source")
+	useGKEManagedDriver = flag.Bool("use-gke-managed-driver", false, "use GKE managed PD CSI driver for the tests")
 
 	// Test flags
 	migrationTest = flag.Bool("migration-test", false, "sets the flag on the e2e binary signalling migration")
@@ -75,12 +77,23 @@ func init() {
 func main() {
 	flag.Parse()
 
-	if !*inProw {
+	if !*inProw && !*useGKEManagedDriver {
 		ensureVariable(stagingImage, true, "staging-image is a required flag, please specify the name of image to stage to")
 	}
 
+	if *useGKEManagedDriver {
+		ensureVariableVal(deploymentStrat, "gke", "deployment strategy must be GKE for using managed driver")
+		ensureFlag(doDriverBuild, false, "'do-driver-build' must be false when using GKE managed driver")
+		ensureFlag(teardownDriver, false, "'teardown-driver' must be false when using GKE managed driver")
+		ensureVariable(stagingImage, false, "'staging-image' must not be set when using GKE managed driver")
+		ensureVariable(deployOverlayName, false, "'deploy-overlay-name' must not be set when using GKE managed driver")
+	}
+
 	ensureVariable(saFile, true, "service-account-file is a required flag")
-	ensureVariable(deployOverlayName, true, "deploy-overlay-name is a required flag")
+	if !*useGKEManagedDriver {
+		ensureVariable(deployOverlayName, true, "deploy-overlay-name is a required flag")
+	}
+
 	ensureVariable(testFocus, true, "test-focus is a required flag")
 	ensureVariable(imageType, true, "image type is a required flag. Available options include 'cos' and 'ubuntu'")
 
@@ -103,7 +116,8 @@ func main() {
 	if *deploymentStrat == "gke" {
 		ensureFlag(migrationTest, false, "Cannot set deployment strategy to 'gke' for migration tests.")
 		ensureVariable(kubeVersion, false, "Cannot set kube-version when using deployment strategy 'gke'. Use gke-cluster-version.")
-		ensureVariable(gkeClusterVer, true, "Must set gke-cluster-version when using deployment strategy 'gke'.")
+		ensureExactlyOneVariableSet([]*string{gkeClusterVer, gkeReleaseChannel},
+			"For GKE cluster deployment, exactly one of 'gke-cluster-version' or 'gke-release-channel' must be set")
 		ensureVariable(kubeFeatureGates, false, "Cannot set feature gates when using deployment strategy 'gke'.")
 		if len(*localK8sDir) == 0 {
 			ensureVariable(testVersion, true, "Must set either test-version or local k8s dir when using deployment strategy 'gke'.")
@@ -243,7 +257,7 @@ func handle() error {
 		case "gce":
 			err = clusterUpGCE(k8sDir, *gceZone, *numNodes, *imageType)
 		case "gke":
-			err = clusterUpGKE(*gceZone, *gceRegion, *numNodes, *imageType)
+			err = clusterUpGKE(*gceZone, *gceRegion, *numNodes, *imageType, *useGKEManagedDriver)
 		default:
 			err = fmt.Errorf("deployment-strategy must be set to 'gce' or 'gke', but is: %s", *deploymentStrat)
 		}
@@ -272,21 +286,24 @@ func handle() error {
 		}()
 	}
 
-	// Install the driver and defer its teardown
-	err := installDriver(goPath, pkgDir, *stagingImage, stagingVersion, *deployOverlayName, *doDriverBuild)
-	if *teardownDriver {
-		defer func() {
-			// TODO (#140): collect driver logs
-			if teardownErr := deleteDriver(goPath, pkgDir, *deployOverlayName); teardownErr != nil {
-				klog.Errorf("failed to delete driver: %v", teardownErr)
-			}
-		}()
-	}
-	if err != nil {
-		return fmt.Errorf("failed to install CSI Driver: %v", err)
+	if !*useGKEManagedDriver {
+		// Install the driver and defer its teardown
+		err := installDriver(goPath, pkgDir, *stagingImage, stagingVersion, *deployOverlayName, *doDriverBuild)
+		if *teardownDriver {
+			defer func() {
+				// TODO (#140): collect driver logs
+				if teardownErr := deleteDriver(goPath, pkgDir, *deployOverlayName); teardownErr != nil {
+					klog.Errorf("failed to delete driver: %v", teardownErr)
+				}
+			}()
+		}
+		if err != nil {
+			return fmt.Errorf("failed to install CSI Driver: %v", err)
+		}
 	}
 
 	var cloudProviderArgs []string
+	var err error
 	switch *deploymentStrat {
 	case "gke":
 		cloudProviderArgs, err = getGKEKubeTestArgs(*gceZone, *gceRegion, *imageType)
@@ -295,12 +312,20 @@ func handle() error {
 		}
 	}
 
-	normalizedVersion, err := getNormalizedVersion(*kubeVersion, *gkeClusterVer)
-	if err != nil {
-		return fmt.Errorf("failed to get cluster minor version: %v", err)
+	// Kubernetes version of GKE deployments are expected to be of the pattern x.y.z-gke.k,
+	// hence we use the main.Version utils to parse and compare GKE managed cluster versions.
+	// For clusters deployed on GCE, use the apimachinery version utils (which supports non-gke based semantic versioning).
+	clusterVersion := mustGetKubeClusterVersion()
+	var testSkip string
+	switch *deploymentStrat {
+	case "gce":
+		testSkip = generateGCETestSkip(clusterVersion)
+	case "gke":
+		testSkip = generateGKETestSkip(clusterVersion, *useGKEManagedDriver)
+	default:
+		return fmt.Errorf("Unknown deployment strategy %s", *deploymentStrat)
 	}
 
-	testSkip := generateTestSkip(normalizedVersion)
 	// Run the tests using the testDir kubernetes
 	if len(*storageClassFile) != 0 {
 		err = runCSITests(pkgDir, testDir, *testFocus, testSkip, *storageClassFile, *snapshotClassFile, cloudProviderArgs, *deploymentStrat)
@@ -317,30 +342,40 @@ func handle() error {
 	return nil
 }
 
-func generateTestSkip(normalizedVersion string) string {
+func generateGCETestSkip(clusterVersion string) string {
 	skipString := "\\[Disruptive\\]|\\[Serial\\]"
-	switch normalizedVersion {
-	// Fall-through versioning since all test cases we want to skip in 1.15
-	// should also be skipped in 1.14
-	case "1.13":
-		fallthrough
-	case "1.14":
-		fallthrough
-	case "1.15":
-		fallthrough
-	case "1.16":
-		// "volumeMode should not mount / map unused volumes in a pod" tests a
-		// bug-fix introduced in 1.17
-		// (https://github.com/kubernetes/kubernetes/pull/81163)
+	v := apimachineryversion.MustParseSemantic(clusterVersion)
+
+	// "volumeMode should not mount / map unused volumes in a pod" tests a
+	// (https://github.com/kubernetes/kubernetes/pull/81163)
+	// bug-fix introduced in 1.16
+	if v.LessThan(apimachineryversion.MustParseSemantic("1.16.0")) {
 		skipString = skipString + "|volumeMode\\sshould\\snot\\smount\\s/\\smap\\sunused\\svolumes\\sin\\sa\\spod"
-		// Skip Snapshot tests pre 1.17
-		skipString = skipString + "|snapshot"
-		fallthrough
-	case "1.17":
-	case "latest":
-	case "master":
-	default:
 	}
+
+	if v.LessThan(apimachineryversion.MustParseSemantic("1.17.0")) {
+		skipString = skipString + "|VolumeSnapshotDataSource"
+	}
+	return skipString
+}
+
+func generateGKETestSkip(clusterVersion string, use_gke_managed_driver bool) string {
+	skipString := "\\[Disruptive\\]|\\[Serial\\]"
+	curVer := mustParseVersion(clusterVersion)
+
+	// "volumeMode should not mount / map unused volumes in a pod" tests a
+	// (https://github.com/kubernetes/kubernetes/pull/81163)
+	// bug-fix introduced in 1.16
+	if curVer.lessThan(mustParseVersion("1.16.0")) {
+		skipString = skipString + "|volumeMode\\sshould\\snot\\smount\\s/\\smap\\sunused\\svolumes\\sin\\sa\\spod"
+	}
+
+	// For GKE deployed PD CSI snapshot is enabled in 1.17.6-gke.4(and higher), 1.18.3-gke.0(and higher).
+	if (use_gke_managed_driver && curVer.lessThan(mustParseVersion("1.17.6-gke.4"))) ||
+		(!use_gke_managed_driver && (*curVer).lessThan(mustParseVersion("1.17.0"))) {
+		skipString = skipString + "|VolumeSnapshotDataSource"
+	}
+
 	return skipString
 }
 

--- a/test/k8s-integration/utils.go
+++ b/test/k8s-integration/utils.go
@@ -58,6 +58,19 @@ func ensureFlag(v *bool, setTo bool, msgOnError string) {
 	}
 }
 
+func ensureExactlyOneVariableSet(vars []*string, msgOnError string) {
+	var count int
+	for _, v := range vars {
+		if len(*v) != 0 {
+			count++
+		}
+	}
+
+	if count != 1 {
+		klog.Fatal(msgOnError)
+	}
+}
+
 func shredFile(filePath string) {
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
 		klog.V(4).Infof("File %v was not found, skipping shredding", filePath)
@@ -78,4 +91,14 @@ func shredFile(filePath string) {
 	if err != nil {
 		klog.V(4).Infof("Failed to remove service account file %s: %v", filePath, err)
 	}
+}
+
+func ensureVariableVal(v *string, val string, msgOnError string) {
+	if *v != val {
+		klog.Fatal(msgOnError)
+	}
+}
+
+func isVariableSet(v *string) bool {
+	return len(*v) != 0
 }

--- a/test/k8s-integration/version.go
+++ b/test/k8s-integration/version.go
@@ -1,0 +1,136 @@
+// main.version is used to parse and compare GKE based versions.
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"k8s.io/klog"
+)
+
+var (
+	versionNum           = `(0|[1-9][0-9]*)`
+	internalPatchVersion = `(\-[a-zA-Z0-9_.+-]+)`
+
+	versionRegex         = regexp.MustCompile(`^` + versionNum + `\.` + versionNum + `\.` + versionNum + internalPatchVersion + "?$")
+	gkeExtraVersionRegex = regexp.MustCompile(`^(?:gke)\.(0|[1-9][0-9]*)$`)
+)
+
+type version struct {
+	version [4]int
+}
+
+func (v *version) String() string {
+	if v.version[3] != -1 {
+		return fmt.Sprintf("%d.%d.%d-gke.%d", v.version[0], v.version[1], v.version[2], v.version[3])
+	}
+
+	return fmt.Sprintf("%d.%d.%d", v.version[0], v.version[1], v.version[2])
+}
+
+func (v *version) major() int {
+	return v.version[0]
+}
+
+func (v *version) minor() int {
+	return v.version[1]
+}
+
+func (v *version) patch() int {
+	return v.version[2]
+}
+
+func (v *version) extra() int {
+	return v.version[3]
+}
+
+func (v *version) isGKEExtraVersion(extrastr string) bool {
+	return gkeExtraVersionRegex.MatchString(extrastr)
+}
+
+func extractGKEExtraVersion(extra string) (int, error) {
+	m := gkeExtraVersionRegex.FindStringSubmatch(extra)
+	if len(m) != 2 {
+		return -1, fmt.Errorf("Invalid GKE Patch version %q", extra)
+	}
+
+	v, err := strconv.Atoi(m[1])
+	if err != nil {
+		return -1, fmt.Errorf("GKE extra version atoi failed: %q", extra)
+	}
+
+	if v < 0 {
+		return -1, fmt.Errorf("GKE extra version check failed: %q", extra)
+	}
+	return v, nil
+}
+
+func parseVersion(vs string) (*version, error) {
+	// If version has a prefix 'v', remove it before parsing.
+	if strings.HasPrefix(vs, "v") {
+		vs = vs[1:]
+	}
+
+	submatches := versionRegex.FindStringSubmatch(vs)
+	if submatches == nil {
+		return nil, fmt.Errorf("version %q is invalid", vs)
+	}
+
+	var v version
+	// submatches[0] is the whole match, [1]..[3] are the version bits, [4] is the extra
+	for i, sm := range submatches[1:4] {
+		var err error
+		if v.version[i], err = strconv.Atoi(sm); err != nil {
+			return nil, fmt.Errorf("submatch %q failed atoi conversion", sm)
+		}
+	}
+
+	// Ensure 1.X.Y < 1.X.Y-gke.0
+	v.version[3] = -1
+	if submatches[4] != "" {
+		extrastr := submatches[4][1:]
+		if v.isGKEExtraVersion(extrastr) {
+			ver, err := extractGKEExtraVersion(extrastr)
+			if err != nil {
+				return nil, err
+			}
+			v.version[3] = ver
+		} else {
+			return nil, fmt.Errorf("GKE extra version check failed: %q", extrastr)
+		}
+	}
+
+	return &v, nil
+}
+
+func mustParseVersion(version string) *version {
+	v, err := parseVersion(version)
+	if err != nil {
+		klog.Fatalf("Failed to parse GKE version: %q", version)
+	}
+	return v
+}
+
+// Helper function to compare versions.
+//  -1 -- if left  < right
+//   0 -- if left == right
+//   1 -- if left  > right
+func (v *version) compare(right *version) int {
+	for i, b := range v.version {
+		if b > right.version[i] {
+			return 1
+		}
+		if b < right.version[i] {
+			return -1
+		}
+	}
+
+	return 0
+}
+
+// Compare versions if left is strictly less than right.
+func (v *version) lessThan(right *version) bool {
+	return v.compare(right) < 0
+}

--- a/test/k8s-integration/version_test.go
+++ b/test/k8s-integration/version_test.go
@@ -1,0 +1,332 @@
+package main
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		version   string
+		expectErr bool
+		expectedV version
+	}{
+		// Positive test cases.
+		{
+			version: "v1.1.1",
+			expectedV: version{
+				version: [4]int{1, 1, 1, -1},
+			},
+		},
+		{
+			version: "v1.18.0",
+			expectedV: version{
+				version: [4]int{1, 18, 0, -1},
+			},
+		},
+		{
+			version: "v1.18.0-gke.0",
+			expectedV: version{
+				version: [4]int{1, 18, 0, 0},
+			},
+		},
+		{
+			version: "1.18.3-gke.10",
+			expectedV: version{
+				version: [4]int{1, 18, 3, 10},
+			},
+		},
+		{
+			version: "1.18.9",
+			expectedV: version{
+				version: [4]int{1, 18, 9, -1},
+			},
+		},
+		{
+			version: "1.18.10-gke.10",
+			expectedV: version{
+				version: [4]int{1, 18, 10, 10},
+			},
+		},
+		{
+			version: "10.18.10-gke.10",
+			expectedV: version{
+				version: [4]int{10, 18, 10, 10},
+			},
+		},
+		{
+			version: "100.101.102-gke.103",
+			expectedV: version{
+				version: [4]int{100, 101, 102, 103},
+			},
+		},
+		// Negative test cases
+		{
+			version:   "1",
+			expectErr: true,
+		},
+		{
+			version:   "-1.18.9",
+			expectErr: true,
+		},
+		{
+			version:   "1.-18.9",
+			expectErr: true,
+		},
+		{
+			version:   "1.18.-9",
+			expectErr: true,
+		},
+		{
+			version:   "1.18.9-gke.-1",
+			expectErr: true,
+		},
+		{
+			version:   "1.1",
+			expectErr: true,
+		},
+		{
+			version:   "1.18",
+			expectErr: true,
+		},
+		{
+			version:   "1.18.9.1",
+			expectErr: true,
+		},
+		{
+			version:   "1.18.9-1",
+			expectErr: true,
+		},
+		{
+			version:   "1.18-gke.0",
+			expectErr: true,
+		},
+		{
+			version:   "1.18.0-alpha.x",
+			expectErr: true,
+		},
+		{
+			version:   "1.18.0-alpha.beta.1",
+			expectErr: true,
+		},
+		{
+			version:   "alpha.3.673+73326ef01d2d7c",
+			expectErr: true,
+		},
+		{
+			version:   "1.18-alpha.3.673+73326ef01d2d7c",
+			expectErr: true,
+		},
+		{
+			version:   "1.18.3-alpha.3.673+73326ef01d2d7c",
+			expectErr: true,
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run("TestCase"+strconv.Itoa(i), func(t *testing.T) {
+			gotV, err := parseVersion(tc.version)
+			if err != nil {
+				if !tc.expectErr {
+					t.Fatalf("Got unexpected err: %v", err)
+				}
+				return
+			}
+
+			if err == nil && tc.expectErr {
+				t.Fatal("Got no error but expected one")
+				return
+			}
+
+			if gotV.version[0] != tc.expectedV.version[0] ||
+				gotV.version[1] != tc.expectedV.version[1] ||
+				gotV.version[2] != tc.expectedV.version[2] ||
+				gotV.version[3] != tc.expectedV.version[3] {
+				t.Fatalf("Got version: %s, expected: %s", gotV.String(), tc.expectedV.String())
+			}
+		})
+	}
+}
+
+func TestIsVersionLessThan(t *testing.T) {
+	tests := []struct {
+		leftVersion  string
+		rightVersion string
+		expectRes    bool
+	}{
+		// Positive cases (left < right).
+		{
+			leftVersion:  "1.17.5-gke.9",
+			rightVersion: "1.17.6",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.17.5-gke.9",
+			rightVersion: "1.18.5",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.17.5-gke.9",
+			rightVersion: "2.17.5",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0",
+			rightVersion: "1.18.0-gke.0",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0",
+			rightVersion: "1.18.1-gke.0",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0",
+			rightVersion: "1.19.0-gke.0",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0",
+			rightVersion: "2.18.0-gke.0",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0-gke.0",
+			rightVersion: "1.18.0-gke.1",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.17.0-gke.9",
+			rightVersion: "1.18.0-gke.0",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0-gke.9",
+			rightVersion: "1.18.1-gke.0",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0-gke.9",
+			rightVersion: "1.19.0-gke.0",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0-gke.9",
+			rightVersion: "2.18.0-gke.0",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0",
+			rightVersion: "1.18.1",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0",
+			rightVersion: "1.19.0",
+			expectRes:    true,
+		},
+		{
+			leftVersion:  "1.18.0",
+			rightVersion: "2.18.0",
+			expectRes:    true,
+		},
+		// Negative test cases.(left == right)
+		{
+			leftVersion:  "0.0.0",
+			rightVersion: "0.0.0",
+		},
+		{
+			leftVersion:  "1.1.1",
+			rightVersion: "1.1.1",
+		},
+		{
+			leftVersion:  "1.18.0",
+			rightVersion: "1.18.0",
+		},
+		{
+			leftVersion:  "1.18.0-gke.0",
+			rightVersion: "1.18.0-gke.0",
+		},
+		// Negative test cases.(left > right)
+		{
+			leftVersion:  "1.17.6",
+			rightVersion: "1.17.5-gke.9",
+		},
+		{
+			leftVersion:  "1.18.5",
+			rightVersion: "1.17.5-gke.9",
+		},
+		{
+			leftVersion:  "2.17.5",
+			rightVersion: "1.17.5-gke.9",
+		},
+		{
+			leftVersion:  "1.18.0-gke.0",
+			rightVersion: "1.18.0",
+		},
+		{
+			leftVersion:  "1.18.1-gke.0",
+			rightVersion: "1.18.0",
+		},
+		{
+			leftVersion:  "1.19.0-gke.0",
+			rightVersion: "1.18.0",
+		},
+		{
+			leftVersion:  "2.18.0-gke.0",
+			rightVersion: "1.18.0",
+		},
+		{
+			leftVersion:  "1.18.0-gke.1",
+			rightVersion: "1.18.0-gke.0",
+		},
+		{
+			leftVersion:  "1.18.0-gke.0",
+			rightVersion: "1.17.0-gke.9",
+		},
+		{
+			leftVersion:  "1.18.1-gke.0",
+			rightVersion: "1.18.0-gke.9",
+		},
+		{
+			leftVersion:  "1.19.0-gke.0",
+			rightVersion: "1.18.0-gke.9",
+		},
+		{
+			leftVersion:  "2.18.0-gke.0",
+			rightVersion: "1.18.0-gke.9",
+		},
+		{
+			leftVersion:  "1.18.1",
+			rightVersion: "1.18.0",
+		},
+		{
+			leftVersion:  "1.19.0",
+			rightVersion: "1.18.0",
+		},
+		{
+			leftVersion:  "2.18.0",
+			rightVersion: "1.18.0",
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run("TestCase"+strconv.Itoa(i), func(t *testing.T) {
+			left, err := parseVersion(tc.leftVersion)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+				return
+			}
+			right, err := parseVersion(tc.rightVersion)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+				return
+			}
+
+			got := left.lessThan(right)
+			if got != tc.expectRes {
+				t.Fatalf("Unpexpected compare value: %v, expected %v, left: %q, right: %q", got, tc.expectRes, left.String(), right.String())
+			}
+		})
+	}
+}

--- a/test/run-k8s-integration-local.sh
+++ b/test/run-k8s-integration-local.sh
@@ -10,7 +10,6 @@ readonly test_version=${TEST_VERSION:-master}
 
 source "${PKGDIR}/deploy/common.sh"
 
-ensure_var GCE_PD_CSI_STAGING_IMAGE
 ensure_var GCE_PD_SA_DIR
 
 make -C ${PKGDIR} test-k8s-integration
@@ -55,6 +54,24 @@ make -C ${PKGDIR} test-k8s-integration
 #--deploy-overlay-name=prow-gke-release-staging-head --bringup-cluster=false --teardown-cluster=false --test-focus="External.*Storage.*snapshot" --local-k8s-dir=$KTOP \
 #--storageclass-file=sc-standard.yaml --snapshotclass-file=pd-volumesnapshotclass.yaml --do-driver-build=true \
 #--gce-zone="us-central1-b" --num-nodes=${NUM_NODES:-3}
+
+# This version of the command brings up (and subsequently tears down) a GKE
+# cluster with managed GCE PersistentDisk CSI driver add-on enabled, and points to
+# the local K8s repository to get the e2e test binary.
+# ${PKGDIR}/bin/k8s-integration-test --run-in-prow=false --service-account-file=${GCE_PD_SA_DIR}/cloud-sa.json \
+# --test-focus="External.Storage" --local-k8s-dir=$KTOP --storageclass-file=sc-standard.yaml \
+# --snapshotclass-file=pd-volumesnapshotclass.yaml --do-driver-build=false --teardown-driver=false \
+# --gce-zone="us-central1-c" --num-nodes=${NUM_NODES:-3} --gke-cluster-version="latest" --deployment-strategy="gke" \
+# --use-gke-managed-driver=true --teardown-cluster=true
+
+# This version of the command brings up (and subsequently tears down) a GKE
+# cluster using a release channel, and with managed GCE PersistentDisk CSI driver add-on enabled, and points to
+# the local K8s repository to get the e2e test binary.
+# ${PKGDIR}/bin/k8s-integration-test --run-in-prow=false --service-account-file=${GCE_PD_SA_DIR}/cloud-sa.json \
+# --test-focus="External.Storage" --local-k8s-dir=$KTOP --storageclass-file=sc-standard.yaml \
+# --snapshotclass-file=pd-volumesnapshotclass.yaml --do-driver-build=false --teardown-driver=false \
+# --gce-zone="us-central1-c" --num-nodes=${NUM_NODES:-3} --gke-release-channel="rapid" --deployment-strategy="gke" \
+# --use-gke-managed-driver=true --teardown-cluster=true
 
 # This version of the command does not build the driver or K8s, points to a
 # local K8s repo to get the e2e.test binary, and does not bring up or down the cluster

--- a/test/run-k8s-integration.sh
+++ b/test/run-k8s-integration.sh
@@ -20,20 +20,33 @@ readonly test_version=${TEST_VERSION:-master}
 readonly gce_zone=${GCE_CLUSTER_ZONE:-us-central1-b}
 readonly gce_region=${GCE_CLUSTER_REGION:-}
 readonly image_type=${IMAGE_TYPE:-cos}
+readonly use_gke_managed_driver=${USE_GKE_MANAGED_DRIVER:-false}
+readonly gke_release_channel=${GKE_RELEASE_CHANNEL:-""}
+readonly teardown_driver=${GCE_PD_TEARDOWN_DRIVER:-true}
 
 export GCE_PD_VERBOSITY=9
 
 make -C ${PKGDIR} test-k8s-integration
 
 base_cmd="${PKGDIR}/bin/k8s-integration-test \
-            --run-in-prow=true --deploy-overlay-name=${overlay_name} --service-account-file=${E2E_GOOGLE_APPLICATION_CREDENTIALS} \
-            --do-driver-build=${do_driver_build} --boskos-resource-type=${boskos_resource_type} \
+            --run-in-prow=true --service-account-file=${E2E_GOOGLE_APPLICATION_CREDENTIALS} \
+            --do-driver-build=${do_driver_build} --teardown-driver=${teardown_driver} --boskos-resource-type=${boskos_resource_type} \
             --storageclass-file=sc-standard.yaml --snapshotclass-file=pd-volumesnapshotclass.yaml --test-focus="External.Storage" \
             --deployment-strategy=${deployment_strategy} --test-version=${test_version} --num-nodes=3 \
             --image-type=${image_type}"
 
+if [ "$use_gke_managed_driver" = false ]; then
+  base_cmd="${base_cmd} --deploy-overlay-name=${overlay_name}"
+else
+  base_cmd="${base_cmd} --use-gke-managed-driver=${use_gke_managed_driver}"
+fi
+
 if [ "$deployment_strategy" = "gke" ]; then
-  base_cmd="${base_cmd} --gke-cluster-version=${gke_cluster_version}"
+  if [ "$gke_release_channel" ]; then
+    base_cmd="${base_cmd} --gke-release-channel=${gke_release_channel}"
+  else
+    base_cmd="${base_cmd} --gke-cluster-version=${gke_cluster_version}"
+  fi
 else
   base_cmd="${base_cmd} --kube-version=${kube_version}"
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
Add hook to deploy GKE with GCE PD CSI driver, and run kubernetes e2e tests against the managed driver.
    Summary of changes:
    1. Add a new hook to pass release-channel for GKE cluster deployment.
    2. Add a new hook to deploy GKE managed PD CSI driver.
    3. Added a version comparision util with supporting UTs.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #511 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add hook to deploy GKE with GCE PD CSI driver, and run kubernetes e2e tests against the managed driver
```
