### PR TITLE
Use node version on GKE when detecting XFS compatibility

### DIFF
--- a/test/k8s-integration/driver-config.go
+++ b/test/k8s-integration/driver-config.go
@@ -86,7 +86,14 @@ func generateDriverConfigFile(testParams *testParameters, storageClassFile strin
 	switch testParams.deploymentStrategy {
 	case "gke":
 		if testParams.imageType == "cos" {
-			gkeVer := mustParseVersion(testParams.clusterVersion)
+			var gkeVer *version
+			// The node version is what matters for XFS support. If the node version is not given, we assume
+			// it's the same as the cluster master version.
+			if testParams.nodeVersion != "" {
+				gkeVer = mustParseVersion(testParams.nodeVersion)
+			} else {
+				gkeVer = mustParseVersion(testParams.clusterVersion)
+			}
 			if gkeVer.lessThan(mustParseVersion("1.18.0")) {
 				// XFS is not supported on COS before 1.18.0
 			} else {

--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -94,6 +94,7 @@ type testParameters struct {
 	allowedNotReadyNodes int
 	useGKEManagedDriver  bool
 	clusterVersion       string
+	nodeVersion          string
 	imageType            string
 }
 
@@ -450,6 +451,7 @@ func handle() error {
 		testParams.testSkip = generateGCETestSkip(testParams)
 	case "gke":
 		testParams.testSkip = generateGKETestSkip(testParams)
+		testParams.nodeVersion = *gkeNodeVersion
 	default:
 		return fmt.Errorf("Unknown deployment strategy %s", testParams.deploymentStrategy)
 	}


### PR DESCRIPTION

/kind bug

**What this PR does / why we need it**:
Use node version when detecting XFS compatibility for testing on GKE

```release-note
NONE
```
