### PR TITLE
Allow using minor version format for GKE

### DIFF
--- a/test/k8s-integration/version_test.go
+++ b/test/k8s-integration/version_test.go
@@ -66,6 +66,12 @@ func TestParseVersion(t *testing.T) {
 				version: [4]int{100, 101, 102, 103},
 			},
 		},
+		{
+			version: "1.20",
+			expectedV: version{
+				version: [4]int{1, 20, -1, -1},
+			},
+		},
 		// Negative test cases
 		{
 			version:   "1",
@@ -85,14 +91,6 @@ func TestParseVersion(t *testing.T) {
 		},
 		{
 			version:   "1.18.9-gke.-1",
-			expectErr: true,
-		},
-		{
-			version:   "1.1",
-			expectErr: true,
-		},
-		{
-			version:   "1.18",
 			expectErr: true,
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Allow tests to use GKE versions of the format X.Y, i.e. latest available for a minor version. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/771

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
