### PR TITLE
Update Stable overlay and Changelogs for 1.2.1 driver image

### DIFF
--- a/CHANGELOG/CHANGELOG-1.2.md
+++ b/CHANGELOG/CHANGELOG-1.2.md
@@ -1,3 +1,20 @@
+# v1.2.1 - Changelog since v1.2.0
+
+
+## Tests
+
+- Update kustomize to 3.9.4 ([703](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/703), [@saikat-royc](https://github.com/saikat-royc))
+- Fix cluster list parsing for latest gcloud version ([720](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/720), [@verult](https://github.com/verult))
+
+## Other
+
+- Remove Probe logging ([682](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/682), [@Jiawei0227](https://github.com/Jiawei0227))
+- Round up pdcsi driver size in CreateVolume ([684](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/684), [@Jiawei0227](https://github.com/Jiawei0227))
+- Add gce disk labels support via create volume parameters ([718](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/718), [@mattcary](https://github.com/mattcary))
+- Emit GKE PDCSI component version metric ([719](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/719), [@saikat-royc](https://github.com/saikat-royc)) 
+- Add cloudbuild configuration to build the image gcp-compute-persistent-disk-csi-driver ([734](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/734), [@cpanato](https://github.com/cpanato))
+- Bump go to the latest 1.13 available in Dockerfile ([734](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/734), [@cpanato](https://github.com/cpanato))
+
 # v1.2.0 - Changelog since v1.1.0
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ lifecycle of Google Compute Engine Persistent Disks.
 ## Project Status
 
 Status: GA
-Latest stable image: `gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver:v1.2.0-gke.0`
+Latest stable image: `gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver:v1.2.1-gke.0`
 
 ### Test Status
 

--- a/deploy/kubernetes/images/stable-1-15/image.yaml
+++ b/deploy/kubernetes/images/stable-1-15/image.yaml
@@ -42,5 +42,5 @@ imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   # Don't change stable image without changing pdImagePlaceholder in
   # test/k8s-integration/main.go
-  newTag: "v1.2.0-gke.0"
+  newTag: "v1.2.1-gke.0"
 ---

--- a/deploy/kubernetes/images/stable-1-16/image.yaml
+++ b/deploy/kubernetes/images/stable-1-16/image.yaml
@@ -42,5 +42,5 @@ imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   # Don't change stable image without changing pdImagePlaceholder in
   # test/k8s-integration/main.go
-  newTag: "v1.2.0-gke.0"
+  newTag: "v1.2.1-gke.0"
 ---

--- a/deploy/kubernetes/images/stable-1-17/image.yaml
+++ b/deploy/kubernetes/images/stable-1-17/image.yaml
@@ -51,5 +51,5 @@ imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   # Don't change stable image without changing pdImagePlaceholder in
   # test/k8s-integration/main.go
-  newTag: "v1.2.0-gke.0"
+  newTag: "v1.2.1-gke.0"
 ---

--- a/deploy/kubernetes/images/stable-1-18/image.yaml
+++ b/deploy/kubernetes/images/stable-1-18/image.yaml
@@ -51,5 +51,5 @@ imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   # Don't change stable image without changing pdImagePlaceholder in
   # test/k8s-integration/main.go
-  newTag: "v1.2.0-gke.8"
+  newTag: "v1.2.1-gke.0"
 ---

--- a/deploy/kubernetes/images/stable-1-19/image.yaml
+++ b/deploy/kubernetes/images/stable-1-19/image.yaml
@@ -51,5 +51,5 @@ imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   # Don't change stable image without changing pdImagePlaceholder in
   # test/k8s-integration/main.go
-  newTag: "v1.2.0-gke.8"
+  newTag: "v1.2.1-gke.0"
 ---

--- a/deploy/kubernetes/images/stable-master/image.yaml
+++ b/deploy/kubernetes/images/stable-master/image.yaml
@@ -51,5 +51,5 @@ imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   # Don't change stable image without changing pdImagePlaceholder in
   # test/k8s-integration/main.go
-  newTag: "v1.2.0-gke.8"
+  newTag: "v1.2.1-gke.0"
 ---


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
/kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
The internal prow tests for prow-staging-rc-{k8minor} with image v1.2.1-rc1 looks good. Hence submitting this PR to create a new release v1.2.1 for the driver image binary
.This PR updates the stable overlays driver manifest to use the yet to be release v1.2.1-gke.0 image, and the necessary changelogs/readme updates.

Link to the test grid: https://testgrid.corp.google.com/gcp-compute-persistent-disk-csi-driver 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

FYI once this PR is merged the cherry-pick will not be a clean one, since the release-1.2 does not have the per minor version overlays. In that cherry-pick I will manually update the [stable/image.yaml](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/release-1.2/deploy/kubernetes/images/stable/image.yaml) file. In future release branches (say release-1.3), the overlays per k8s minor version will be picked up.

Next steps: when this PR is merged, cherry pick to release-1.2 branch and create v1.2.1 tag. Promote the image manually to [gcr.io/gke-release](https://pantheon.corp.google.com/gcr/images/gke-release/GLOBAL/gcp-compute-persistent-disk-csi-driver?gcrImageListsize=30)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
