### PR TITLE
fix missing variable when building the image on cloudbuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,19 @@
 # limitations under the License.
 
 FROM golang:1.13.15 as builder
+
+ARG STAGINGVERSION
+
 WORKDIR /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 ADD . .
-RUN make
+RUN GCE_PD_CSI_STAGING_VERSION=${STAGINGVERSION} make gce-pd-driver
 
 # MAD HACKS: Build a version first so we can take the scsi_id bin and put it somewhere else in our real build
-FROM k8s.gcr.io/build-image/debian-base-amd64:buster-v1.5.0 as mad-hack
+FROM k8s.gcr.io/build-image/debian-base-amd64:buster-v1.6.0 as mad-hack
 RUN clean-install udev
 
 # Start from Kubernetes Debian base
-FROM k8s.gcr.io/build-image/debian-base-amd64:buster-v1.5.0
+FROM k8s.gcr.io/build-image/debian-base-amd64:buster-v1.6.0
 COPY --from=builder /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/bin/gce-pd-csi-driver /gce-pd-csi-driver
 # Install necessary dependencies
 RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,8 @@
 # Args:
 # GCE_PD_CSI_STAGING_IMAGE: Staging image repository
 REV=$(shell git describe --long --tags --match='v*' --dirty 2>/dev/null || git rev-list -n1 HEAD)
-ifdef GCE_PD_CSI_STAGING_VERSION
-	STAGINGVERSION=${GCE_PD_CSI_STAGING_VERSION}
-else
-	STAGINGVERSION=${REV}
-endif
+GCE_PD_CSI_STAGING_VERSION ?= ${REV}
+STAGINGVERSION=${GCE_PD_CSI_STAGING_VERSION}
 STAGINGIMAGE=${GCE_PD_CSI_STAGING_IMAGE}
 DRIVERBINARY=gce-pd-csi-driver
 DRIVERWINDOWSBINARY=${DRIVERBINARY}.exe
@@ -45,7 +42,7 @@ gce-pd-driver-windows:
 	GOOS=windows go build -mod=vendor -ldflags -X=main.version=$(STAGINGVERSION) -o bin/${DRIVERWINDOWSBINARY} ./cmd/gce-pd-csi-driver/
 
 build-container: require-GCE_PD_CSI_STAGING_IMAGE
-	$(DOCKER) build --build-arg TAG=$(STAGINGVERSION) -t $(STAGINGIMAGE):$(STAGINGVERSION) .
+	$(DOCKER) build --build-arg STAGINGVERSION=$(STAGINGVERSION) -t $(STAGINGIMAGE):$(STAGINGVERSION) .
 
 build-and-push-windows-container-ltsc2019: require-GCE_PD_CSI_STAGING_IMAGE init-buildx
 	$(DOCKER) buildx build --file=Dockerfile.Windows --platform=windows \
@@ -82,7 +79,7 @@ push-container: build-container
 build-and-push-container-linux: require-GCE_PD_CSI_STAGING_IMAGE init-buildx
 	$(DOCKER) buildx build --platform=linux \
 		-t $(STAGINGIMAGE):$(STAGINGVERSION)_linux \
-		--build-arg TAG=$(STAGINGVERSION) --push .
+		--build-arg STAGINGVERSION=$(STAGINGVERSION) --push .
 
 test-sanity: gce-pd-driver
 	go test -mod=vendor --v -timeout 30s sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/test/sanity -run ^TestSanity$


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When we built the image `k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.2.1` we missed one parameter that needs to be set during the compilation process

This PR fix that, making it similar in how we build the image for windows.


built on my GCP account and now we can run the image without the error we saw before

```
$ docker run -it k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.2.1
F0421 13:50:23.955027       1 main.go:71] version must be set at compile time

# after the fix
$ docker run -it gcr.io/cpanato-general/gcp-compute-persistent-disk-csi-driver:v99.99.99
W0421 13:50:31.576613       1 gce.go:137] GOOGLE_APPLICATION_CREDENTIALS env var not set
F0421 13:50:31.576650       1 main.go:103] Failed to get cloud provider: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
```

We will need to release a version `v1.2.2` to fix the image issue

this PR is needed to unblock https://github.com/kubernetes/kubernetes/pull/100747

/assign @msau42 @mattcary @saikat-royc 


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
