### PR TITLE
disable gke deployment for clusters with installation by default if GKE deployment is not requested

### DIFF
--- a/test/k8s-integration/version.go
+++ b/test/k8s-integration/version.go
@@ -105,6 +105,7 @@ func parseVersion(vs string) (*version, error) {
 	return &v, nil
 }
 
+// mustParseVersion parses a GKE cluster version.
 func mustParseVersion(version string) *version {
 	v, err := parseVersion(version)
 	if err != nil {
@@ -133,4 +134,9 @@ func (v *version) compare(right *version) int {
 // Compare versions if left is strictly less than right.
 func (v *version) lessThan(right *version) bool {
 	return v.compare(right) < 0
+}
+
+// Compare versions if left is greater than or equal to right.
+func (v *version) atLeast(right *version) bool {
+	return v.compare(right) >= 0
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**: 1.18 driver tests are failing when an overlay is used in a GKE deployment because the GKE deployment is enabled by default. This PR explicitly disables it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/assign @saikat-royc 