### PR TITLE
Windows Server 20H2 and 2004 support, configurable base layer versions.

### DIFF
--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 ARG BASE_IMAGE
-ARG BASE_IMAGE_TAG
 FROM --platform=$BUILDPLATFORM golang:1.13.4 AS builder
 
 ARG TARGETPLATFORM
@@ -23,7 +22,7 @@ WORKDIR /code
 ADD . /code/
 RUN cd /code/ && GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') GCE_PD_CSI_STAGING_VERSION=${STAGINGVERSION} make gce-pd-driver-windows
 
-FROM mcr.microsoft.com/windows/${BASE_IMAGE}:${BASE_IMAGE_TAG}
+FROM ${BASE_IMAGE}
 LABEL description="PD CSI driver"
 COPY --from=builder /code/bin/gce-pd-csi-driver.exe /gce-pd-csi-driver.exe
 

--- a/manifest_osversion.sh
+++ b/manifest_osversion.sh
@@ -6,26 +6,28 @@
 # replace the following with annotation approach. https://github.com/docker/cli/pull/2578
 
 export DOCKER_CLI_EXPERIMENTAL=enabled
-_WINDOWS_VERSIONS="1909 ltsc2019"
+_WINDOWS_VERSIONS="20H2 2004 1909 ltsc2019"
 BASE="mcr.microsoft.com/windows/servercore"
 
-IFS=', ' read -r -a osversions <<< "$_WINDOWS_VERSIONS"
+IFS=', ' read -r -a imagetags <<< "$WINDOWS_IMAGE_TAGS"
+IFS=', ' read -r -a baseimages <<< "$WINDOWS_BASE_IMAGES"
 MANIFEST_TAG=${STAGINGIMAGE}:${STAGINGVERSION}
 
 # translate from image tag to docker manifest foler format
 # e.g., gcr.io_k8s-staging-csi_gce-pd-windows-v2
 manifest_folder=$(echo "${MANIFEST_TAG}" | sed "s|/|_|g" | sed "s/:/-/")
 echo ${manifest_folder}
-echo ${#osversions[@]}
+echo ${#imagetags[@]}
+echo ${#baseimages[@]}
 
-for ((i=0;i<${#osversions[@]};++i)); do
-  BASEIMAGE="${BASE}:${osversions[i]}"
+for ((i=0;i<${#imagetags[@]};++i)); do
+  BASEIMAGE="${baseimages[i]}"
   echo $BASEIIMAGE
 
   full_version=$(docker manifest inspect ${BASEIMAGE} | grep "os.version" | head -n 1 | awk '{print $2}') || true
   echo $full_version
 
-  IMAGETAG=${STAGINGIMAGE}-${osversions[i]}:${STAGINGVERSION}
+  IMAGETAG=${STAGINGIMAGE}:${STAGINGVERSION}_${imagetags[i]}
   image_folder=$(echo "${IMAGETAG}" | sed "s|/|_|g" | sed "s/:/-/")
   echo ${manifest_folder}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Newer versions of Kubernetes will support Windows Server 2004 and 20H2.
This PR also adds the support to pick a specific tag within a release band so that builds across CI runs can be consistent.
Lastly, this PR also changes the tagging for the OS specific images in the multi-arch build. There's a small chance this can cause some disruption but it's low. This change was necessary because of the `20H2` version suffix. The capital H is rejected in the image name but ok for tag. This change does reduce the image repository count so there's a benefit to moving the OS suffix from the image name to the tag.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #690

**Special notes for your reviewer**:

This change needs to go in relatively soon because Windows Server 1909 will be EOL in a few months and we'll need some lead time to release this.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added Support for Windows Server 2004 and 20H2.
```
