### PR TITLE
update image registry location

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ lifecycle of Google Compute Engine Persistent Disks.
 ## Project Status
 
 Status: GA
-Latest stable image: `gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver:v1.2.1-gke.0`
+Latest stable image: `k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.2.1`
 
 ### Test Status
 

--- a/docs/kubernetes/user-guides/snapshots.md
+++ b/docs/kubernetes/user-guides/snapshots.md
@@ -245,7 +245,7 @@ snapshot-controller and PD CSI driver:
   * gke.gcr.io/csi-attacher:v2.1.1-gke.0
   * gke.gcr.io/csi-resizer:v0.4.0-gke.0
   * gke.gcr.io/csi-snapshotter:v2.1.1-gke.0
-  * gke.gcr.io/gcp-compute-persistent-disk-csi-driver:v0.7.0-gke.0
+  * k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.2.1
 
 #### Migrating by Restoring from a Manually Provisioned Snapshot
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
The release `v1.2.1` is out and the image `gcr.io/k8s-staging-cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.2.1` is available in the staging registry and was promoted to the production registry (see https://github.com/kubernetes/k8s.io/pull/1854)

Update the docs to reflect the latest stable location

/assign @msau42 @mattcary 


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
