### PR TITLE
exit if driver master deployment fails

### DIFF
--- a/deploy/kubernetes/wait-for-driver.sh
+++ b/deploy/kubernetes/wait-for-driver.sh
@@ -24,10 +24,10 @@ while [[ -n "${1-}" ]]; do
   esac
 done
 
-kubectl wait -n gce-pd-csi-driver deployment csi-gce-pd-controller --for condition=available
+kubectl wait -n gce-pd-csi-driver deployment csi-gce-pd-controller --for condition=available || exit -1
 
 retries=90
-while [[ $retries -ge 0 ]];do
+while [[ $retries -ge 0 ]]; do
     ready=$(kubectl -n gce-pd-csi-driver get daemonset "${node_daemonset}" -o jsonpath="{.status.numberReady}")
     required=$(kubectl -n gce-pd-csi-driver get daemonset "${node_daemonset}" -o jsonpath="{.status.desiredNumberScheduled}")
     if [[ $ready -eq $required ]];then


### PR DESCRIPTION
/kind bug
/assign @saikat-royc 

**What this PR does / why we need it**:

If driver deployment on the master fails, deploy/kubernetes/wait-for-driver.sh continues successfully. This is causing many spurious error messages in tests when there are problems with the deployment.

```release-note
None
```
