### PR TITLE
Strip .yaml from test output dirs

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -370,12 +370,15 @@ func handle() error {
 	if len(*storageClassFiles) != 0 {
 		storageClasses := strings.Split(*storageClassFiles, ",")
 		var ginkgoErrors []string
+		var testOutputDirs []string
 		for _, scFile := range storageClasses {
-			if err = runCSITests(*platform, pkgDir, testDir, *testFocus, testSkip, scFile, *snapshotClassFile, cloudProviderArgs, *deploymentStrat, scFile); err != nil {
+			outputDir := strings.TrimSuffix(scFile, ".yaml")
+			testOutputDirs = append(testOutputDirs, outputDir)
+			if err = runCSITests(*platform, pkgDir, testDir, *testFocus, testSkip, scFile, *snapshotClassFile, cloudProviderArgs, *deploymentStrat, outputDir); err != nil {
 				ginkgoErrors = append(ginkgoErrors, err.Error())
 			}
 		}
-		if err = mergeArtifacts(storageClasses); err != nil {
+		if err = mergeArtifacts(testOutputDirs); err != nil {
 			return fmt.Errorf("artifact merging failed: %w", err)
 		}
 		if ginkgoErrors != nil {


### PR DESCRIPTION
/kind cleanup

The change to test multiple storage classes used the full storageclass filename for the test output directory. Feedback came that it was confusing for a directory to end in .yaml; this PR strips that suffix.
```release-note
NONE
```
