### PR TITLE
fix missing variable when building the image on cloudbuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,23 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.13.15 as builder
+FROM --platform=$BUILDPLATFORM golang:1.13.15 as builder
 
 ARG STAGINGVERSION
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
 WORKDIR /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 ADD . .
-RUN GCE_PD_CSI_STAGING_VERSION=${STAGINGVERSION} make gce-pd-driver
+# RUN mkdir -p bin \
+#   && GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') go build -mod=vendor -ldflags "-X main.version=${STAGINGVERSION}" -o bin/gce-pd-csi-driver ./cmd/gce-pd-csi-driver/
+RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') GCE_PD_CSI_STAGING_VERSION=${STAGINGVERSION} make gce-pd-driver
 
 # MAD HACKS: Build a version first so we can take the scsi_id bin and put it somewhere else in our real build
-FROM k8s.gcr.io/build-image/debian-base-amd64:buster-v1.5.0 as mad-hack
-RUN clean-install udev
+FROM k8s.gcr.io/build-image/debian-base:buster-v1.6.0 as mad-hack
+RUN ln -s /bin/rm /usr/sbin/rm \
+  && clean-install udev
 
 # Start from Kubernetes Debian base
-FROM k8s.gcr.io/build-image/debian-base-amd64:buster-v1.5.0
+FROM k8s.gcr.io/build-image/debian-base:buster-v1.6.0
 COPY --from=builder /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/bin/gce-pd-csi-driver /gce-pd-csi-driver
 # Install necessary dependencies
-RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs
+RUN ln -s /bin/rm /usr/sbin/rm \
+  && clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs
 COPY --from=mad-hack /lib/udev/scsi_id /lib/udev_containerized/scsi_id
 
 ENTRYPOINT ["/gce-pd-csi-driver"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 FROM golang:1.13.15 as builder
+
+ARG STAGINGVERSION
+
 WORKDIR /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 ADD . .
-RUN make gce-pd-driver
+RUN GCE_PD_CSI_STAGING_VERSION=${STAGINGVERSION} make gce-pd-driver
 
 # MAD HACKS: Build a version first so we can take the scsi_id bin and put it somewhere else in our real build
 FROM k8s.gcr.io/build-image/debian-base-amd64:buster-v1.5.0 as mad-hack

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@ options:
   substitution_option: ALLOW_LOOSE
 
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20201130-750d12f'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583'
     entrypoint: make
     env:
     - GCE_PD_CSI_STAGING_IMAGE=gcr.io/${_STAGING_PROJECT}/gcp-compute-persistent-disk-csi-driver


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When we built the image `k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.2.1` we missed one parameter that needs to be set during the compilation process

This PR fix that, making it similar to how we build the image for windows.


built on my gcp account and now we can run the image without the error we saw before

```
$ docker run -it k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.2.1
F0421 13:50:23.955027       1 main.go:71] version must be set at compile time

# after the fix
$ docker run -it gcr.io/cpanato-general/gcp-compute-persistent-disk-csi-driver:v99.99.99
W0421 13:50:31.576613       1 gce.go:137] GOOGLE_APPLICATION_CREDENTIALS env var not set
F0421 13:50:31.576650       1 main.go:103] Failed to get cloud provider: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
```


/assign @msau42 @mattcary @saikat-royc 

PR for release-1.2: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/760


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
