### PR TITLE
Add cloudbuild for gcp-compute-persistent-disk-csi-drive - cherry pick #724

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.13.4 as builder
+FROM golang:1.13.15 as builder
 WORKDIR /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 ADD . .
 RUN make
@@ -22,7 +22,7 @@ FROM k8s.gcr.io/build-image/debian-base-amd64:v2.1.3 as base
 RUN clean-install udev
 
 # Start from Kubernetes Debian base
-FROM k8s.gcr.io/build-image/debian-base-amd64:v2.1.3 
+FROM k8s.gcr.io/build-image/debian-base-amd64:v2.1.3
 COPY --from=builder /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/bin/gce-pd-csi-driver /gce-pd-csi-driver
 # Install necessary dependencies
 RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs

--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG BASE_IMAGE
-FROM --platform=$BUILDPLATFORM golang:1.13.4 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.13.15 AS builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,26 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+# For more information about Image pushing refer to https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md
+timeout: 3600s
+
+options:
+  substitution_option: ALLOW_LOOSE
+
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20201130-750d12f'
+    entrypoint: make
+    env:
+    - GCE_PD_CSI_STAGING_IMAGE=gcr.io/${_STAGING_PROJECT}/gcp-compute-persistent-disk-csi-driver
+    - GCE_PD_CSI_STAGING_VERSION=${_PULL_BASE_REF}
+    # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx
+    # set the home to /root explicitly to if using docker buildx
+    - HOME=/root
+    args:
+      - build-and-push-multi-arch
+
+substitutions:
+  _STAGING_PROJECT: 'k8s-staging-cloud-provider-gcp'
+  _PULL_BASE_REF: 'master'
+
+tags:
+- 'gcp-compute-persistent-disk-csi-driver'
+- ${_PULL_BASE_REF}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
To build the image `gcr.io/k8s-staging-cloud-provider-gcp/gcp-compute-persistent-disk-csi-drive,` we need to cherry-pick the changes made in the main branch to the release-1.2 branch.

Because when the RC1 tag was generated (https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/releases/tag/v1.2.1-rc1), the prow job to build the image for the tag/release branch failed: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-gcp-compute-persistent-disk-csi-driver-push-images/1375144655808630784 because there is no cloudbuild in the branch.

this PR is a cherry-pick of
- https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/724


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes,` please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended-release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/assign @saad-ali @mattcary @msau42 