### PR TITLE
Revert "Use kubetest instead of kubetest2 for CSI migration test"

### DIFF
--- a/test/run-k8s-integration-migration.sh
+++ b/test/run-k8s-integration-migration.sh
@@ -19,7 +19,7 @@ readonly do_driver_build="${GCE_PD_DO_DRIVER_BUILD:-true}"
 readonly deployment_strategy=${DEPLOYMENT_STRATEGY:-gce}
 readonly kube_version=${GCE_PD_KUBE_VERSION:-master}
 readonly test_version=${TEST_VERSION:-master}
-readonly use_kubetest2=${USE_KUBETEST2:-false}
+readonly use_kubetest2=${USE_KUBETEST2:-true}
 
 make -C "${PKGDIR}" test-k8s-integration
 

--- a/test/run-k8s-windows-migration.sh
+++ b/test/run-k8s-windows-migration.sh
@@ -20,7 +20,7 @@ readonly kube_version=${GCE_PD_KUBE_VERSION:-master}
 readonly test_version=${TEST_VERSION:-master}
 readonly gce_zone=${GCE_CLUSTER_ZONE:-us-central1-b}
 readonly feature_gates="CSIMigration=true,CSIMigrationGCE=true,ExpandCSIVolumes=true"
-readonly use_kubetest2=${USE_KUBETEST2:-false}
+readonly use_kubetest2=${USE_KUBETEST2:-true}
 
 make -C "${PKGDIR}" test-k8s-integration
 


### PR DESCRIPTION
Reverts kubernetes-sigs/gcp-compute-persistent-disk-csi-driver#775

![image](https://user-images.githubusercontent.com/2010320/121119190-c77fa380-c84d-11eb-93c0-8faa3e4642c2.png)
