### PR TITLE
Cherry pick #788 to release-1.2

### DIFF
--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -137,10 +137,7 @@ func (ns *GCENodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePub
 		}
 
 		klog.V(4).Infof("NodePublishVolume with filesystem %s", fstype)
-
-		for _, flag := range mnt.MountFlags {
-			options = append(options, flag)
-		}
+		options = append(options, collectMountOptions(fstype, mnt.MountFlags)...)
 
 		sourcePath = stagingTargetPath
 		if err := preparePublishPath(targetPath, ns.Mounter); err != nil {
@@ -307,9 +304,7 @@ func (ns *GCENodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStage
 		if mnt.FsType != "" {
 			fstype = mnt.FsType
 		}
-		for _, flag := range mnt.MountFlags {
-			options = append(options, flag)
-		}
+		options = collectMountOptions(fstype, mnt.MountFlags)
 	} else if blk := volumeCapability.GetBlock(); blk != nil {
 		// Noop for Block NodeStageVolume
 		klog.V(4).Infof("NodeStageVolume succeeded on %v to %s, capability is block so this is a no-op", volumeID, stagingTargetPath)

--- a/pkg/gce-pd-csi-driver/utils.go
+++ b/pkg/gce-pd-csi-driver/utils.go
@@ -27,6 +27,10 @@ import (
 	"k8s.io/klog"
 )
 
+const (
+	fsTypeXFS = "xfs"
+)
+
 var ProbeCSIFullMethod = "/csi.v1.Identity/Probe"
 
 func NewVolumeCapabilityAccessMode(mode csi.VolumeCapability_AccessMode_Mode) *csi.VolumeCapability_AccessMode {
@@ -151,4 +155,19 @@ func getMultiWriterFromCapabilities(vcs []*csi.VolumeCapability) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func collectMountOptions(fsType string, mntFlags []string) []string {
+	var options []string
+
+	for _, opt := range mntFlags {
+		options = append(options, opt)
+	}
+
+	// By default, xfs does not allow mounting of two volumes with the same filesystem uuid.
+	// Force ignore this uuid to be able to mount volume + its clone / restored snapshot on the same node.
+	if fsType == fsTypeXFS {
+		options = append(options, "nouuid")
+	}
+	return options
 }

--- a/pkg/gce-pd-csi-driver/utils_linux.go
+++ b/pkg/gce-pd-csi-driver/utils_linux.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/gce-pd-csi-driver/utils_windows.go
+++ b/pkg/gce-pd-csi-driver/utils_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/pkg/mount-manager/safe-mounter_linux.go
+++ b/pkg/mount-manager/safe-mounter_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/pkg/mount-manager/safe-mounter_windows.go
+++ b/pkg/mount-manager/safe-mounter_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/pkg/mount-manager/statter_windows.go
+++ b/pkg/mount-manager/statter_windows.go
@@ -1,4 +1,6 @@
+//go:build windows
 // +build windows
+
 /*
 Copyright 2019 The Kubernetes Authors.
 

--- a/pkg/resizefs/resizefs_linux.go
+++ b/pkg/resizefs/resizefs_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/pkg/resizefs/resizefs_windows.go
+++ b/pkg/resizefs/resizefs_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*


### PR DESCRIPTION
By default, XFS does not allow mounting two devices that have the same UUID
of the XFS filesystem. Therefore it's not possible to mount a volume + its
restored snapshot.

Therefore disable UUID check in XFS using a mount option.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
It is now possible to mount a volume with XFS filesystem and its restored snapshot.
```
