### PR TITLE
replace gcr.io/gke-release-staging to use k8s.gcr.io/cloud-provider-gcp

### DIFF
--- a/deploy/kubernetes/images/prow-gke-release-staging-head/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-head/image.yaml
@@ -4,8 +4,8 @@ metadata:
   name: imagetag-gcepd-driver-prow-head
 imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
-  newName: gcr.io/gke-release-staging/gcp-compute-persistent-disk-csi-driver
-  newTag: "latest"
+  newName: gcr.io/k8s-staging-cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+  newTag: "master"
 ---
 apiVersion: builtin
 kind: ImageTagTransformer

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-15/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-15/image.yaml
@@ -22,8 +22,8 @@ metadata:
   name: imagetag-csi-gce-driver-prow-rc
 imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
-  newName: gcr.io/gke-release-staging/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.2.1-rc1"
+  newName: k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+  newTag: "v1.2.2"
 ---
 
 apiVersion: builtin

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-16/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-16/image.yaml
@@ -31,8 +31,8 @@ metadata:
   name: imagetag-csi-gce-driver-prow-rc
 imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
-  newName: gcr.io/gke-release-staging/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.2.1-rc1"
+  newName: k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+  newTag: "v1.2.2"
 ---
 
 apiVersion: builtin

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-17/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-17/image.yaml
@@ -31,8 +31,8 @@ metadata:
   name: imagetag-csi-gce-driver-prow-rc
 imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
-  newName: gcr.io/gke-release-staging/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.2.1-rc1"
+  newName: k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+  newTag: "v1.2.2"
 ---
 
 apiVersion: builtin

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-18/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-18/image.yaml
@@ -31,8 +31,8 @@ metadata:
   name: imagetag-csi-gce-driver-prow-rc
 imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
-  newName: gcr.io/gke-release-staging/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.2.1-rc1"
+  newName: k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+  newTag: "v1.2.2"
 ---
 
 apiVersion: builtin

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc-1-19/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc-1-19/image.yaml
@@ -31,8 +31,8 @@ metadata:
   name: imagetag-csi-gce-driver-prow-rc
 imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
-  newName: gcr.io/gke-release-staging/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.2.1-rc1"
+  newName: k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+  newTag: "v1.2.2"
 ---
 
 apiVersion: builtin

--- a/deploy/kubernetes/images/prow-gke-release-staging-rc/image.yaml
+++ b/deploy/kubernetes/images/prow-gke-release-staging-rc/image.yaml
@@ -31,8 +31,8 @@ metadata:
   name: imagetag-csi-gce-driver-prow-rc
 imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
-  newName: gcr.io/gke-release-staging/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.2.0"
+  newName: k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+  newTag: "v1.2.2"
 ---
 
 apiVersion: builtin


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Follow up https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/724

deprecate the `gcr.io/gke-release-staging` and use the images that is promoted to the k8s prod registry or use the images that are built in the staging project

/assign @spiffxp @mattcary 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
