### PR TITLE
Revert sidecar upgrade change for staging-rc

### DIFF
--- a/deploy/kubernetes/images/prow-gke-release-staging-rc/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc/image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: imagetag-csi-provisioner-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-provisioner
-  newTag: "v2.0.4"
+  newTag: "v1.6.0"
 ---
 
 apiVersion: builtin
@@ -13,7 +13,7 @@ metadata:
   name: imagetag-csi-attacher-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-attacher
-  newTag: "v3.0.1"
+  newTag: "v2.2.0"
 ---
 
 apiVersion: builtin

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc/sidecar-upgrade.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc/sidecar-upgrade.yaml
@@ -1,0 +1,25 @@
+# Does not delete this for now for future sidecar upgrade needs.
+# csi-provisioner
+# "--leader-election-type=leases"
+- op: remove
+  path: /spec/template/spec/containers/0/args/5
+
+# csi-provisioner
+# "--enable-leader-election"
+- op: remove
+  path: /spec/template/spec/containers/0/args/4
+
+# csi-provisioner
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-election"
+
+# csi-provisioner
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--default-fstype=ext4"
+
+# csi-resizer
+- op: add
+  path: /spec/template/spec/containers/2/args/-
+  value: "--handle-volume-inuse-error=false"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
/kind bug

**What this PR does / why we need it**:
This PR revert the change to staging-rc on the sidecar upgrades as the sidecar upgrades only apply for v1.17+ and that will break current testing for v1.15 and v1.16. So until we properly set the overlay, we will not upgrade these.

Only keep csi-snapshotter to the latest version as it does not rely on k8s version and the v3 snapshotter has some test flakiness fix.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @jingxu97 
/cc @msau42 
