### PR TITLE
Enable Volume expansion test for GKE PDCSI driver

### DIFF
--- a/test/k8s-integration/driver-config.go
+++ b/test/k8s-integration/driver-config.go
@@ -74,11 +74,8 @@ func generateDriverConfigFile(platform, pkgDir, storageClassFile, snapshotClassF
 	// TODO: Support adding/removing capabilities based on Kubernetes version.
 	switch deploymentStrat {
 	case "gke":
+		fallthrough
 	case "gce":
-		// TODO: OSS K8S supports volume expansion for CSI by default in 1.16+;
-		// however, at time of writing GKE does not support K8S 1.16+. Add these
-		// capabilities for both deployment strategies when GKE Supports CSI
-		// Expansion by default.
 		caps = append(caps, "controllerExpansion", "nodeExpansion")
 	default:
 		return "", fmt.Errorf("got unknown deployment strat %s, expected gce or gke", deploymentStrat)

--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -412,6 +412,12 @@ func generateGKETestSkip(clusterVersion string, use_gke_managed_driver bool) str
 		skipString = skipString + "|volumeMode\\sshould\\snot\\smount\\s/\\smap\\sunused\\svolumes\\sin\\sa\\spod"
 	}
 
+	// For GKE deployed PD CSI driver, resizer sidecar is enabled in 1.16.8-gke.3
+	if (use_gke_managed_driver && curVer.lessThan(mustParseVersion("1.16.8-gke.3"))) ||
+		(!use_gke_managed_driver && curVer.lessThan(mustParseVersion("1.16.0"))) {
+		skipString = skipString + "|allowExpansion"
+	}
+
 	// For GKE deployed PD CSI snapshot is enabled in 1.17.6-gke.4(and higher), 1.18.3-gke.0(and higher).
 	if (use_gke_managed_driver && curVer.lessThan(mustParseVersion("1.17.6-gke.4"))) ||
 		(!use_gke_managed_driver && (*curVer).lessThan(mustParseVersion("1.17.0"))) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #583 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
 Enable volume expansion test for GKE managed driver
```
