### PR TITLE
Round up pdcsi driver size in CreateVolume

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -49,9 +49,17 @@ const (
 	regionalDeviceNameSuffix = "_regional"
 )
 
-func BytesToGb(bytes int64) int64 {
+func BytesToGbRoundDown(bytes int64) int64 {
 	// TODO: Throw an error when div to 0
 	return bytes / (1024 * 1024 * 1024)
+}
+
+func BytesToGbRoundUp(bytes int64) int64 {
+	re := bytes / (1024 * 1024 * 1024)
+	if (bytes % (1024 * 1024 * 1024)) != 0 {
+		re++
+	}
+	return re
 }
 
 func GbToBytes(Gb int64) int64 {

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -29,7 +29,7 @@ const (
 	volIDRegionFmt = "projects/%s/regions/%s/disks/%s"
 )
 
-func TestBytesToGb(t *testing.T) {
+func TestBytesToGbRoundDown(t *testing.T) {
 	testCases := []struct {
 		name  string
 		bytes int64
@@ -58,7 +58,50 @@ func TestBytesToGb(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Logf("test case: %s", tc.name)
-		gotGB := BytesToGb(tc.bytes)
+		gotGB := BytesToGbRoundDown(tc.bytes)
+
+		if gotGB != tc.expGB {
+			t.Errorf("got GB %v, expected %v", gotGB, tc.expGB)
+		}
+
+	}
+}
+
+func TestBytesToGbRoundUp(t *testing.T) {
+	testCases := []struct {
+		name  string
+		bytes int64
+		expGB int64
+	}{
+		{
+			name:  "normal 5gb",
+			bytes: 5368709120,
+			expGB: 5,
+		},
+		{
+			name:  "slightly less than 5gb",
+			bytes: 5368709119,
+			expGB: 5,
+		},
+		{
+			name:  "slightly more than 5gb",
+			bytes: 5368709121,
+			expGB: 6,
+		},
+		{
+			name:  "1.5Gi",
+			bytes: 1610612736,
+			expGB: 2,
+		},
+		{
+			name:  "zero",
+			bytes: 0,
+			expGB: 0,
+		},
+	}
+	for _, tc := range testCases {
+		t.Logf("test case: %s", tc.name)
+		gotGB := BytesToGbRoundUp(tc.bytes)
 
 		if gotGB != tc.expGB {
 			t.Errorf("got GB %v, expected %v", gotGB, tc.expGB)

--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -262,7 +262,7 @@ func (cloud *FakeCloudProvider) InsertDisk(ctx context.Context, volKey *meta.Key
 
 	computeDisk := &computev1.Disk{
 		Name:             volKey.Name,
-		SizeGb:           common.BytesToGb(capBytes),
+		SizeGb:           common.BytesToGbRoundUp(capBytes),
 		Description:      "Disk created by GCE-PD CSI Driver",
 		Type:             cloud.GetDiskTypeURI(volKey, params.DiskType),
 		SourceSnapshotId: snapshotID,
@@ -414,9 +414,11 @@ func (cloud *FakeCloudProvider) ResizeDisk(ctx context.Context, volKey *meta.Key
 		return -1, notFoundError()
 	}
 
-	disk.setSizeGb(common.BytesToGb(requestBytes))
+	requestSizGb := common.BytesToGbRoundUp(requestBytes)
 
-	return common.BytesToGb(requestBytes), nil
+	disk.setSizeGb(requestSizGb)
+
+	return requestSizGb, nil
 
 }
 

--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -381,7 +381,7 @@ func (cloud *CloudProvider) insertRegionalDisk(
 
 	diskToCreate := &computev1.Disk{
 		Name:        volKey.Name,
-		SizeGb:      common.BytesToGb(capBytes),
+		SizeGb:      common.BytesToGbRoundUp(capBytes),
 		Description: description,
 		Type:        cloud.GetDiskTypeURI(volKey, params.DiskType),
 	}
@@ -474,7 +474,7 @@ func (cloud *CloudProvider) insertZonalDisk(
 
 	diskToCreate := &computev1.Disk{
 		Name:        volKey.Name,
-		SizeGb:      common.BytesToGb(capBytes),
+		SizeGb:      common.BytesToGbRoundUp(capBytes),
 		Description: description,
 		Type:        cloud.GetDiskTypeURI(volKey, params.DiskType),
 	}
@@ -815,7 +815,7 @@ func (cloud *CloudProvider) ResizeDisk(ctx context.Context, volKey *meta.Key, re
 	}
 
 	sizeGb := cloudDisk.GetSizeGb()
-	requestGb := common.BytesToGb(requestBytes)
+	requestGb := common.BytesToGbRoundUp(requestBytes)
 
 	// If disk is already of size equal or greater than requested size, we
 	// simply return the found size

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -182,7 +182,7 @@ func (gceCS *GCEControllerServer) CreateVolume(ctx context.Context, req *csi.Cre
 
 		// If there is no validation error, immediately return success
 		klog.V(4).Infof("CreateVolume succeeded for disk %v, it already exists and was compatible", volKey)
-		return generateCreateVolumeResponse(existingDisk, capBytes, zones), nil
+		return generateCreateVolumeResponse(existingDisk, zones), nil
 	}
 
 	snapshotID := ""
@@ -234,7 +234,7 @@ func (gceCS *GCEControllerServer) CreateVolume(ctx context.Context, req *csi.Cre
 	}
 
 	klog.V(4).Infof("CreateVolume succeeded for disk %v", volKey)
-	return generateCreateVolumeResponse(disk, capBytes, zones), nil
+	return generateCreateVolumeResponse(disk, zones), nil
 
 }
 
@@ -979,16 +979,17 @@ func getDefaultZonesInRegion(ctx context.Context, gceCS *GCEControllerServer, ex
 	return ret, nil
 }
 
-func generateCreateVolumeResponse(disk *gce.CloudDisk, capBytes int64, zones []string) *csi.CreateVolumeResponse {
+func generateCreateVolumeResponse(disk *gce.CloudDisk, zones []string) *csi.CreateVolumeResponse {
 	tops := []*csi.Topology{}
 	for _, zone := range zones {
 		tops = append(tops, &csi.Topology{
 			Segments: map[string]string{common.TopologyKeyZone: zone},
 		})
 	}
+	realDiskSizeBytes := common.GbToBytes(disk.GetSizeGb())
 	createResp := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
-			CapacityBytes:      capBytes,
+			CapacityBytes:      realDiskSizeBytes,
 			VolumeId:           cleanSelfLink(disk.GetSelfLink()),
 			VolumeContext:      nil,
 			AccessibleTopology: tops,

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -210,7 +210,7 @@ func GetBlockSizeInGb(instance *remote.InstanceInfo, devicePath string) (int64, 
 	if err != nil {
 		return -1, fmt.Errorf("failed to parse size %s into int", output)
 	}
-	return utilcommon.BytesToGb(n), nil
+	return utilcommon.BytesToGbRoundDown(n), nil
 }
 
 func Symlink(instance *remote.InstanceInfo, src, dest string) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently if we create a PVC of size 1.5Gi, the pdcsi driver will convert it to 1Gi but the provisioner will say it is 2Gi[1]. And both of them are not accurate. From the CSI spec, we know that we should provide size larger than the requested size. So if user ask for 1.5Gi, we should give them at least 1.5Gi. 

This PR changes the RoundDown behavior of CreateVolume to RoundUp. This is to align with the CreateVolume CSI spec that when the required_bytes is set, the driver should provision something bigger.

[1] https://github.com/kubernetes-csi/external-provisioner/issues/199

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix a bug that CreateVolume should round up the request_bytes.
```

/cc @msau42 
/cc @saikat-royc 
/assign @mattcary 
