### PR TITLE
Staging RC overlay: Bump all sidecar versions to latest

### DIFF
--- a/deploy/kubernetes/images/prow-gke-release-staging-rc/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc/image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: imagetag-csi-provisioner-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-provisioner
-  newTag: "v2.0.4"
+  newTag: "v2.1.0"
 ---
 
 apiVersion: builtin
@@ -13,7 +13,7 @@ metadata:
   name: imagetag-csi-attacher-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-attacher
-  newTag: "v3.0.1"
+  newTag: "v3.1.0"
 ---
 
 apiVersion: builtin
@@ -22,7 +22,7 @@ metadata:
   name: imagetag-csi-resize-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-resizer
-  newTag: "v1.0.1"
+  newTag: "v1.1.0"
 ---
 
 apiVersion: builtin
@@ -32,7 +32,7 @@ metadata:
 imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   newName: gcr.io/gke-release-staging/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.2.0-rc1"
+  newTag: "v1.2.0"
 ---
 
 apiVersion: builtin
@@ -41,7 +41,7 @@ metadata:
   name: imagetag-csi-node-registrar-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-  newTag: "v2.0.1"
+  newTag: "v2.1.0"
 ---
 
 apiVersion: builtin
@@ -50,6 +50,6 @@ metadata:
   name: imagetag-csi-snapshotter-prow-head
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-snapshotter
-  newTag: "v3.0.1"
+  newTag: "v3.0.3"
 ---
 

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc/controller_patches.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc/controller_patches.yaml
@@ -1,0 +1,62 @@
+# for external-provisioner
+- op: replace
+  path: /spec/template/spec/containers/0/args/3
+  value: "--http-endpoint=:22011"
+- op: add
+  path: /spec/template/spec/containers/0/ports
+  value:
+  - containerPort: 22011
+    name: http-endpoint
+    protocol: TCP
+- op: add
+  path: /spec/template/spec/containers/0/livenessProbe
+  value:
+    failureThreshold: 1
+    httpGet:
+      path: /healthz/leader-election
+      port: http-endpoint
+    initialDelaySeconds: 10
+    timeoutSeconds: 10
+    periodSeconds: 20
+
+# for external-attacher
+- op: replace
+  path: /spec/template/spec/containers/1/args/2
+  value: "--http-endpoint=:22012"
+- op: add
+  path: /spec/template/spec/containers/1/ports
+  value:
+  - containerPort: 22012
+    name: http-endpoint
+    protocol: TCP
+- op: add
+  path: /spec/template/spec/containers/1/livenessProbe
+  value:
+    failureThreshold: 1
+    httpGet:
+      path: /healthz/leader-election
+      port: http-endpoint
+    initialDelaySeconds: 10
+    timeoutSeconds: 10
+    periodSeconds: 20
+
+# for external-resizer
+- op: replace
+  path: /spec/template/spec/containers/2/args/2
+  value: "--http-endpoint=:22013"
+- op: add
+  path: /spec/template/spec/containers/2/ports
+  value:
+  - containerPort: 22013
+    name: http-endpoint
+    protocol: TCP
+- op: add
+  path: /spec/template/spec/containers/2/livenessProbe
+  value:
+    failureThreshold: 1
+    httpGet:
+      path: /healthz/leader-election
+      port: http-endpoint
+    initialDelaySeconds: 10
+    timeoutSeconds: 10
+    periodSeconds: 20

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc/kustomization.yaml
@@ -4,3 +4,10 @@ resources:
 - ../stable
 transformers:
 - ../../images/prow-gke-release-staging-rc
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: csi-gce-pd-controller
+  path: controller_patches.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Snapshotter is updated to 3.0.3 because 4.0.0 is 1.20+

Node sidecar flag changes are ignored because:
* Node sidecar liveness probes should be changed to exec-based so they don't consume ports on user nodes.
* Metrics manager in livenessprobe sidecar is only measuring probe CSI calls it seems.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/assign @saikat-royc @mattcary 
/cc @msau42 