### PR TITLE
Disable uuid checks on XFS

### DIFF
--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -137,10 +137,7 @@ func (ns *GCENodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePub
 		}
 
 		klog.V(4).Infof("NodePublishVolume with filesystem %s", fstype)
-
-		for _, flag := range mnt.MountFlags {
-			options = append(options, flag)
-		}
+		options = append(options, collectMountOptions(fstype, mnt.MountFlags)...)
 
 		sourcePath = stagingTargetPath
 		if err := preparePublishPath(targetPath, ns.Mounter); err != nil {
@@ -307,9 +304,7 @@ func (ns *GCENodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStage
 		if mnt.FsType != "" {
 			fstype = mnt.FsType
 		}
-		for _, flag := range mnt.MountFlags {
-			options = append(options, flag)
-		}
+		options = collectMountOptions(fstype, mnt.MountFlags)
 	} else if blk := volumeCapability.GetBlock(); blk != nil {
 		// Noop for Block NodeStageVolume
 		klog.V(4).Infof("NodeStageVolume succeeded on %v to %s, capability is block so this is a no-op", volumeID, stagingTargetPath)

--- a/pkg/gce-pd-csi-driver/utils.go
+++ b/pkg/gce-pd-csi-driver/utils.go
@@ -27,6 +27,10 @@ import (
 	"k8s.io/klog"
 )
 
+const (
+	fsTypeXFS = "xfs"
+)
+
 var ProbeCSIFullMethod = "/csi.v1.Identity/Probe"
 
 func NewVolumeCapabilityAccessMode(mode csi.VolumeCapability_AccessMode_Mode) *csi.VolumeCapability_AccessMode {
@@ -154,4 +158,19 @@ func getMultiWriterFromCapabilities(vcs []*csi.VolumeCapability) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func collectMountOptions(fsType string, mntFlags []string) []string {
+	var options []string
+
+	for _, opt := range mntFlags {
+		options = append(options, opt)
+	}
+
+	// By default, xfs does not allow mounting of two volumes with the same filesystem uuid.
+	// Force ignore this uuid to be able to mount volume + its clone / restored snapshot on the same node.
+	if fsType == fsTypeXFS {
+		options = append(options, "nouuid")
+	}
+	return options
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
By default, XFS does not allow mounting two devices that have the same UUID of the XFS filesystem. Therefore it's not possible to mount a volume + its restored snapshot.

Therefore disable UUID check in XFS using a mount option.

Since https://github.com/kubernetes/kubernetes/pull/102538 was merged, all pull-kubernetes-e2e-gce-storage-slow tests fail in Kubernetes, e.g. https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/102690/pull-kubernetes-e2e-gce-storage-slow/1402241210831081472/


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
It is now possible to mount a volume with XFS filesystem and its restored snapshot.
```
