### PR TITLE
Shorten the GKE cluster name

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -47,7 +47,7 @@ var (
 	numNodes           = flag.Int("num-nodes", -1, "the number of nodes in the test cluster")
 	imageType          = flag.String("image-type", "cos", "the image type to use for the cluster")
 	gkeReleaseChannel  = flag.String("gke-release-channel", "", "GKE release channel to be used for cluster deploy. One of 'rapid', 'stable' or 'regular'")
-	gkeTestClusterName = flag.String("gke-cluster-name", "gcp-pd-csi-driver-test-cluster", "GKE cluster name")
+	gkeTestClusterName = flag.String("gke-cluster-name", "gcp-pd-csi-cluster", "GKE cluster name")
 	gkeNodeVersion     = flag.String("gke-node-version", "", "GKE cluster worker node version")
 	isRegionalCluster  = flag.Bool("is-regional-cluster", false, "tell the test that a regional cluster is being used. Should be used for running on an existing regional cluster (ie, --bringup-cluster=false). The test will fail if a zonal GKE cluster is created when this flag is true")
 


### PR DESCRIPTION
Some intree tests create disks with names which is a combination of
cluster name + UUID, and exceeds the 63 chars limit of disk resources

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fix in-tree tests run on GKE clusters

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
For reference of how the pd name is created: https://github.com/kubernetes/kubernetes/blob/master/test/e2e/framework/providers/gce/gce.go#L208
Without this fix, the disk resource name is something like this `gke-gcp-pd-csi-driver-test-cluster-8ac691ac-4d1f-41ed-9d6c-e528d0101609` which results in error ```Invalid value for field 'resource.name': 'gke-gcp-pd-csi-driver-test-cluster-8ac691ac-4d1f-41ed-9d6c-e528d0101609'. Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
