### PR TITLE
Use go install for kubetest2

### DIFF
--- a/test/run-k8s-integration-ci.sh
+++ b/test/run-k8s-integration-ci.sh
@@ -52,11 +52,10 @@ export GCE_PD_VERBOSITY=9
 make -C "${PKGDIR}" test-k8s-integration
 
 if [ "$use_kubetest2" = true ]; then
-    export GO111MODULE=on;
-    go get sigs.k8s.io/kubetest2@latest;
-    go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;
-    go get sigs.k8s.io/kubetest2/kubetest2-gke@latest;
-    go get sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
+    go install sigs.k8s.io/kubetest2@latest;
+    go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
+    go install sigs.k8s.io/kubetest2/kubetest2-gke@latest;
+    go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
 fi
 
 base_cmd="${PKGDIR}/bin/k8s-integration-test \

--- a/test/run-k8s-integration-migration.sh
+++ b/test/run-k8s-integration-migration.sh
@@ -24,11 +24,10 @@ readonly use_kubetest2=${USE_KUBETEST2:-false}
 make -C "${PKGDIR}" test-k8s-integration
 
 if [ "$use_kubetest2" = true ]; then
-    export GO111MODULE=on;
-    go get sigs.k8s.io/kubetest2@latest;
-    go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;
-    go get sigs.k8s.io/kubetest2/kubetest2-gke@latest;
-    go get sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
+    go install sigs.k8s.io/kubetest2@latest;
+    go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
+    go install sigs.k8s.io/kubetest2/kubetest2-gke@latest;
+    go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
 fi
 
 readonly GCE_PD_TEST_FOCUS="PersistentVolumes\sGCEPD|[V|v]olume\sexpand|\[sig-storage\]\sIn-tree\sVolumes\s\[Driver:\sgcepd\]|allowedTopologies|Pod\sDisks|PersistentVolumes\sDefault"

--- a/test/run-windows-k8s-integration.sh
+++ b/test/run-windows-k8s-integration.sh
@@ -21,11 +21,10 @@ readonly use_kubetest2=${USE_KUBETEST2:-true}
 make -C "${PKGDIR}" test-k8s-integration
 
 if [ "$use_kubetest2" = true ]; then
-    export GO111MODULE=on;
-    go get sigs.k8s.io/kubetest2@latest;
-    go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;
-    go get sigs.k8s.io/kubetest2/kubetest2-gke@latest;
-    go get sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
+    go install sigs.k8s.io/kubetest2@latest;
+    go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
+    go install sigs.k8s.io/kubetest2/kubetest2-gke@latest;
+    go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
 fi
 
 base_cmd="${PKGDIR}/bin/k8s-integration-test \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
#850 introduced golang 1.17 and changed the kubetest2 installtion only in the run-k8s-integration.sh script. See [this](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/850/files#diff-5d11239145feb5bcd6e847d58470e4d37c36ff943152a075f223ba19b21d1b1a). Similar change needed in the other scripts. 
FYI: the tests are passing because they dont use the kubetest2 yet. however internal prow [CI job](https://testgrid.corp.google.com/gcp-compute-persistent-disk-csi-driver#pd-master-sidecars-latest-k8s-master-on-gce) uses kubetest2 and go get command messes the vendoring. See this [log](https://prow-gob.gcpnode.com/view/gcs/gob-prow/logs/periodic-gcp-pd-csi-driver-k8s-integration-latest/1451273271029796864) errors.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
