### PR TITLE
Switch the integration scripts and deploy driver scripts default overlays

### DIFF
--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -4,18 +4,21 @@
 
 The current structure for kustomization is as follows. Note that Windows support is currently an alpha feature.
 
-* `base`: it contains the setup that is common to different driver versions.
-  * `controller_setup`: includes cluster setup and controller yaml files.
+* `base`: It contains the setup that is common to different driver versions.
+  * `controller_setup`: Includes cluster setup and controller yaml files.
   * `node_setup`:
-    * Linux: includes node yaml file and related setting that is only applicable for Linux.
-    * Windows: includes node yaml file and related setting that is only applicable for Windows.
-* `images`: it has a list of images for different versions.
-  * `stable`: image list of a stable driver release. Currently only has image list for Linux stable version.
-  * `alpha`: image list containing features in development, in addition to images in stable. It also includes Windows images.
-  * `dev`: based on alpha, and also contains the developer's image for use in driver development.
-  * `prow-gke-release-xxx`: image list used for Prow tests. Currently only Linux is supported.
-* `overlays`: it has the version-specific setup. Each overlay corresponds to image lists with the matching name.
-  * `stable`: contains deployment specs of a stable driver release. Currently only Linux is supported.
-  * `alpha`: contains deployment specs for features in development. Both Linux and Windows are supported. 
-  * `dev`: based on alpha, and also contains the developer's specs for use in driver development.
-  * `prow-gke-release-xxx`: based on stable, and contains specs for Prow tests. Currently only Linux is supported.
+    * Linux: Includes node yaml file and related setting that is only applicable for Linux.
+    * Windows: Includes node yaml file and related setting that is only applicable for Windows.
+* `images`: It has a list of images for different versions.
+  * `stable-master`: Image list of a stable driver for latest k8s master.
+  * `alpha`: Image list containing features in development, in addition to images in `stable-master`. It also includes Windows images.
+  * `prow-gke-release-xxx`: Image list used for Prow tests.
+* `overlays`: It has the k8s minor version-specific driver manifest bundle.
+  * `stable-master`: Contains deployment specs of a stable driver for k8s master.
+  * `stable-{k8s-minor}`: Contains deployment specs of a stable driver for given k8s minor version release.
+  * `alpha`: Contains deployment specs for features in development. Both Linux and Windows are supported. 
+  * `dev`: Based on alpha, and also contains the developer's specs for use in driver development.
+  * `prow-gke-release-staging-rc-master`: Used for prow tests. Contains deployment specs of a driver for latest k8s master.
+  * `prow-gke-release-staging-rc-{k8s-minor}`: Used for prow tests. Contains deployment specs of a driver for given k8s    minor version release.
+  * `prow-gke-release-staging-rc-head`: Used for prow tests. Contains deployment specs of a driver with latest sidecar images, for latest k8s master.
+  * `stable`, `prow-gke-release-staging-rc`: Soon to be removed!

--- a/deploy/kubernetes/delete-driver.sh
+++ b/deploy/kubernetes/delete-driver.sh
@@ -5,13 +5,13 @@
 #
 # Args:
 # GCE_PD_DRIVER_VERSION: The kustomize overlay to deploy (located under
-#   deploy/kubernetes/overlays). Can be one of {stable, dev}
+#   deploy/kubernetes/overlays).
 
 set -o nounset
 set -o errexit
 
 readonly NAMESPACE="${GCE_PD_DRIVER_NAMESPACE:-gce-pd-csi-driver}"
-readonly DEPLOY_VERSION="${GCE_PD_DRIVER_VERSION:-stable}"
+readonly DEPLOY_VERSION="${GCE_PD_DRIVER_VERSION:-stable-master}"
 readonly PKGDIR="${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
 source "${PKGDIR}/deploy/common.sh"
 

--- a/deploy/kubernetes/deploy-driver.sh
+++ b/deploy/kubernetes/deploy-driver.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -x
 
 readonly NAMESPACE="${GCE_PD_DRIVER_NAMESPACE:-gce-pd-csi-driver}"
-readonly DEPLOY_VERSION="${GCE_PD_DRIVER_VERSION:-stable}"
+readonly DEPLOY_VERSION="${GCE_PD_DRIVER_VERSION:-stable-master}"
 readonly PKGDIR="${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
 source "${PKGDIR}/deploy/common.sh"
 

--- a/deploy/kubernetes/images/alpha/kustomization.yaml
+++ b/deploy/kubernetes/images/alpha/kustomization.yaml
@@ -1,5 +1,5 @@
 namespace:
   gce-pd-csi-driver
 resources:
-- ../stable/
+- ../stable-master/
 - image.yaml

--- a/deploy/kubernetes/overlays/prow-gke-release-staging-head/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-head/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../stable
+- ../stable-master
 transformers:
 - ../../images/prow-gke-release-staging-head

--- a/test/run-k8s-integration-ci.sh
+++ b/test/run-k8s-integration-ci.sh
@@ -10,7 +10,7 @@ set -o nounset
 set -o errexit
 
 readonly PKGDIR=${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
-readonly overlay_name="${GCE_PD_OVERLAY_NAME:-stable}"
+readonly overlay_name="${GCE_PD_OVERLAY_NAME:-stable-master}"
 readonly boskos_resource_type="${GCE_PD_BOSKOS_RESOURCE_TYPE:-gce-project}"
 readonly do_driver_build="${GCE_PD_DO_DRIVER_BUILD:-true}"
 readonly deployment_strategy=${DEPLOYMENT_STRATEGY:-gce}

--- a/test/run-k8s-integration-migration.sh
+++ b/test/run-k8s-integration-migration.sh
@@ -13,7 +13,7 @@ export GCE_PD_VERBOSITY=9
 
 readonly PKGDIR=${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 
-readonly overlay_name="${GCE_PD_OVERLAY_NAME:-stable}"
+readonly overlay_name="${GCE_PD_OVERLAY_NAME:-stable-master}"
 readonly boskos_resource_type="${GCE_PD_BOSKOS_RESOURCE_TYPE:-gce-project}"
 readonly do_driver_build="${GCE_PD_DO_DRIVER_BUILD:-true}"
 readonly deployment_strategy=${DEPLOYMENT_STRATEGY:-gce}

--- a/test/run-k8s-integration.sh
+++ b/test/run-k8s-integration.sh
@@ -10,7 +10,7 @@ set -o nounset
 set -o errexit
 
 readonly PKGDIR=${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
-readonly overlay_name="${GCE_PD_OVERLAY_NAME:-stable}"
+readonly overlay_name="${GCE_PD_OVERLAY_NAME:-stable-master}"
 readonly boskos_resource_type="${GCE_PD_BOSKOS_RESOURCE_TYPE:-gce-project}"
 readonly do_driver_build="${GCE_PD_DO_DRIVER_BUILD:-true}"
 readonly deployment_strategy=${DEPLOYMENT_STRATEGY:-gce}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This patch will switch the existing presubmit and CI jobs to use stable-master instead of stable.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Please let me know if I missed out on any prow job configs.
So far I checked
1. internal GKE test grids
2. https://k8s-testgrid.appspot.com/provider-gcp-compute-persistent-disk-csi-driver
3. Configs for presubmits defined [here](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml). The presubmit `pull-gcp-compute-persistent-disk-csi-driver-kubernetes-integration` against this pull request should use the stable-master.
4. windows jobs are already using stable-master

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
