### PR TITLE
Move extra-create-metadata to stable

### DIFF
--- a/deploy/kubernetes/base/controller/controller.yaml
+++ b/deploy/kubernetes/base/controller/controller.yaml
@@ -33,6 +33,7 @@ spec:
             - "--leader-election-type=leases"
             - "--leader-election-namespace=$(PDCSI_NAMESPACE)"
             - "--timeout=250s"
+            - "--extra-create-metadata"
           # - "--run-controller-service=false" # disable the controller service of the CSI driver
           # - "--run-node-service=false"       # disable the node service of the CSI driver
           env:

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-head/enable-extra-create-metadata.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-head/enable-extra-create-metadata.yaml
@@ -1,4 +1,0 @@
-# Enable extra-create-metadata flag for external-provisioner
-- op: add
-  path: /spec/template/spec/containers/0/args/-
-  value: "--extra-create-metadata"

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-head/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-head/kustomization.yaml
@@ -17,9 +17,3 @@ patchesJson6902:
     kind: Deployment
     name: csi-gce-pd-controller
   path: volume-inuse-error-handler.yaml
-- target:
-    group: apps
-    version: v1
-    kind: Deployment
-    name: csi-gce-pd-controller
-  path: enable-extra-create-metadata.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind cleanup

**What this PR does / why we need it**:
This PR moves the PD tagging functionality introduced in https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/570 to all deployments including stable.

Since the stable version has not yet been cut, the new test introduced in that PR will fail until a new release is cut and stable version is updated.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```

/assign @msau42 