### PR TITLE
Fix TestExtractAndDefaultParameters test.

### DIFF
--- a/pkg/common/parameters_test.go
+++ b/pkg/common/parameters_test.go
@@ -70,6 +70,7 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 				DiskType:             "pd-balanced",
 				ReplicationType:      "regional-pd",
 				DiskEncryptionKMSKey: "foo/key",
+				Tags:                 make(map[string]string),
 			},
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Fix this problem. 
```bash
go version
go version go1.14.4 linux/amd64
go test ./pkg/...
--- FAIL: TestExtractAndDefaultParameters (0.00s)
    --- FAIL: TestExtractAndDefaultParameters/real_values,_checking_balanced_pd (0.00s)
        parameters_test.go:109: ExtractAndDefaultParameters(map[disk-encryption-kms-key:foo/key replication-type:regional-pd type:pd-balanced]) = {pd-balanced regional-pd foo/key map[]}; expected params: {pd-balanced regional-pd foo/key map[]}
FAIL
FAIL    sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common   0.003s
ok      sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute       (cached)
?       sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/metadata      [no test files]
ok      sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-pd-csi-driver        (cached)
?       sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/mount-manager    [no test files]
?       sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/resizefs [no test files]
FAIL
```
**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
