### PR TITLE
removed beta because pdcsi is not only available in beta

### DIFF
--- a/test/k8s-integration/cluster.go
+++ b/test/k8s-integration/cluster.go
@@ -185,8 +185,6 @@ func clusterUpGKE(gceZone, gceRegion string, numNodes int, imageType string, use
 	}
 
 	if useManagedDriver {
-		// PD CSI Driver add on is enabled only in gcloud beta.
-		cmdParams = append([]string{"beta"}, cmdParams...)
 		cmdParams = append(cmdParams, "--addons", "GcePersistentDiskCsiDriver")
 	}
 


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
since managed pdcsi driver is out of beta it makes sense to remove the beta flag in `clusterUpGKE`

```release-note
NONE
```