### PR TITLE
Enable windows driver components for k8s minor staging overlays

### DIFF
--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-16/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-16/image.yaml
@@ -32,7 +32,7 @@ metadata:
 imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   newName: gcr.io/gke-release-staging/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.2.0"
+  newTag: "v1.2.0-gke.8"
 ---
 
 apiVersion: builtin

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-17/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-17/image.yaml
@@ -32,7 +32,7 @@ metadata:
 imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   newName: gcr.io/gke-release-staging/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.2.0"
+  newTag: "v1.2.0-gke.8"
 ---
 
 apiVersion: builtin

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-18/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-18/image.yaml
@@ -32,7 +32,7 @@ metadata:
 imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   newName: gcr.io/gke-release-staging/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.2.0"
+  newTag: "v1.2.0-gke.8"
 ---
 
 apiVersion: builtin

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-19/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-19/image.yaml
@@ -32,7 +32,7 @@ metadata:
 imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   newName: gcr.io/gke-release-staging/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.2.0"
+  newTag: "v1.2.0-gke.8"
 ---
 
 apiVersion: builtin

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-master/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-master/image.yaml
@@ -32,7 +32,7 @@ metadata:
 imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   newName: gcr.io/gke-release-staging/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.2.0"
+  newTag: "v1.2.0-gke.8"
 ---
 
 apiVersion: builtin

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-18/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-18/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace:
+  gce-pd-csi-driver
 resources:
-- ../stable-1-18
+- ../../base
 transformers:
 - ../../images/prow-gke-release-staging-rc-1-18

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-19/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc-1-19/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace:
+  gce-pd-csi-driver
 resources:
-- ../stable-1-19
+- ../../base
 transformers:
 - ../../images/prow-gke-release-staging-rc-1-19

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc-master/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc-master/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace:
+  gce-pd-csi-driver
 resources:
-- ../stable-master
+- ../../base
 transformers:
 - ../../images/prow-gke-release-staging-rc-master


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
1. Bump staging images to use latest 1.2.0-gke.8 driver image
2. Enable windows driver components

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
