### PR TITLE
Build only linux container image for tests on Linux

### DIFF
--- a/test/k8s-integration/driver.go
+++ b/test/k8s-integration/driver.go
@@ -120,13 +120,23 @@ func pushImage(pkgDir, stagingImage, stagingVersion, platform string) error {
 	}
 	var cmd *exec.Cmd
 
-	// build multi-arch image which can work for both Linux and Windows
-	cmd = exec.Command("make", "-C", pkgDir, "build-and-push-multi-arch",
-		fmt.Sprintf("GCE_PD_CSI_STAGING_VERSION=%s", stagingVersion),
-		fmt.Sprintf("GCE_PD_CSI_STAGING_IMAGE=%s", stagingImage))
-	err = runCommand("Building and Pushing GCP Container for Windows", cmd)
-	if err != nil {
-		return fmt.Errorf("failed to run make command for windows: err: %v", err)
+	if platform == "windows" {
+		// build multi-arch image which can work for both Linux and Windows
+		cmd = exec.Command("make", "-C", pkgDir, "build-and-push-multi-arch",
+			fmt.Sprintf("GCE_PD_CSI_STAGING_VERSION=%s", stagingVersion),
+			fmt.Sprintf("GCE_PD_CSI_STAGING_IMAGE=%s", stagingImage))
+		err = runCommand("Building and Pushing GCP Container for Windows", cmd)
+		if err != nil {
+			return fmt.Errorf("failed to run make command for windows: err: %v", err)
+		}
+	} else {
+		cmd = exec.Command("make", "-C", pkgDir, "push-container",
+			fmt.Sprintf("GCE_PD_CSI_STAGING_VERSION=%s", stagingVersion),
+			fmt.Sprintf("GCE_PD_CSI_STAGING_IMAGE=%s", stagingImage))
+		err = runCommand("Pushing GCP Container for Linux", cmd)
+		if err != nil {
+			return fmt.Errorf("failed to run make command for linux: err: %v", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Build multi-arch container image takes much longer time than only
building linux container image. This PR changes back to only build linux
container image for linux tests to avoid timeout issue

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
