### PR TITLE
Enable dump GKE node logs

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -560,15 +560,15 @@ func runTestsWithConfig(testDir, testFocus, testSkip, testConfigArg string, clou
 
 	artifactsDir, ok := os.LookupEnv("ARTIFACTS")
 	reportArg := ""
+	kubetestDumpDir := ""
 	if ok {
 		if len(reportPrefix) > 0 {
-			reportDir := filepath.Join(artifactsDir, reportPrefix)
-			if err := os.MkdirAll(reportDir, 0755); err != nil {
+			kubetestDumpDir = filepath.Join(artifactsDir, reportPrefix)
+			if err := os.MkdirAll(kubetestDumpDir, 0755); err != nil {
 				return err
 			}
-			reportArg = fmt.Sprintf("-report-dir=%s", reportDir)
 		} else {
-			reportArg = fmt.Sprintf("-report-dir=%s", artifactsDir)
+			kubetestDumpDir = artifactsDir
 		}
 	}
 	ginkgoArgs := fmt.Sprintf("--ginkgo.focus=%s --ginkgo.skip=%s", testFocus, testSkip)
@@ -585,6 +585,9 @@ func runTestsWithConfig(testDir, testFocus, testSkip, testConfigArg string, clou
 		"--ginkgo-parallel",
 		"--check-version-skew=false",
 		fmt.Sprintf("--test_args=%s", testArgs),
+	}
+	if kubetestDumpDir != "" {
+		kubeTestArgs = append(kubeTestArgs, fmt.Sprintf("--dump=%s", kubetestDumpDir))
 	}
 	kubeTestArgs = append(kubeTestArgs, cloudProviderArgs...)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Capturing the flow here: 
This patch uses kubetest --dump flag instead of directly setting up --report-dir flag. If dump flag is provided, kubetest will setup report-dir [here](https://github.com/kubernetes/test-infra/blob/master/kubetest/e2e.go#L40). Also using dump flag, enables kubetest to call DumpClusterLogs for both GCE and GKE deployments. For GKE, the function will setup the enviroment variables and filters [here](https://github.com/kubernetes/test-infra/blob/master/kubetest/gke.go#L409). For GKE deployment, this enables log-dump.sh to find the [node names](https://github.com/kubernetes/kubernetes/blob/master/cluster/log-dump/log-dump.sh#L400) for GKE and also gracefully skip master dump. The above dump flag works for both zonal and regional GKE clusters.

Also with this change, we do not need the change https://github.com/kubernetes/kubernetes/pull/95088. I will be closing that PR once this one is reviewed.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Enable dump GKE node logs
```
