### PR TITLE
Stage v1.3.1-rc1

### DIFF
--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-master/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-master/image.yaml
@@ -32,7 +32,7 @@ metadata:
 imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   newName: gcr.io/k8s-staging-cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.3.0-rc1"
+  newTag: "v1.3.1-rc1"
 ---
 
 apiVersion: builtin


### PR DESCRIPTION
/kind cleanup
/assign @saikat-royc 

The build is slowly appearing at https://pantheon.corp.google.com/gcr/images/k8s-staging-cloud-provider-gcp/global/gcp-compute-persistent-disk-csi-driver (the windows builds make take a while).

I think we can submit this now, and the build will probably be finished by the time the job kicks off. It will save some time probably, so I can finalize the release tomorrow.

```release-note
None
```
