### PR TITLE
Update dev overlay so that image overwrite can work

### DIFF
--- a/deploy/kubernetes/overlays/dev/kustomization.yaml
+++ b/deploy/kubernetes/overlays/dev/kustomization.yaml
@@ -1,11 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources:
-- ../alpha
 patchesStrategicMerge:
 - controller_always_pull.yaml
 - node_always_pull.yaml
 namespace: gce-pd-csi-driver
+resources:
+- ../../base/
+# Here dev overlay is using the same image as alpha
+transformers:
+- ../../images/alpha
 # To change the dev image, add something like the following.
 #images:
 #- name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver

--- a/deploy/kubernetes/overlays/noauth/kustomization.yaml
+++ b/deploy/kubernetes/overlays/noauth/kustomization.yaml
@@ -1,7 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../dev
+- ../../base/
+# Here noauth overlay is using the same image as alpha
+transformers:
+- ../../images/alpha
 patchesStrategicMerge:
 - noauth.yaml
 namespace: gce-pd-csi-driver
+# To change the dev image, add something like the following.
+#images:
+#- name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
+#  newName: gcr.io/mattcary-gke-dev-owned/csi/gce-pd-driver
+#  newTag: latest.


### PR DESCRIPTION
After PR https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/610 change, in current dev overlay, kustomization will not work well with image
setting (overwriting)

Modify the structure to fix it.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #650
Fixes #649

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
