### PR TITLE
Fix Random CMEK Disk Creation Failure (disk already exists)

### DIFF
--- a/pkg/gce-cloud-provider/compute/gce-compute_test.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcecloudprovider
+
+import (
+	"testing"
+
+	computev1 "google.golang.org/api/compute/v1"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
+)
+
+func TestValidateDiskParameters(t *testing.T) {
+	testCases := []struct {
+		fetchedKMSKey      string
+		storageClassKMSKey string
+		expectErr          bool
+	}{
+		{
+			fetchedKMSKey:      "projects/my-project/locations/us-central1/keyRings/TestKeyRing/cryptoKeys/test-key/cryptoKeyVersions/8",
+			storageClassKMSKey: "projects/my-project/locations/us-central1/keyRings/TestKeyRing/cryptoKeys/test-key",
+			expectErr:          false,
+		},
+		{
+			fetchedKMSKey:      "projects/my-project/locations/us-central1/keyRings/TestKeyRing/cryptoKeys/test-key",
+			storageClassKMSKey: "projects/my-project/locations/us-central1/keyRings/TestKeyRing/cryptoKeys/test-key",
+			expectErr:          false,
+		},
+		{
+			fetchedKMSKey:      "projects/my-project/locations/us-central1/keyRings/TestKeyRing/cryptoKeys/garbage/cryptoKeyVersions/8",
+			storageClassKMSKey: "projects/my-project/locations/us-central1/keyRings/TestKeyRing/cryptoKeys/test-key",
+			expectErr:          true,
+		},
+		{
+			fetchedKMSKey:      "projects/my-project/locations/us-central1/keyRings/TestKeyRing/cryptoKeys/garbage",
+			storageClassKMSKey: "projects/my-project/locations/us-central1/keyRings/TestKeyRing/cryptoKeys/test-key",
+			expectErr:          true,
+		},
+		{
+			fetchedKMSKey:      "projects/my-project/locations/us-central1/keyRings/TestKeyRing/cryptoKeys/test-key",
+			storageClassKMSKey: "projects/my-project/locations/us-west1/keyRings/TestKeyRing/cryptoKeys/test-key",
+			expectErr:          true,
+		},
+		{
+			fetchedKMSKey:      "projects/my-project/locations/us-central1/keyRings/TestKeyRing/cryptoKeys/foobar/cryptoKeyVersions/8",
+			storageClassKMSKey: "projects/my-project/locations/us-central1/keyRings/TestKeyRing/cryptoKeys/foo",
+			expectErr:          true,
+		},
+		{
+			fetchedKMSKey:      "projects/my-project/locations/us-central1/keyRings/TestKeyRing/cryptoKeys/foobar",
+			storageClassKMSKey: "projects/my-project/locations/us-central1/keyRings/TestKeyRing/cryptoKeys/foo",
+			expectErr:          true,
+		},
+	}
+
+	for i, tc := range testCases {
+		// Arrange
+		existingDisk := &CloudDisk{
+			ZonalDisk: &computev1.Disk{
+				Id:                546559531467326555,
+				CreationTimestamp: "2020-07-24T17:20:06.292-07:00",
+				Name:              "test-disk",
+				SizeGb:            500,
+				Zone:              "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-c",
+				Status:            "READY",
+				SelfLink:          "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-c/disks/test-disk",
+				Type:              "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-c/diskTypes/pd-standard",
+				DiskEncryptionKey: &computev1.CustomerEncryptionKey{
+					KmsKeyName: tc.fetchedKMSKey,
+				},
+				LabelFingerprint:       "42WmSpB8rSM=",
+				PhysicalBlockSizeBytes: 4096,
+				Kind:                   "compute#disk",
+			},
+		}
+
+		storageClassParams := common.DiskParameters{
+			DiskType:             "pd-standard",
+			ReplicationType:      "none",
+			DiskEncryptionKMSKey: tc.storageClassKMSKey,
+		}
+
+		// Act
+		err := ValidateDiskParameters(existingDisk, storageClassParams)
+
+		// Assert
+		if !tc.expectErr && err != nil {
+			t.Fatalf("Test case #%v: ValidateDiskParameters did not expect error, but got %v", i, err)
+		}
+		if tc.expectErr && err == nil {
+			t.Fatalf("Test case #%v: ValidateDiskParameters expected error, but got no error", i)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
This PR fixes the issue where provisioning of GCE PDs with CMEK used to sometimes fails with `disk already exists with same name` error.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #558

**Special notes for your reviewer**:

Added unit test to prevent future regression.

Manually verified by setting csi-provisioner timeout to 1 seconds:

```
  Type     Reason                 Age                From                                                                                                 Message
  ----     ------                 ----               ----                                                                                                 -------
  Normal   ExternalProvisioning   32s (x2 over 34s)  persistentvolume-controller                                                                          waiting for a volume to be created, either by external provisioner "pd.csi.storage.gke.io" or manually created by system administrator
  Warning  ProvisioningFailed     32s (x2 over 33s)  pd.csi.storage.gke.io_gke-cluster-1-default-pool-4cede575-43h6_5ca3c339-e79e-4f83-acc5-97267112065f  failed to provision volume with StorageClass "csi-gce-pd-cmek": rpc error: code = DeadlineExceeded desc = context deadline exceeded
  Warning  ProvisioningFailed     30s (x2 over 32s)  pd.csi.storage.gke.io_gke-cluster-1-default-pool-4cede575-43h6_5ca3c339-e79e-4f83-acc5-97267112065f  failed to provision volume with StorageClass "csi-gce-pd-cmek": rpc error: code = Aborted desc = An operation with the given Volume ID projects/test-project/zones/us-central1-c/disks/pvc-0a3d4780-ce27-11ea-b569-42010a8000c9 already exists
  Normal   Provisioning           22s (x5 over 34s)  pd.csi.storage.gke.io_gke-cluster-1-default-pool-4cede575-43h6_5ca3c339-e79e-4f83-acc5-97267112065f  External provisioner is provisioning volume for claim "default/pvc-demo"
  Normal   ProvisioningSucceeded  21s                pd.csi.storage.gke.io_gke-cluster-1-default-pool-4cede575-43h6_5ca3c339-e79e-4f83-acc5-97267112065f  Successfully provisioned volume pvc-0a3d4780-ce27-11ea-b569-42010a8000c9
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed issue where provisioning of GCE PDs with CMEK used to sometimes fails with `disk already exists with same name` error.
```

/assign @msau42 