### PR TITLE
Allow users to specify "storage-locations" for snapshots.

### DIFF
--- a/docs/kubernetes/user-guides/snapshots.md
+++ b/docs/kubernetes/user-guides/snapshots.md
@@ -23,6 +23,14 @@ Kubernetes 1.17+.
     kubectl create -f ./examples/kubernetes/snapshot/default-volumesnapshotclass.yaml
     ```
 
+  To place the snapshot in a [custom storage location](https://cloud.google.com/compute/docs/disks/snapshots#custom_location),
+  edit `volumesnapshotclass-storage-locations.yaml` to change the `storage-locations` parameter to a location of your
+  choice, and then create the `VolumeSnapshotClass`.
+
+    ```console
+    kubectl create -f ./examples/kubernetes/snapshot/volumesnapshotclass-storage-locations.yaml
+    ```
+
 1. Create source PVC
 
     ```console

--- a/examples/kubernetes/snapshot/volumesnapshotclass-storage-locations.yaml
+++ b/examples/kubernetes/snapshot/volumesnapshotclass-storage-locations.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1beta1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-gce-pd-snapshot-class-with-storage-locations
+parameters:
+  storage-locations: us-east2
+driver: pd.csi.storage.gke.io
+deletionPolicy: Delete

--- a/pkg/common/parameters_test.go
+++ b/pkg/common/parameters_test.go
@@ -164,3 +164,40 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 		})
 	}
 }
+
+// Currently the only parameter is storage-locations, which is already tested
+// in utils_test/TestSnapshotStorageLocations. Here we just test the case where
+// no parameter is set in the snapshot class.
+func TestSnapshotParameters(t *testing.T) {
+	tests := []struct {
+		desc                    string
+		parameters              map[string]string
+		expectedSnapshotParames SnapshotParameters
+	}{
+		{
+			desc:       "valid parameter",
+			parameters: map[string]string{ParameterKeyStorageLocations: "ASIA "},
+			expectedSnapshotParames: SnapshotParameters{
+				StorageLocations: []string{"asia"},
+			},
+		},
+		{
+			desc:       "nil parameter",
+			parameters: nil,
+			expectedSnapshotParames: SnapshotParameters{
+				StorageLocations: []string{},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			p, err := ExtractAndDefaultSnapshotParameters(tc.parameters)
+			if err != nil {
+				t.Errorf("Got error processing snapshot parameters: %v; expect no error", err)
+			}
+			if !reflect.DeepEqual(p, tc.expectedSnapshotParames) {
+				t.Errorf("Got ExtractAndDefaultSnapshotParameters(%+v) = %+v; expect %+v", tc.parameters, p, tc.expectedSnapshotParames)
+			}
+		})
+	}
+}

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -50,6 +50,18 @@ const (
 	nodeIDTotalElements = 6
 
 	regionalDeviceNameSuffix = "_regional"
+
+	// Snapshot storage location format
+	// Reference: https://cloud.google.com/storage/docs/locations
+	// Example: us
+	multiRegionalLocationFmt = "^[a-z]+$"
+	// Example: us-east1
+	regionalLocationFmt = "^[a-z]+-[a-z]+[0-9]$"
+)
+
+var (
+	multiRegionalPattern = regexp.MustCompile(multiRegionalLocationFmt)
+	regionalPattern      = regexp.MustCompile(regionalLocationFmt)
 )
 
 func BytesToGbRoundDown(bytes int64) int64 {
@@ -216,4 +228,13 @@ func ConvertLabelsStringToMap(labels string) (map[string]string, error) {
 	}
 
 	return labelsMap, nil
+}
+
+// ProcessStorageLocations trims and normalizes storage location to lower letters.
+func ProcessStorageLocations(storageLocations string) ([]string, error) {
+	normalizedLoc := strings.ToLower(strings.TrimSpace(storageLocations))
+	if !multiRegionalPattern.MatchString(normalizedLoc) && !regionalPattern.MatchString(normalizedLoc) {
+		return []string{}, fmt.Errorf("invalid location for snapshot: %q", storageLocations)
+	}
+	return []string{normalizedLoc}, nil
 }

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -534,3 +534,46 @@ func TestConvertLabelsStringToMap(t *testing.T) {
 	})
 
 }
+
+func TestSnapshotStorageLocations(t *testing.T) {
+	tests := []struct {
+		desc                        string
+		locationString              string
+		expectedNormalizedLocations []string
+		expectError                 bool
+	}{
+		{
+			"valid multi-region",
+			"   uS ",
+			[]string{"us"},
+			false,
+		},
+		{
+			"valid region",
+			"  US-EAST1",
+			[]string{"us-east1"},
+			false,
+		},
+		{
+			// Zones are not valid bucket/snapshot locations.
+			"single zone",
+			"us-east1a",
+			[]string{},
+			true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			normalizedLocations, err := ProcessStorageLocations(tc.locationString)
+			if err != nil && !tc.expectError {
+				t.Errorf("Got error %v processing storage locations %q; expect no error", err, tc.locationString)
+			}
+			if err == nil && tc.expectError {
+				t.Errorf("Got no error processing storage locations %q; expect an error", tc.locationString)
+			}
+			if err == nil && !reflect.DeepEqual(normalizedLocations, tc.expectedNormalizedLocations) {
+				t.Errorf("Got %v for normalized storage locations; expect %v", normalizedLocations, tc.expectedNormalizedLocations)
+			}
+		})
+	}
+}

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -609,7 +609,11 @@ func (gceCS *GCEControllerServer) CreateSnapshot(ctx context.Context, req *csi.C
 			return nil, status.Error(codes.Internal, fmt.Sprintf("Unknown get snapshot error: %v", err))
 		}
 		// If we could not find the snapshot, we create a new one
-		snapshot, err = gceCS.CloudProvider.CreateSnapshot(ctx, project, volKey, req.Name)
+		snapshotParams, err := common.ExtractAndDefaultSnapshotParameters(req.GetParameters())
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Invalid snapshot parameters: %v", err))
+		}
+		snapshot, err = gceCS.CloudProvider.CreateSnapshot(ctx, project, volKey, req.Name, snapshotParams)
 		if err != nil {
 			if gce.IsGCEError(err, "notFound") {
 				return nil, status.Error(codes.NotFound, fmt.Sprintf("Could not find volume with ID %v: %v", volKey.String(), err))


### PR DESCRIPTION
Use a comma separated string, for example "us-central1,us-west1"
as the "snapshot-locations" field of snapshot class parameters.
See the PR for detailed examples.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind feature

**What this PR does / why we need it**:
Allow users to set storage locations[1] for their PD snapshots by specifying them in the snapshot class. For example:

```yaml
apiVersion: snapshot.storage.k8s.io/v1beta1
kind: VolumeSnapshotClass
metadata:
  name: snapshot-class-with-storage-locations
parameters:
  storage-locations: us-central1
driver: pd.csi.storage.gke.io
deletionPolicy: Delete
```

Current the default location[2] will be used for all snapshots. GKE customers may have organization policies restricting the placement of snapshots that conflicts with the default location. This features will help customers to consistently apply their policies.

This parameter is described in the API document[3] for snapshots.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #791

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Users will be able to set the storage locations for snapshots by specifying them in the snapshot class.
```
[1] https://cloud.google.com/compute/docs/disks/snapshots#custom_location
[2] https://cloud.google.com/compute/docs/disks/snapshots#default_location
[3] https://cloud.google.com/compute/docs/reference/rest/v1/snapshots