### PR TITLE
e2e test should take GKE node version as an input

### DIFF
--- a/test/k8s-integration/cluster.go
+++ b/test/k8s-integration/cluster.go
@@ -167,6 +167,10 @@ func clusterUpGKE(gceZone, gceRegion string, numNodes int, imageType string, use
 		cmdParams = append(cmdParams, "--enable-autorepair")
 	}
 
+	if isVariableSet(gkeNodeVersion) {
+		cmdParams = append(cmdParams, "--node-version", *gkeNodeVersion)
+	}
+
 	if useManagedDriver {
 		// PD CSI Driver add on is enabled only in gcloud beta.
 		cmdParams = append([]string{"beta"}, cmdParams...)

--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -48,6 +48,7 @@ var (
 	imageType          = flag.String("image-type", "cos", "the image type to use for the cluster")
 	gkeReleaseChannel  = flag.String("gke-release-channel", "", "GKE release channel to be used for cluster deploy. One of 'rapid', 'stable' or 'regular'")
 	gkeTestClusterName = flag.String("gke-cluster-name", "gcp-pd-csi-driver-test-cluster", "GKE cluster name")
+	gkeNodeVersion     = flag.String("gke-node-version", "", "GKE cluster worker node version")
 
 	// Test infrastructure flags
 	boskosResourceType = flag.String("boskos-resource-type", "gce-project", "name of the boskos resource type to reserve")

--- a/test/run-k8s-integration-ci.sh
+++ b/test/run-k8s-integration-ci.sh
@@ -23,6 +23,7 @@ readonly image_type=${IMAGE_TYPE:-cos}
 readonly use_gke_managed_driver=${USE_GKE_MANAGED_DRIVER:-false}
 readonly gke_release_channel=${GKE_RELEASE_CHANNEL:-""}
 readonly teardown_driver=${GCE_PD_TEARDOWN_DRIVER:-true}
+readonly gke_node_version=${GKE_NODE_VERSION:-}
 
 export GCE_PD_VERBOSITY=9
 
@@ -55,6 +56,10 @@ if [ -z "$gce_region" ]; then
   base_cmd="${base_cmd} --gce-zone=${gce_zone}"
 else
   base_cmd="${base_cmd} --gce-region=${gce_region}"
+fi
+
+if [ -z "$gke_node_version" ]; then
+  base_cmd="${base_cmd} --gke-node-version=${gke_node_version}"
 fi
 
 eval "$base_cmd"

--- a/test/run-k8s-integration.sh
+++ b/test/run-k8s-integration.sh
@@ -23,6 +23,7 @@ readonly image_type=${IMAGE_TYPE:-cos}
 readonly use_gke_managed_driver=${USE_GKE_MANAGED_DRIVER:-false}
 readonly gke_release_channel=${GKE_RELEASE_CHANNEL:-""}
 readonly teardown_driver=${GCE_PD_TEARDOWN_DRIVER:-true}
+readonly gke_node_version=${GKE_NODE_VERSION:-}
 
 export GCE_PD_VERBOSITY=9
 
@@ -57,4 +58,7 @@ else
   base_cmd="${base_cmd} --gce-region=${gce_region}"
 fi
 
+if [ -z "$gke_node_version" ]; then
+  base_cmd="${base_cmd} --gke-node-version=${gke_node_version}"
+fi
 eval "$base_cmd"


### PR DESCRIPTION
For GKE clusters, node-version flag can be provided during cluster
creation to specify worker node k8s version. This change is needed
to test node and master version skew combinations.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
PD CSI e2e test infra should take GKE node version as an optional input argument.
```
