### PR TITLE
Set major & minor version in docker version defs

### DIFF
--- a/test/k8s-integration/.dockerized-kube-version-defs
+++ b/test/k8s-integration/.dockerized-kube-version-defs
@@ -1,5 +1,5 @@
 KUBE_GIT_COMMIT='somefakecommit'
 KUBE_GIT_TREE_STATE='dirty'
 KUBE_GIT_VERSION='v888.888.888-fake-testing-master.version'
-KUBE_GIT_MAJOR='888'
-KUBE_GIT_MINOR='888+'
+KUBE_GIT_MAJOR='1'
+KUBE_GIT_MINOR='21+'


### PR DESCRIPTION
This should get kube-up used by the integration tests temporarily working. It appears the old fake 888.888 version was causing something---I haven't figured out what yet---to not get installed or activated, and node RBAC couldn't get installed.  See the issue for further details.

/kind bug

**Which issue(s) this PR fixes**:
Fixes #721

```release-note
None
```
