### PR TITLE
Add a param for full GKE cluster name.

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -32,24 +32,25 @@ import (
 
 var (
 	// Kubernetes cluster flags
-	teardownCluster    = flag.Bool("teardown-cluster", true, "teardown the cluster after the e2e test")
-	teardownDriver     = flag.Bool("teardown-driver", true, "teardown the driver after the e2e test")
-	bringupCluster     = flag.Bool("bringup-cluster", true, "build kubernetes and bringup a cluster")
-	platform           = flag.String("platform", "linux", "platform that the tests will be run, either linux or windows")
-	gceZone            = flag.String("gce-zone", "", "zone that the gce k8s cluster is created/found in")
-	gceRegion          = flag.String("gce-region", "", "region that gke regional cluster should be created in")
-	kubeVersion        = flag.String("kube-version", "", "version of Kubernetes to download and use for the cluster")
-	testVersion        = flag.String("test-version", "", "version of Kubernetes to download and use for tests")
-	kubeFeatureGates   = flag.String("kube-feature-gates", "", "feature gates to set on new kubernetes cluster")
-	localK8sDir        = flag.String("local-k8s-dir", "", "local prebuilt kubernetes/kubernetes directory to use for cluster and test binaries")
-	deploymentStrat    = flag.String("deployment-strategy", "gce", "choose between deploying on gce or gke")
-	gkeClusterVer      = flag.String("gke-cluster-version", "", "version of Kubernetes master and node for gke")
-	numNodes           = flag.Int("num-nodes", -1, "the number of nodes in the test cluster")
-	imageType          = flag.String("image-type", "cos", "the image type to use for the cluster")
-	gkeReleaseChannel  = flag.String("gke-release-channel", "", "GKE release channel to be used for cluster deploy. One of 'rapid', 'stable' or 'regular'")
-	gkeTestClusterName = flag.String("gke-cluster-name", "pdcsi", "Prefix of GKE cluster names. A random suffix will be appended to form the full name.")
-	gkeNodeVersion     = flag.String("gke-node-version", "", "GKE cluster worker node version")
-	isRegionalCluster  = flag.Bool("is-regional-cluster", false, "tell the test that a regional cluster is being used. Should be used for running on an existing regional cluster (ie, --bringup-cluster=false). The test will fail if a zonal GKE cluster is created when this flag is true")
+	teardownCluster      = flag.Bool("teardown-cluster", true, "teardown the cluster after the e2e test")
+	teardownDriver       = flag.Bool("teardown-driver", true, "teardown the driver after the e2e test")
+	bringupCluster       = flag.Bool("bringup-cluster", true, "build kubernetes and bringup a cluster")
+	platform             = flag.String("platform", "linux", "platform that the tests will be run, either linux or windows")
+	gceZone              = flag.String("gce-zone", "", "zone that the gce k8s cluster is created/found in")
+	gceRegion            = flag.String("gce-region", "", "region that gke regional cluster should be created in")
+	kubeVersion          = flag.String("kube-version", "", "version of Kubernetes to download and use for the cluster")
+	testVersion          = flag.String("test-version", "", "version of Kubernetes to download and use for tests")
+	kubeFeatureGates     = flag.String("kube-feature-gates", "", "feature gates to set on new kubernetes cluster")
+	localK8sDir          = flag.String("local-k8s-dir", "", "local prebuilt kubernetes/kubernetes directory to use for cluster and test binaries")
+	deploymentStrat      = flag.String("deployment-strategy", "gce", "choose between deploying on gce or gke")
+	gkeClusterVer        = flag.String("gke-cluster-version", "", "version of Kubernetes master and node for gke")
+	numNodes             = flag.Int("num-nodes", -1, "the number of nodes in the test cluster")
+	imageType            = flag.String("image-type", "cos", "the image type to use for the cluster")
+	gkeReleaseChannel    = flag.String("gke-release-channel", "", "GKE release channel to be used for cluster deploy. One of 'rapid', 'stable' or 'regular'")
+	gkeTestClusterPrefix = flag.String("gke-cluster-prefix", "pdcsi", "Prefix of GKE cluster names. A random suffix will be appended to form the full name.")
+	gkeTestClusterName   = flag.String("gke-cluster-name", "", "Name of existing cluster")
+	gkeNodeVersion       = flag.String("gke-node-version", "", "GKE cluster worker node version")
+	isRegionalCluster    = flag.Bool("is-regional-cluster", false, "tell the test that a regional cluster is being used. Should be used for running on an existing regional cluster (ie, --bringup-cluster=false). The test will fail if a zonal GKE cluster is created when this flag is true")
 
 	// Test infrastructure flags
 	boskosResourceType = flag.String("boskos-resource-type", "gce-project", "name of the boskos resource type to reserve")
@@ -164,8 +165,10 @@ func main() {
 		if len(*localK8sDir) == 0 {
 			ensureVariable(testVersion, true, "Must set either test-version or local k8s dir when using deployment strategy 'gke'.")
 		}
-		randSuffix := string(uuid.NewUUID())[0:4]
-		*gkeTestClusterName += randSuffix
+		if len(*gkeTestClusterName) == 0 {
+			randSuffix := string(uuid.NewUUID())[0:4]
+			*gkeTestClusterName = *gkeTestClusterPrefix + randSuffix
+		}
 	} else if *deploymentStrat == "gce" {
 		ensureVariable(gceRegion, false, "regional clusters not supported for 'gce' deployment")
 		ensureVariable(gceZone, true, "gce-zone required for 'gce' deployment")


### PR DESCRIPTION
Since we now use a random suffix for GKE clusters, we need another
flag for existing cluster names.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adds a new flag to the test binary so we can specify the name of an existing GKE cluster.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
