### PR TITLE
Fix cluster list parsing for latest gcloud version

### DIFF
--- a/test/k8s-integration/cluster.go
+++ b/test/k8s-integration/cluster.go
@@ -145,8 +145,9 @@ func clusterUpGKE(gceZone, gceRegion string, numNodes int, imageType string, use
 		return err
 	}
 
-	out, err := exec.Command("gcloud", "container", "clusters", "list", locationArg, locationVal,
-		"--filter", fmt.Sprintf("name=%s", *gkeTestClusterName)).CombinedOutput()
+	out, err := exec.Command("gcloud", "container", "clusters", "list",
+		locationArg, locationVal, "--verbosity", "none", "--filter",
+		fmt.Sprintf("name=%s", *gkeTestClusterName)).CombinedOutput()
 
 	if err != nil {
 		return fmt.Errorf("failed to check for previous test cluster: %v %s", err, out)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**: Prow tests are failing with the latest kubekins image because in the latest gcloud version, `gcloud container clusters list --filter name=<cluster_name>` prints one line of warning instead of returning empty, which makes the k8s-integration binary to proceed to cluster deletion, and fail when the cluster doesn't actually exist.

This PR is a short term solution. Long term solution would be moving to the cloud SDK (#680).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
