### PR TITLE
Enable kubelet-registration-probe mode in node-driver-registrar in Windows & Linux

### DIFF
--- a/deploy/kubernetes/base/node_linux/node.yaml
+++ b/deploy/kubernetes/base/node_linux/node.yaml
@@ -38,6 +38,13 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          livenessProbe:
+            initialDelaySeconds: 3
+            exec:
+              command:
+                - /csi-node-driver-registrar
+                - --kubelet-registration-path=/var/lib/kubelet/plugins/pd.csi.storage.gke.io/csi.sock
+                - --mode=kubelet-registration-probe
         - name: gce-pd-driver
           # Don't change base image without changing pdImagePlaceholder in
           # test/k8s-integration/main.go

--- a/deploy/kubernetes/base/node_windows/node.yaml
+++ b/deploy/kubernetes/base/node_windows/node.yaml
@@ -39,6 +39,13 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          livenessProbe:
+            initialDelaySeconds: 3
+            exec:
+              command:
+                - /csi-node-driver-registrar.exe
+                - --kubelet-registration-path=C:\\var\\lib\\kubelet\\plugins\\pd.csi.storage.gke.io\\csi.sock
+                - --mode=kubelet-registration-probe
         - name: gce-pd-driver
           # Don't change base image without changing pdImagePlaceholder in
           # test/k8s-integration/main.go

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-master/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-master/image.yaml
@@ -43,7 +43,7 @@ metadata:
   name: imagetag-csi-node-registrar-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-  newTag: "v2.1.0"
+  newTag: "v2.3.0"
 ---
 
 apiVersion: builtin

--- a/deploy/kubernetes/images/stable/image.yaml
+++ b/deploy/kubernetes/images/stable/image.yaml
@@ -40,7 +40,7 @@ metadata:
   name: imagetag-csi-node-registrar
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-  newTag: "v2.3.0"
+  newTag: "v2.1.0"
 ---
 
 apiVersion: builtin

--- a/deploy/kubernetes/images/stable/image.yaml
+++ b/deploy/kubernetes/images/stable/image.yaml
@@ -40,7 +40,7 @@ metadata:
   name: imagetag-csi-node-registrar
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-  newTag: "v2.1.0"
+  newTag: "v2.3.0"
 ---
 
 apiVersion: builtin

--- a/deploy/kubernetes/overlays/stable-1-17/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable-1-17/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
 patchesStrategicMerge:
 - no_win_roles.yaml
 - no_v1_csidriver.yaml
+- no-node-driver-registrar-probe.yaml
 transformers:
 - ../../images/stable-1-17

--- a/deploy/kubernetes/overlays/stable-1-17/no-node-driver-registrar-probe.yaml
+++ b/deploy/kubernetes/overlays/stable-1-17/no-node-driver-registrar-probe.yaml
@@ -1,0 +1,25 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-gce-pd-node-win
+spec:
+  template:
+    spec:
+      containers:
+        - name: csi-driver-registrar
+          # introduced in node-driver-registrar v2.3.0
+          livenessProbe:
+            $patch: delete
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-gce-pd-node
+spec:
+  template:
+    spec:
+      containers:
+        - name: csi-driver-registrar
+          # introduced in node-driver-registrar v2.3.0
+          livenessProbe:
+            $patch: delete

--- a/deploy/kubernetes/overlays/stable-1-18/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable-1-18/kustomization.yaml
@@ -4,5 +4,7 @@ namespace:
   gce-pd-csi-driver
 resources:
 - ../../base
+patchesStrategicMerge:
+- no-node-driver-registrar-probe.yaml
 transformers:
 - ../../images/stable-1-18

--- a/deploy/kubernetes/overlays/stable-1-18/no-node-driver-registrar-probe.yaml
+++ b/deploy/kubernetes/overlays/stable-1-18/no-node-driver-registrar-probe.yaml
@@ -1,0 +1,25 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-gce-pd-node-win
+spec:
+  template:
+    spec:
+      containers:
+        - name: csi-driver-registrar
+          # introduced in node-driver-registrar v2.3.0
+          livenessProbe:
+            $patch: delete
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-gce-pd-node
+spec:
+  template:
+    spec:
+      containers:
+        - name: csi-driver-registrar
+          # introduced in node-driver-registrar v2.3.0
+          livenessProbe:
+            $patch: delete

--- a/deploy/kubernetes/overlays/stable-1-19/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable-1-19/kustomization.yaml
@@ -4,5 +4,7 @@ namespace:
   gce-pd-csi-driver
 resources:
 - ../../base/
+patchesStrategicMerge:
+- no-node-driver-registrar-probe.yaml
 transformers:
 - ../../images/stable-1-19

--- a/deploy/kubernetes/overlays/stable-1-19/no-node-driver-registrar-probe.yaml
+++ b/deploy/kubernetes/overlays/stable-1-19/no-node-driver-registrar-probe.yaml
@@ -1,0 +1,25 @@
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-gce-pd-node-win
+spec:
+  template:
+    spec:
+      containers:
+        - name: csi-driver-registrar
+          # introduced in node-driver-registrar v2.3.0
+          livenessProbe:
+            $patch: delete
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-gce-pd-node
+spec:
+  template:
+    spec:
+      containers:
+        - name: csi-driver-registrar
+          # introduced in node-driver-registrar v2.3.0
+          livenessProbe:
+            $patch: delete

--- a/deploy/kubernetes/overlays/stable-master/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable-master/kustomization.yaml
@@ -4,5 +4,7 @@ namespace:
   gce-pd-csi-driver
 resources:
 - ../../base
+patchesStrategicMerge:
+- no-node-driver-registrar-probe.yaml
 transformers:
 - ../../images/stable-master

--- a/deploy/kubernetes/overlays/stable-master/no-node-driver-registrar-probe.yaml
+++ b/deploy/kubernetes/overlays/stable-master/no-node-driver-registrar-probe.yaml
@@ -1,0 +1,27 @@
+# TODO(mauriciopoppe): remove this file once testgrid is green with
+# prow-gke-release-staging-rc-master
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-gce-pd-node-win
+spec:
+  template:
+    spec:
+      containers:
+        - name: csi-driver-registrar
+          # introduced in node-driver-registrar v2.3.0
+          livenessProbe:
+            $patch: delete
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-gce-pd-node
+spec:
+  template:
+    spec:
+      containers:
+        - name: csi-driver-registrar
+          # introduced in node-driver-registrar v2.3.0
+          livenessProbe:
+            $patch: delete


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
/kind feature

**What this PR does / why we need it**:
Adds support for https://github.com/kubernetes-csi/node-driver-registrar/pull/152 on Windows & Linux nodes, I tried patching previous releases to remove the probe configuration because it was introduced in node-driver-registrar v2.3.0

The output for `kustomize build deploy/kubernetes/overlays/stable-1-19` is ok (liveness probe should be removed because the version is less than v2.3.0): 

```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: csi-gce-pd-node-win
  namespace: gce-pd-csi-driver
spec:
  selector:
    matchLabels:
      app: gcp-compute-persistent-disk-csi-driver
  template:
    metadata:
      labels:
        app: gcp-compute-persistent-disk-csi-driver
    spec:
      containers:
      - args:
        - --v=5
        - --csi-address=unix://C:\\csi\\csi.sock
        - --kubelet-registration-path=C:\\var\\lib\\kubelet\\plugins\\pd.csi.storage.gke.io\\csi.sock
        env:
        - name: KUBE_NODE_NAME
          valueFrom:
            fieldRef:
              fieldPath: spec.nodeName
        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0
        name: csi-driver-registrar
        volumeMounts:
        - mountPath: /csi
          name: plugin-dir
        - mountPath: /registration
          name: registration-dir
```

Also the output for `kustomize build deploy/kubernetes/overlays/stable` is ok:

```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: csi-gce-pd-node-win
  namespace: gce-pd-csi-driver
spec:
  selector:
    matchLabels:
      app: gcp-compute-persistent-disk-csi-driver
  template:
    metadata:
      labels:
        app: gcp-compute-persistent-disk-csi-driver
    spec:
      containers:
      - args:
        - --v=5
        - --csi-address=unix://C:\\csi\\csi.sock
        - --kubelet-registration-path=C:\\var\\lib\\kubelet\\plugins\\pd.csi.storage.gke.io\\csi.sock
        env:
        - name: KUBE_NODE_NAME
          valueFrom:
            fieldRef:
              fieldPath: spec.nodeName
        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
        livenessProbe:
          exec:
            command:
            - /csi-node-driver-registrar.exe
            - --kubelet-registration-path=C:\\var\\lib\\kubelet\\plugins\\pd.csi.storage.gke.io\\csi.sock
            - --mode=kubelet-registration-probe
          initialDelaySeconds: 3
        name: csi-driver-registrar
        volumeMounts:
        - mountPath: /csi
          name: plugin-dir
        - mountPath: /registration
          name: registration-dir
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @jingxu97 @msau42