### PR TITLE
Migrate from alpha to beta compute APIs

### DIFF
--- a/pkg/gce-cloud-provider/compute/gce-compute_test.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute_test.go
@@ -66,24 +66,22 @@ func TestValidateDiskParameters(t *testing.T) {
 
 	for i, tc := range testCases {
 		// Arrange
-		existingDisk := &CloudDisk{
-			ZonalDisk: &computev1.Disk{
-				Id:                546559531467326555,
-				CreationTimestamp: "2020-07-24T17:20:06.292-07:00",
-				Name:              "test-disk",
-				SizeGb:            500,
-				Zone:              "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-c",
-				Status:            "READY",
-				SelfLink:          "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-c/disks/test-disk",
-				Type:              "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-c/diskTypes/pd-standard",
-				DiskEncryptionKey: &computev1.CustomerEncryptionKey{
-					KmsKeyName: tc.fetchedKMSKey,
-				},
-				LabelFingerprint:       "42WmSpB8rSM=",
-				PhysicalBlockSizeBytes: 4096,
-				Kind:                   "compute#disk",
+		existingDisk := CloudDiskFromV1(&computev1.Disk{
+			Id:                546559531467326555,
+			CreationTimestamp: "2020-07-24T17:20:06.292-07:00",
+			Name:              "test-disk",
+			SizeGb:            500,
+			Zone:              "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-c",
+			Status:            "READY",
+			SelfLink:          "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-c/disks/test-disk",
+			Type:              "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-c/diskTypes/pd-standard",
+			DiskEncryptionKey: &computev1.CustomerEncryptionKey{
+				KmsKeyName: tc.fetchedKMSKey,
 			},
-		}
+			LabelFingerprint:       "42WmSpB8rSM=",
+			PhysicalBlockSizeBytes: 4096,
+			Kind:                   "compute#disk",
+		})
 
 		storageClassParams := common.DiskParameters{
 			DiskType:             "pd-standard",

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -115,7 +115,7 @@ func (gceCS *GCEControllerServer) CreateVolume(ctx context.Context, req *csi.Cre
 	gceAPIVersion := gce.GCEAPIVersionV1
 	multiWriter, _ := getMultiWriterFromCapabilities(volumeCapabilities)
 	if multiWriter {
-		gceAPIVersion = gce.GCEAPIVersionAlpha
+		gceAPIVersion = gce.GCEAPIVersionBeta
 	}
 	// Determine the zone or zones+region of the disk
 	var zones []string
@@ -1033,7 +1033,7 @@ func createRegionalDisk(ctx context.Context, cloudProvider gce.GCECompute, name 
 
 	gceAPIVersion := gce.GCEAPIVersionV1
 	if multiWriter {
-		gceAPIVersion = gce.GCEAPIVersionAlpha
+		gceAPIVersion = gce.GCEAPIVersionBeta
 	}
 
 	disk, err := cloudProvider.GetDisk(ctx, meta.RegionalKey(name, region), gceAPIVersion)
@@ -1055,7 +1055,7 @@ func createSingleZoneDisk(ctx context.Context, cloudProvider gce.GCECompute, nam
 
 	gceAPIVersion := gce.GCEAPIVersionV1
 	if multiWriter {
-		gceAPIVersion = gce.GCEAPIVersionAlpha
+		gceAPIVersion = gce.GCEAPIVersionBeta
 	}
 	disk, err := cloudProvider.GetDisk(ctx, meta.ZonalKey(name, diskZone), gceAPIVersion)
 	if err != nil {

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -751,10 +751,10 @@ func TestListVolumeArgs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup new driver each time so no interference
-			d := []*gce.CloudDisk{}
+			var d []*gce.CloudDisk
 			for i := 0; i < 600; i++ {
 				// Create 600 dummy disks
-				d = append(d, &gce.CloudDisk{ZonalDisk: &compute.Disk{Name: fmt.Sprintf("%v", i)}})
+				d = append(d, gce.CloudDiskFromV1(&compute.Disk{Name: fmt.Sprintf("%v", i)}))
 			}
 			gceDriver := initGCEDriver(t, d)
 			lvr := &csi.ListVolumesRequest{
@@ -890,7 +890,7 @@ func TestCreateVolumeRandomRequisiteTopology(t *testing.T) {
 }
 
 func createZonalCloudDisk(name string) *gce.CloudDisk {
-	return gce.ZonalCloudDisk(&compute.Disk{
+	return gce.CloudDiskFromV1(&compute.Disk{
 		Name: name,
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The only Disk feature that required an alpha API (multiwriter) is now in beta.
We keep the infrastructure to be able to swap API versions, but it has been simplified to reduce code duplication.

**Special notes for your reviewer**:

Builds on top of #642

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
