### PR TITLE
Add metadata info in tag on PD

### DIFF
--- a/deploy/kubernetes/overlays/prow-gke-release-staging-head/enable-extra-create-metadata.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-head/enable-extra-create-metadata.yaml
@@ -1,0 +1,4 @@
+# Enable extra-create-metadata flag for external-provisioner
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--extra-create-metadata"

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-head/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-head/kustomization.yaml
@@ -23,3 +23,9 @@ patchesJson6902:
     kind: Deployment
     name: csi-gce-pd-controller
   path: increase-sidecar-operation-timeout.yaml
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: csi-gce-pd-controller
+  path: enable-extra-create-metadata.yaml

--- a/pkg/common/parameters_test.go
+++ b/pkg/common/parameters_test.go
@@ -35,6 +35,7 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 				DiskType:             "pd-standard",
 				ReplicationType:      "none",
 				DiskEncryptionKMSKey: "",
+				Tags:                 make(map[string]string),
 			},
 		},
 		{
@@ -44,6 +45,7 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 				DiskType:             "pd-standard",
 				ReplicationType:      "none",
 				DiskEncryptionKMSKey: "",
+				Tags:                 make(map[string]string),
 			},
 		},
 		{
@@ -58,6 +60,7 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 				DiskType:             "pd-ssd",
 				ReplicationType:      "regional-pd",
 				DiskEncryptionKMSKey: "foo/key",
+				Tags:                 make(map[string]string),
 			},
 		},
 		{
@@ -67,13 +70,24 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 				DiskType:             "pd-standard",
 				ReplicationType:      "none",
 				DiskEncryptionKMSKey: "foo/key",
+				Tags:                 make(map[string]string),
+			},
+		},
+		{
+			name:       "tags",
+			parameters: map[string]string{ParameterKeyPVCName: "testPVCName", ParameterKeyPVCNamespace: "testPVCNamespace", ParameterKeyPVName: "testPVName"},
+			expectParams: DiskParameters{
+				DiskType:             "pd-standard",
+				ReplicationType:      "none",
+				DiskEncryptionKMSKey: "",
+				Tags:                 map[string]string{tagKeyCreatedForClaimName: "testPVCName", tagKeyCreatedForClaimNamespace: "testPVCNamespace", tagKeyCreatedForVolumeName: "testPVName", tagKeyCreatedBy: "testDriver"},
 			},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			p, err := ExtractAndDefaultParameters(tc.parameters)
+			p, err := ExtractAndDefaultParameters(tc.parameters, "testDriver")
 			if gotErr := err != nil; gotErr != tc.expectErr {
 				t.Fatalf("ExtractAndDefaultParameters(%+v) = %v; expectedErr: %v", tc.parameters, err, tc.expectErr)
 			}

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -110,7 +110,7 @@ func (gceCS *GCEControllerServer) CreateVolume(ctx context.Context, req *csi.Cre
 
 	// Apply Parameters (case-insensitive). We leave validation of
 	// the values to the cloud provider.
-	params, err := common.ExtractAndDefaultParameters(req.GetParameters())
+	params, err := common.ExtractAndDefaultParameters(req.GetParameters(), gceCS.Driver.name)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to extract parameters: %v", err)
 	}
@@ -471,7 +471,7 @@ func (gceCS *GCEControllerServer) ValidateVolumeCapabilities(ctx context.Context
 	}
 
 	// Validate the disk parameters match the disk we GET
-	params, err := common.ExtractAndDefaultParameters(req.GetParameters())
+	params, err := common.ExtractAndDefaultParameters(req.GetParameters(), gceCS.Driver.name)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to extract parameters: %v", err)
 	}

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -676,6 +676,42 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		Expect(err).To(BeNil(), "Failed to go through volume lifecycle")
 	})
 
+	It("Should successfully create disk with PVC/PV tags", func() {
+		Expect(testContexts).ToNot(BeEmpty())
+		testContext := getRandomTestContext()
+
+		controllerInstance := testContext.Instance
+		controllerClient := testContext.Client
+
+		p, z, _ := controllerInstance.GetIdentity()
+
+		// Create Disk
+		volName := testNamePrefix + string(uuid.NewUUID())
+		volID, err := controllerClient.CreateVolume(volName, map[string]string{
+			common.ParameterKeyPVCName:      "test-pvc",
+			common.ParameterKeyPVCNamespace: "test-pvc-namespace",
+			common.ParameterKeyPVName:       "test-pv-name",
+		}, defaultSizeGb, nil /* topReq */)
+		Expect(err).To(BeNil(), "CreateVolume failed with error: %v", err)
+
+		// Validate Disk Created
+		cloudDisk, err := computeService.Disks.Get(p, z, volName).Do()
+		Expect(err).To(BeNil(), "Could not get disk from cloud directly")
+		Expect(cloudDisk.Type).To(ContainSubstring(standardDiskType))
+		Expect(cloudDisk.Status).To(Equal(readyState))
+		Expect(cloudDisk.SizeGb).To(Equal(defaultSizeGb))
+		Expect(cloudDisk.Name).To(Equal(volName))
+		Expect(cloudDisk.Description).To(Equal("{\"kubernetes.io/created-for/pv/name\":\"test-pv-name\",\"kubernetes.io/created-for/pvc/name\":\"test-pvc\",\"kubernetes.io/created-for/pvc/namespace\":\"test-pvc-namespace\",\"storage.gke.io/created-by\":\"pd.csi.storage.gke.io\"}"))
+		defer func() {
+			// Delete Disk
+			controllerClient.DeleteVolume(volID)
+			Expect(err).To(BeNil(), "DeleteVolume failed")
+
+			// Validate Disk Deleted
+			_, err = computeService.Disks.Get(p, z, volName).Do()
+			Expect(gce.IsGCEError(err, "notFound")).To(BeTrue(), "Expected disk to not be found")
+		}()
+	})
 })
 
 func equalWithinEpsilon(a, b, epsiolon int64) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind feature

**What this PR does / why we need it**:
In-tree GCE PD "tags" a disk with information about which PVC/PV the disk was created for.
These tags are stored as JSON in the disk Description field.
This PR archives feature-parity with that behavior using https://github.com/kubernetes-csi/external-provisioner/pull/399
Added automated tests and did manual tests to verify new behavior:

Example disk Description field provisioned by in-tree GCE PD plugin:
```
{"kubernetes.io/created-for/pv/name":"pvc-4ffe59ed-8ee0-11e7-a29f-42010a800002","kubernetes.io/created-for/pvc/name":"myclaim","kubernetes.io/created-for/pvc/namespace":"default"}
```

Example disk Description field provisioned by GCE PD CSI Driver with this change:
```
{"kubernetes.io/created-for/pv/name":"pvc-32af883a-d7cc-11ea-86f9-42010a800053","kubernetes.io/created-for/pvc/name":"pvc-demo","kubernetes.io/created-for/pvc/namespace":"default","storage.gke.io/created-by":"pd.csi.storage.gke.io"}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #387

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Provisioned GCE PD Description will contain JSON with information about what PVC/PV disk was created for (similar to volumes provisioned by in-tree GCE PD plugin). This feature requires the `--extra-create-metadata` flag to be set on the CSI external-provisioner.
```
