### PR TITLE
Increase PD CSI sidecar operation timeout

### DIFF
--- a/deploy/kubernetes/overlays/prow-gke-release-staging-head/increase-sidecar-operation-timeout.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-head/increase-sidecar-operation-timeout.yaml
@@ -1,0 +1,12 @@
+# Increase operation timeout for provisioner sidecar.
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--timeout=250s"
+# Increase operation timeout for attacher sidecar.
+- op: add
+  path: /spec/template/spec/containers/1/args/-
+  value: "--timeout=250s"
+# Increase operation timeout for snapshotter sidecar.
+- op: add
+  path: /spec/template/spec/containers/3/args/-
+  value: "--timeout=300s"

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-head/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-head/kustomization.yaml
@@ -17,3 +17,9 @@ patchesJson6902:
     kind: Deployment
     name: csi-gce-pd-controller
   path: volume-inuse-error-handler.yaml
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: csi-gce-pd-controller
+  path: increase-sidecar-operation-timeout.yaml

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc/increase-sidecar-operation-timeout.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc/increase-sidecar-operation-timeout.yaml
@@ -1,0 +1,12 @@
+# Increase operation timeout for provisioner sidecar.
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--timeout=250s"
+# Increase operation timeout for attacher sidecar.
+- op: add
+  path: /spec/template/spec/containers/1/args/-
+  value: "--timeout=250s"
+# Increase operation timeout for snapshotter sidecar.
+- op: add
+  path: /spec/template/spec/containers/3/args/-
+  value: "--timeout=300s"

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc/kustomization.yaml
@@ -4,3 +4,10 @@ resources:
 - ../stable
 transformers:
 - ../../images/prow-gke-release-staging-rc
+patchesJson6902:
+- path: increase-sidecar-operation-timeout.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: csi-gce-pd-controller
+    version: v1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #541 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Increase provisioner and attacher op timeout to reduce retries
```
