### PR TITLE
Update parallel setting for in integration test

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -70,6 +70,7 @@ var (
 	testFocus     = flag.String("test-focus", "", "test focus for Kubernetes e2e")
 
 	useKubeTest2 = flag.Bool("use-kubetest2", false, "use kubetest2 to run e2e tests")
+	parallel     = flag.Int("parallel", 10, "the number of parallel tests setting for ginkgo parallelism")
 )
 
 const (
@@ -99,6 +100,7 @@ type testParameters struct {
 	clusterVersion       string
 	nodeVersion          string
 	imageType            string
+	parallel             int
 }
 
 func init() {
@@ -200,6 +202,7 @@ func handle() error {
 		deploymentStrategy:  *deploymentStrat,
 		useGKEManagedDriver: *useGKEManagedDriver,
 		imageType:           *imageType,
+		parallel:            *parallel,
 	}
 
 	goPath, ok := os.LookupEnv("GOPATH")
@@ -663,8 +666,7 @@ func runTestsWithConfig(testParams *testParameters, testConfigArg, reportPrefix 
 	}
 	kubeTest2Args = append(kubeTest2Args, fmt.Sprintf("--focus-regex=%s", testParams.testFocus))
 	kubeTest2Args = append(kubeTest2Args, fmt.Sprintf("--skip-regex=%s", testParams.testSkip))
-	// kubetest uses 25 as default value for ginkgo parallelism (--nodes).
-	kubeTest2Args = append(kubeTest2Args, "--parallel=25")
+	kubeTest2Args = append(kubeTest2Args, fmt.Sprintf("--parallel=%d", testParams.parallel))
 	kubeTest2Args = append(kubeTest2Args, fmt.Sprintf("--test-args=%s %s", testConfigArg, windowsArgs))
 
 	if kubetestDumpDir != "" {


### PR DESCRIPTION
Current parallel setting to 25 is too high for Windows. Every node will
have about 8-10 disks are being attached and fomatted around the same
time. For Windows Disk format time could reach about 4 mins which makes
the whole pod start time exceeds 5 mins and timeout.

Set parallel to 6 for Windows

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
