### PR TITLE
Use a fixed version of kustomization

### DIFF
--- a/deploy/kubernetes/install-kustomize.sh
+++ b/deploy/kubernetes/install-kustomize.sh
@@ -16,6 +16,50 @@ fi
 if [ -f "kustomize" ]; then
   rm kustomize
 fi
-echo "installing latest version of kustomize"
-curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+
+echo "installing kustomize"
+
+where=$PWD
+if [ -f $where/kustomize ]; then
+  echo "A file named kustomize already exists (remove it first)."
+  exit 1
+fi
+
+tmpDir=`mktemp -d`
+if [[ ! "$tmpDir" || ! -d "$tmpDir" ]]; then
+  echo "Could not create temp dir."
+  exit 1
+fi
+
+function cleanup {
+  rm -rf "$tmpDir"
+}
+
+trap cleanup EXIT
+
+pushd $tmpDir >& /dev/null
+
+opsys=windows
+if [[ "$OSTYPE" == linux* ]]; then
+  opsys=linux
+elif [[ "$OSTYPE" == darwin* ]]; then
+  opsys=darwin
+fi
+
+curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases |\
+  grep browser_download |\
+  grep $opsys |\
+  cut -d '"' -f 4 |\
+  grep /kustomize/v3.8.0 |\
+  sort | tail -n 1 |\
+  xargs curl -s -O -L
+
+tar xzf ./kustomize_v*_${opsys}_amd64.tar.gz
+
+cp ./kustomize $where
+
+popd >& /dev/null
+
+./kustomize version
+
 mv kustomize "${INSTALL_DIR}"


### PR DESCRIPTION
The latest version of kustomize does not work for image tag transfer
This PR use a fixed version 3.8.0

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
