### PR TITLE
Add option to test without labels

### DIFF
--- a/test/k8s-integration/config/sc-standard-no-labels.yaml
+++ b/test/k8s-integration/config/sc-standard-no-labels.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-gcepd
+provisioner: pd.csi.storage.gke.io
+parameters:
+  type: pd-standard
+volumeBindingMode: WaitForFirstConsumer

--- a/test/run-k8s-integration-ci.sh
+++ b/test/run-k8s-integration-ci.sh
@@ -26,8 +26,15 @@ readonly teardown_driver=${GCE_PD_TEARDOWN_DRIVER:-true}
 readonly gke_node_version=${GKE_NODE_VERSION:-}
 readonly run_intree_plugin_tests=${RUN_INTREE_PLUGIN_TESTS:-false}
 readonly use_kubetest2=${USE_KUBETEST2:-false}
+readonly test_pd_labels=${TEST_PD_LABELS:-true}
 
-storage_classes=sc-standard.yaml,sc-balanced.yaml,sc-ssd.yaml
+storage_classes=sc-balanced.yaml,sc-ssd.yaml
+
+if [[ $test_pd_labels = true ]] ; then
+  storage_classes=${storage_classes},sc-standard.yaml
+else
+  storage_classes=${storage_classes},sc-standard-no-labels.yaml
+fi
 
 if [[ -n $gce_region ]] ; then
   storage_classes="${storage_classes}",sc-regional.yaml


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Until the managed driver on platforms like GKE catch up their driver version in test environments, the label testing needs to have an option for disabling. See also #727.

```release-note
NONE
```
