### PR TITLE
Fix label test used in staging

### DIFF
--- a/deploy/kubernetes/overlays/prow-gke-release-staging-rc-master/disk_labels.yaml
+++ b/deploy/kubernetes/overlays/prow-gke-release-staging-rc-master/disk_labels.yaml
@@ -1,4 +1,4 @@
 # for gce-pd-driver
 - op: add
   path: /spec/template/spec/containers/4/args/2
-  value: "--extra-labels=csi=gce-pd-driver  # Used for testing, not to be merged to stable"
+  value: "--extra-labels=csi=gce-pd-driver"  # Used for testing, not to be merged to stable


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

The staging overlay has a bad command-line patch which tests the label command line.

```release-note
None
```
