### PR TITLE
Provide a knob to run intree and csi plugin tests

### DIFF
--- a/test/run-k8s-integration-ci.sh
+++ b/test/run-k8s-integration-ci.sh
@@ -24,7 +24,7 @@ readonly use_gke_managed_driver=${USE_GKE_MANAGED_DRIVER:-false}
 readonly gke_release_channel=${GKE_RELEASE_CHANNEL:-""}
 readonly teardown_driver=${GCE_PD_TEARDOWN_DRIVER:-true}
 readonly gke_node_version=${GKE_NODE_VERSION:-}
-
+readonly run_intree_plugin_tests=${RUN_INTREE_PLUGIN_TESTS:-false}
 export GCE_PD_VERBOSITY=9
 
 make -C "${PKGDIR}" test-k8s-integration
@@ -33,8 +33,14 @@ base_cmd="${PKGDIR}/bin/k8s-integration-test \
             --run-in-prow=true --service-account-file=${E2E_GOOGLE_APPLICATION_CREDENTIALS} \
             --do-driver-build=${do_driver_build} --teardown-driver=${teardown_driver} --boskos-resource-type=${boskos_resource_type} \
             --storageclass-files=sc-standard.yaml,sc-balanced.yaml,sc-ssd.yaml --snapshotclass-file=pd-volumesnapshotclass.yaml \
-            --test-focus='External.Storage' --deployment-strategy=${deployment_strategy} --test-version=${test_version} \
+            --deployment-strategy=${deployment_strategy} --test-version=${test_version} \
             --num-nodes=3 --image-type=${image_type}"
+
+if [ "$run_intree_plugin_tests" = true ]; then
+  base_cmd="${base_cmd} --test-focus='External.Storage|In-tree.*Driver.*gcepd"
+else
+  base_cmd="${base_cmd} --test-focus='External.Storage"
+fi
 
 if [ "$use_gke_managed_driver" = false ]; then
   base_cmd="${base_cmd} --deploy-overlay-name=${overlay_name}"


### PR DESCRIPTION
Using this new knob, intree plugin and csi tests can be run together

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Provide a knob to run intree and csi plugin tests
```
