### PR TITLE
release-1.3 cut details

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ lifecycle of Google Compute Engine Persistent Disks.
 ## Project Status
 
 Status: GA
-Latest stable image: `k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.2.1`
+Latest stable image: `k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.3.0`
 
 ### Test Status
 

--- a/deploy/kubernetes/images/stable-master/image.yaml
+++ b/deploy/kubernetes/images/stable-master/image.yaml
@@ -51,5 +51,6 @@ imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   # Don't change stable image without changing pdImagePlaceholder in
   # test/k8s-integration/main.go
-  newTag: "v1.2.1-gke.0"
+  newName: k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+  newTag: "v1.3.0"
 ---


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
Put 1.3.0 release into stable-master.

RC passing testgrid (visible google internal only): https://prow-gob.gcpnode.com/view/gcs/gob-prow/logs/periodic-gcp-pd-csi-driver-k8s-integration-staging/1417971893247414272

```release-note
None
```
