### PR TITLE
update documentation to show that any PD disk type can be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See Github [Issues](https://github.com/kubernetes-sigs/gcp-compute-persistent-di
 
 | Parameter        | Values                    | Default       | Description                                                                                        |
 |------------------|---------------------------|---------------|----------------------------------------------------------------------------------------------------|
-| type             | `pd-ssd` OR `pd-standard` | `pd-standard` | Type allows you to choose between standard Persistent Disks  or Solid State Drive Persistent Disks |
+| type             | Any PD type (see [GCP documentation](https://cloud.google.com/compute/docs/disks#disk-types)), eg `pd-ssd` `pd-balanced` | `pd-standard` | Type allows you to choose between standard Persistent Disks  or Solid State Drive Persistent Disks |
 | replication-type | `none` OR `regional-pd`   | `none`        | Replication type allows you to choose between Zonal Persistent Disks or Regional Persistent Disks  |
 | disk-encryption-kms-key | Fully qualified resource identifier for the key to use to encrypt new disks. | Empty string. | Encrypt disk using Customer Managed Encryption Key (CMEK). See [GKE Docs](https://cloud.google.com/kubernetes-engine/docs/how-to/using-cmek#create_a_cmek_protected_attached_disk) for details. |
 | labels           | `key1=value1,key2=value2` |               | Labels allow you to assign custom [GCE Disk labels](https://cloud.google.com/compute/docs/labeling-resources). |


### PR DESCRIPTION
The documentation implies that only pd-standard or pd-ssd can be used, when in fact any pd type is possible.

```release-note
None
```

/assign @saikat-royc 