### PR TITLE
Add legacy build directives necessary for some go versions

### DIFF
--- a/pkg/gce-pd-csi-driver/utils_linux.go
+++ b/pkg/gce-pd-csi-driver/utils_linux.go
@@ -1,4 +1,5 @@
 //go:build !windows
+// +build !windows
 
 /*
 Copyright 2020 The Kubernetes Authors.

--- a/pkg/gce-pd-csi-driver/utils_windows.go
+++ b/pkg/gce-pd-csi-driver/utils_windows.go
@@ -1,4 +1,5 @@
 //go:build windows
+// +build windows
 
 /*
 Copyright 2020 The Kubernetes Authors.

--- a/pkg/mount-manager/safe-mounter_linux.go
+++ b/pkg/mount-manager/safe-mounter_linux.go
@@ -1,4 +1,5 @@
 //go:build linux
+// +build linux
 
 /*
 Copyright 2018 The Kubernetes Authors.

--- a/pkg/mount-manager/safe-mounter_windows.go
+++ b/pkg/mount-manager/safe-mounter_windows.go
@@ -1,4 +1,5 @@
 //go:build windows
+// +build windows
 
 /*
 Copyright 2020 The Kubernetes Authors.

--- a/pkg/mount-manager/statter_windows.go
+++ b/pkg/mount-manager/statter_windows.go
@@ -1,4 +1,5 @@
 //go:build windows
+// +build windows
 
 /*
 Copyright 2019 The Kubernetes Authors.


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Some go versions (at least 1.16) require the legacy +build comments in addition to the new go:build commands. At least, without this change the following error happens when running make with go1.16:

```
go build -mod=vendor -ldflags "-X main.vendorVersion=v1.0.2-0-g5d19516" -o bin/gce-pd-csi-driver ./cmd/
cmd/main.go:28:2: //go:build comment without // +build comment
pkg/gce-pd-csi-driver/gce-pd-driver.go:28:2: //go:build comment without // +build comment
make: *** [gce-pd-driver] Error 1
Makefile:29: recipe for target 'gce-pd-driver' failed
```

/release-note-none