### PR TITLE
Change supported dev version to 1.17+ only, due to CSINode v1 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This plugin is compatible with CSI versions [v1.2.0](https://github.com/containe
 | v0.6.x (beta)                        | no            | no   | no   | yes  | yes  | yes   | yes   |
 | v0.7.x (beta)                        | no            | no   | no   | no   | no   | yes   | yes   |
 | v1.0.x (ga)                          | no            | no   | no   | no   | no   | no    | yes   |
-| dev                                  | no            | no   | no   | no   | no   | yes   | yes   |
+| dev                                  | no            | no   | no   | no   | no   | no    | yes   |
 
 ### Known Issues
 


### PR DESCRIPTION
/kind documentation

**What this PR does / why we need it**:
The dev overlay no longer works on pre-1.17 versions due to CSINode needing to be v1 for the recent sidecars used now in master.

```release-note
NONE
```
