### PR TITLE
Use kubetest instead of kubetest2 for CSI migration test

### DIFF
--- a/test/run-k8s-integration-migration.sh
+++ b/test/run-k8s-integration-migration.sh
@@ -19,7 +19,7 @@ readonly do_driver_build="${GCE_PD_DO_DRIVER_BUILD:-true}"
 readonly deployment_strategy=${DEPLOYMENT_STRATEGY:-gce}
 readonly kube_version=${GCE_PD_KUBE_VERSION:-master}
 readonly test_version=${TEST_VERSION:-master}
-readonly use_kubetest2=${USE_KUBETEST2:-true}
+readonly use_kubetest2=${USE_KUBETEST2:-false}
 
 make -C "${PKGDIR}" test-k8s-integration
 

--- a/test/run-k8s-windows-migration.sh
+++ b/test/run-k8s-windows-migration.sh
@@ -20,7 +20,7 @@ readonly kube_version=${GCE_PD_KUBE_VERSION:-master}
 readonly test_version=${TEST_VERSION:-master}
 readonly gce_zone=${GCE_CLUSTER_ZONE:-us-central1-b}
 readonly feature_gates="CSIMigration=true,CSIMigrationGCE=true,ExpandCSIVolumes=true"
-readonly use_kubetest2=${USE_KUBETEST2:-true}
+readonly use_kubetest2=${USE_KUBETEST2:-false}
 
 make -C "${PKGDIR}" test-k8s-integration
 


### PR DESCRIPTION
Due to kubetest2 issue, provider is not passing correctly which are
checked by in-tree test cases. For now
change back to use kubetest for migration test.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
