### PR TITLE
Project setup script authorizes GCE to use Cloud KMS keys on the dev project.

### DIFF
--- a/deploy/setup-project.sh
+++ b/deploy/setup-project.sh
@@ -2,7 +2,8 @@
 
 # This script will setup the given project with a Service Account that has the correct
 # restricted permissions to run the gcp_compute_persistent_disk_csi_driver and download
-# the keys to a specified directory
+# the keys to a specified directory. This script also authorizes GCE to encrypt/decrypt
+# using Cloud KMS keys for the CMEK feature.
 
 # WARNING: This script will delete and recreate the service accounts, bindings, and keys
 # associated with ${GCE_PD_SA_NAME}. Great care must be taken to not run the script
@@ -12,6 +13,7 @@
 # PROJECT: GCP project
 # GCE_PD_SA_NAME: Name of the service account to create
 # GCE_PD_SA_DIR: Directory to save the service account key
+# ENABLE_KMS: If true, it will enable Cloud KMS and configure IAM ACLs.
 
 
 set -o nounset
@@ -24,6 +26,7 @@ source "${PKGDIR}/deploy/common.sh"
 ensure_var PROJECT
 ensure_var GCE_PD_SA_NAME
 ensure_var GCE_PD_SA_DIR
+ensure_var ENABLE_KMS
 
 # If the project id includes the org name in the format "org-name:project", the
 # gCloud api will format the project part of the iam email domain as
@@ -38,6 +41,7 @@ fi
 readonly KUBEDEPLOY="${PKGDIR}/deploy/kubernetes"
 readonly BIND_ROLES=$(get_needed_roles)
 readonly IAM_NAME="${GCE_PD_SA_NAME}@${IAM_PROJECT}.iam.gserviceaccount.com"
+readonly PROJECT_NUMBER=`gcloud projects describe ${PROJECT} --format="value(projectNumber)"`
 
 # Check if SA exists
 CREATE_SA=true
@@ -90,6 +94,15 @@ for role in ${BIND_ROLES}
 do
   gcloud projects add-iam-policy-binding "${PROJECT}" --member serviceAccount:"${IAM_NAME}" --role "${role}"
 done
+
+# Authorize GCE to encrypt/decrypt using Cloud KMS encryption keys.
+# https://cloud.google.com/compute/docs/disks/customer-managed-encryption#before_you_begin
+if [ "${ENABLE_KMS}" = true ];
+then
+  gcloud services enable cloudkms.googleapis.com --project="${PROJECT}"
+  gcloud projects add-iam-policy-binding "${PROJECT}" --member serviceAccount:"service-${PROJECT_NUMBER}@compute-system.iam.gserviceaccount.com" --role "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+fi
+
 
 # Export key if needed
 if [ "${CREATE_SA}" = true ];


### PR DESCRIPTION
…project.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The project setup script will now run `gcloud projects add-iam-policy-binding "${PROJECT}" --member serviceAccount:"service-${PROJECT_NUMBER}@compute-system.iam.gserviceaccount.com" --role "roles/cloudkms.cryptoKeyEncrypterDecrypter"`.

This is important because it authorizes GCE to use Cloud KMS encryption keys. Without this grant usage to Cloud KMS will be blocked and tests will fail with,

```
Should create CMEK key, go through volume lifecycle, validate behavior on key revoke and restore [It]
  /usr/local/google/home/jeremyedwards/github/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/test/e2e/tests/single_zone_e2e_test.go:347

  CreateVolume failed with error: rpc error: code = Internal desc = CreateVolume failed to create single zonal disk "gcepd-csi-e2e-abfae45e-d0af-4cd7-a996-8b5e74089a2e": failed to insert zonal disk: unknown Insert disk error: googleapi: Error 400: Cloud KMS error when using key projects/REDACTED/locations/global/keyRings/gce-pd-csi-test-ring/cryptoKeys/test-key-99db27e5-88e7-47c5-a1f8-4b7e4cebce88: Permission 'cloudkms.cryptoKeyVersions.useToEncrypt' denied on resource 'projects/REDACTED/locations/global/keyRings/gce-pd-csi-test-ring/cryptoKeys/test-key-99db27e5-88e7-47c5-a1f8-4b7e4cebce88' (or it may not exist)., kmsPermissionDenied
  Expected
      <*status.statusError | 0xc0000bb040>: {
          Code: 13,
          Message: "CreateVolume failed to create single zonal disk \"gcepd-csi-e2e-abfae45e-d0af-4cd7-a996-8b5e74089a2e\": failed to insert zonal disk: unknown Insert disk error: googleapi: Error 400: Cloud KMS error when using key projects/REDACTED/locations/global/keyRings/gce-pd-csi-test-ring/cryptoKeys/test-key-99db27e5-88e7-47c5-a1f8-4b7e4cebce88: Permission 'cloudkms.cryptoKeyVersions.useToEncrypt' denied on resource 'projects/REDACTED/locations/global/keyRings/gce-pd-csi-test-ring/cryptoKeys/test-key-99db27e5-88e7-47c5-a1f8-4b7e4cebce88' (or it may not exist)., kmsPermissionDenied",
          Details: nil,
          XXX_NoUnkeyedLiteral: {},
          XXX_unrecognized: nil,
          XXX_sizecache: 0,
      }
  to be nil
```



**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
