### PR TITLE
Push v1.3.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ lifecycle of Google Compute Engine Persistent Disks.
 ## Project Status
 
 Status: GA
-Latest stable image: `k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.3.0`
+Latest stable image: `k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.3.1`
 
 ### Test Status
 

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-master/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-master/image.yaml
@@ -52,6 +52,5 @@ metadata:
   name: imagetag-csi-gce-driver-prow-rc
 imageTag:
   name: k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-  newName: gcr.io/k8s-staging-cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.3.1-rc1"
+  newTag: "v1.3.1"
 ---

--- a/deploy/kubernetes/images/stable-master/image.yaml
+++ b/deploy/kubernetes/images/stable-master/image.yaml
@@ -52,5 +52,5 @@ imageTag:
   # Don't change stable image without changing pdImagePlaceholder in
   # test/k8s-integration/main.go
   newName: k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.3.0"
+  newTag: "v1.3.1"
 ---


### PR DESCRIPTION
v1.3.1-rc1 image has passed staging tests, pushing the release now which are appearing in the [repo](https://pantheon.corp.google.com/gcr/images/k8s-staging-cloud-provider-gcp/global/gcp-compute-persistent-disk-csi-driver).

/kind documentation
/assign @saikat-royc 

```release-note
None
```
