### PR TITLE
add CSI liveness probe container

### DIFF
--- a/deploy/kubernetes/base/node_linux/node.yaml
+++ b/deploy/kubernetes/base/node_linux/node.yaml
@@ -38,13 +38,13 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
-          livenessProbe:
-            initialDelaySeconds: 3
-            exec:
-              command:
-                - /csi-node-driver-registrar
-                - --kubelet-registration-path=/var/lib/kubelet/plugins/pd.csi.storage.gke.io/csi.sock
-                - --mode=kubelet-registration-probe
+        - name: liveness-probe
+          image: k8s.gcr.io/sig-storage/livenessprobe
+          args:
+            - --csi-address=/csi/csi.sock
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
         - name: gce-pd-driver
           # Don't change base image without changing pdImagePlaceholder in
           # test/k8s-integration/main.go

--- a/deploy/kubernetes/base/node_windows/node.yaml
+++ b/deploy/kubernetes/base/node_windows/node.yaml
@@ -39,13 +39,13 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
-          livenessProbe:
-            initialDelaySeconds: 3
-            exec:
-              command:
-                - /csi-node-driver-registrar.exe
-                - --kubelet-registration-path=C:\\var\\lib\\kubelet\\plugins\\pd.csi.storage.gke.io\\csi.sock
-                - --mode=kubelet-registration-probe
+        - name: liveness-probe
+          image: k8s.gcr.io/sig-storage/livenessprobe
+          args:
+            - --csi-address=unix://C:\\csi\\csi.sock
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
         - name: gce-pd-driver
           # Don't change base image without changing pdImagePlaceholder in
           # test/k8s-integration/main.go

--- a/deploy/kubernetes/images/stable-master/image.yaml
+++ b/deploy/kubernetes/images/stable-master/image.yaml
@@ -46,6 +46,16 @@ imageTag:
 apiVersion: builtin
 kind: ImageTagTransformer
 metadata:
+  name: imagetag-csi-liveness-probe
+imageTag:
+  name: k8s.gcr.io/sig-storage/livenessprobe
+  newTag: "v2.2.0"
+
+---
+
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
   name: imagetag-gcepd-driver
 imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

`-mode` parameter is not valid anymore to `csi-node-driver-registrar`. Also nowadays upstream uses separate container to run liveness probes using `k8s.gcr.io/sig-storage/livenessprobe` image

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add CSI liveness probe container for CSI daemonset
```
