### PR TITLE
list volumes in cluster's region instead of zone

### DIFF
--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/klog"
 
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
@@ -38,6 +39,9 @@ import (
 type GCEControllerServer struct {
 	Driver        *GCEDriver
 	CloudProvider gce.GCECompute
+
+	disks []*compute.Disk
+	seen  map[string]int
 
 	// A map storing all volumes with ongoing operations so that additional
 	// operations for that same volume (as defined by Volume Key) return an
@@ -524,22 +528,36 @@ func (gceCS *GCEControllerServer) ListVolumes(ctx context.Context, req *csi.List
 	// https://cloud.google.com/compute/docs/reference/beta/disks/list
 	if req.MaxEntries < 0 {
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf(
-			"ListVolumes got max entries request %v. GCE only supports values between 0-500", req.MaxEntries))
+			"ListVolumes got max entries request %v. GCE only supports values >0", req.MaxEntries))
 	}
-	var maxEntries int64 = int64(req.MaxEntries)
-	if maxEntries > 500 {
-		klog.Warningf("ListVolumes requested max entries of %v, GCE only supports values <=500 so defaulting value back to 500", maxEntries)
-		maxEntries = 500
-	}
-	diskList, nextToken, err := gceCS.CloudProvider.ListDisks(ctx, maxEntries, req.StartingToken)
-	if err != nil {
-		if gce.IsGCEInvalidError(err) {
-			return nil, status.Error(codes.Aborted, fmt.Sprintf("ListVolumes error with invalid request: %v", err))
+
+	offset := 0
+	var ok bool
+	if req.StartingToken == "" {
+		diskList, _, err := gceCS.CloudProvider.ListDisks(ctx)
+		if err != nil {
+			if gce.IsGCEInvalidError(err) {
+				return nil, status.Error(codes.Aborted, fmt.Sprintf("ListVolumes error with invalid request: %v", err))
+			}
+			return nil, status.Error(codes.Internal, fmt.Sprintf("Unknown list disk error: %v", err))
 		}
-		return nil, status.Error(codes.Internal, fmt.Sprintf("Unknown list disk error: %v", err))
+		gceCS.disks = diskList
+		gceCS.seen = map[string]int{}
+	} else {
+		offset, ok = gceCS.seen[req.StartingToken]
+		if !ok {
+			return nil, status.Error(codes.Aborted, fmt.Sprintf("ListVolumes error with invalid startingToken: %s", req.StartingToken))
+		}
 	}
+
+	var maxEntries int = int(req.MaxEntries)
+	if maxEntries == 0 {
+		maxEntries = len(gceCS.disks)
+	}
+
 	entries := []*csi.ListVolumesResponse_Entry{}
-	for _, d := range diskList {
+	for i := 0; i+offset < len(gceCS.disks) && i < maxEntries; i++ {
+		d := gceCS.disks[i+offset]
 		users := []string{}
 		for _, u := range d.Users {
 			users = append(users, cleanSelfLink(u))
@@ -552,6 +570,12 @@ func (gceCS *GCEControllerServer) ListVolumes(ctx context.Context, req *csi.List
 				PublishedNodeIds: users,
 			},
 		})
+	}
+
+	nextToken := ""
+	if len(entries)+offset < len(gceCS.disks) {
+		nextToken = string(uuid.NewUUID())
+		gceCS.seen[nextToken] = len(entries) + offset
 	}
 
 	return &csi.ListVolumesResponse{

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -771,6 +771,7 @@ func TestCreateVolumeArguments(t *testing.T) {
 }
 
 func TestListVolumeArgs(t *testing.T) {
+	diskCount := 600
 	testCases := []struct {
 		name            string
 		maxEntries      int32
@@ -779,17 +780,12 @@ func TestListVolumeArgs(t *testing.T) {
 	}{
 		{
 			name:            "normal",
-			expectedEntries: 500,
+			expectedEntries: diskCount,
 		},
 		{
 			name:            "fine amount of entries",
 			maxEntries:      420,
 			expectedEntries: 420,
-		},
-		{
-			name:            "too many entries, but defaults to 500",
-			maxEntries:      501,
-			expectedEntries: 500,
 		},
 		{
 			name:        "negative entries",
@@ -802,7 +798,7 @@ func TestListVolumeArgs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup new driver each time so no interference
 			var d []*gce.CloudDisk
-			for i := 0; i < 600; i++ {
+			for i := 0; i < diskCount; i++ {
 				// Create 600 dummy disks
 				d = append(d, gce.CloudDiskFromV1(&compute.Disk{Name: fmt.Sprintf("%v", i)}))
 			}

--- a/pkg/gce-pd-csi-driver/gce-pd-driver.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver.go
@@ -151,6 +151,7 @@ func NewControllerServer(gceDriver *GCEDriver, cloudProvider gce.GCECompute) *GC
 	return &GCEControllerServer{
 		Driver:        gceDriver,
 		CloudProvider: cloudProvider,
+		seen:          map[string]int{},
 		volumeLocks:   common.NewVolumeLocks(),
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
when controller is not in the same zone as nodes, DiskList don't list out disks attached in other zones, thus reconciler will force controllerPublishVolume to reprocess them, causing excessive api calls breaking customer clusters' quotas.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-csi/external-attacher/issues/291

**Special notes for your reviewer**:
No comment still from arcus team so chose this implementation over `aggregatedList` due to concerns over it being potentially slow for projects with PVs in lots of regions.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
