### PR TITLE
Disable default pd csi install

### DIFF
--- a/test/k8s-integration/cluster.go
+++ b/test/k8s-integration/cluster.go
@@ -108,6 +108,13 @@ func clusterUpGCE(k8sDir, gceZone string, numNodes int, imageType string) error 
 		}
 	}
 
+	// we shouldn't install pd-csi driver when spinning up the cluster if we launch the test
+	// from here
+	err = os.Setenv("ENABLE_PDCSI_DRIVER", "false")
+	if err != nil {
+		return err
+	}
+
 	err = os.Setenv("KUBE_GCE_ZONE", gceZone)
 	if err != nil {
 		return err


### PR DESCRIPTION
 /kind feature
because pd-csi driver is installed by default in k/k, we want to disable that when launching test from this repo