### PR TITLE
pdcsi rox workflow fix

### DIFF
--- a/deploy/kubernetes/images/alpha/image.yaml
+++ b/deploy/kubernetes/images/alpha/image.yaml
@@ -1,0 +1,7 @@
+apiVersion: builtin
+kind: ImageTagTransformer
+metadata:
+  name: imagetag-csi-provisioner-alpha
+imageTag:
+  name: k8s.gcr.io/sig-storage/csi-provisioner
+  newTag: "v3.0.0"

--- a/deploy/kubernetes/images/alpha/kustomization.yaml
+++ b/deploy/kubernetes/images/alpha/kustomization.yaml
@@ -2,3 +2,4 @@ namespace:
   gce-pd-csi-driver
 resources:
 - ../stable-master/
+- image.yaml

--- a/deploy/kubernetes/overlays/alpha/controller_readonly.yaml
+++ b/deploy/kubernetes/overlays/alpha/controller_readonly.yaml
@@ -1,0 +1,20 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: csi-gce-pd-controller
+spec:
+  template:
+    spec:
+      containers:
+        - name: csi-provisioner
+          args:
+            - "--v=5"
+            - "--csi-address=/csi/csi.sock"
+            - "--feature-gates=Topology=true"
+            - "--http-endpoint=:22011"
+            - "--leader-election-namespace=$(PDCSI_NAMESPACE)"
+            - "--timeout=250s"
+            - "--extra-create-metadata"
+            - "--leader-election"
+            - "--default-fstype=ext4"
+            - "--controller-publish-readonly=true"

--- a/deploy/kubernetes/overlays/alpha/kustomization.yaml
+++ b/deploy/kubernetes/overlays/alpha/kustomization.yaml
@@ -3,5 +3,7 @@ kind: Kustomization
 namespace: gce-pd-csi-driver
 resources:
 - ../../base/
+patchesStrategicMerge:
+- controller_readonly.yaml
 transformers:
 - ../../images/alpha

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -252,7 +252,12 @@ func (gceCS *GCEControllerServer) CreateVolume(ctx context.Context, req *csi.Cre
 				return nil, status.Error(codes.Internal, fmt.Sprintf("CreateVolume disk from source volume %v is not ready", sourceVolKey))
 			}
 		}
+	} else { // if VolumeContentSource is nil, validate access mode is not read only
+		if readonly, _ := getReadOnlyFromCapabilities(volumeCapabilities); readonly {
+			return nil, status.Error(codes.InvalidArgument, "VolumeContentSource must be provided when AccessMode is set to read only")
+		}
 	}
+
 	// Create the disk
 	var disk *gce.CloudDisk
 	switch params.ReplicationType {

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -358,19 +358,14 @@ func TestCreateVolumeArguments(t *testing.T) {
 			},
 		},
 		{
-			name: "success with MULTI_NODE_READER_ONLY",
+			name: "fail with MULTI_NODE_READER_ONLY",
 			req: &csi.CreateVolumeRequest{
 				Name:               "test-name",
 				CapacityRange:      stdCapRange,
 				VolumeCapabilities: createVolumeCapabilities(csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY),
 				Parameters:         stdParams,
 			},
-			expVol: &csi.Volume{
-				CapacityBytes:      common.GbToBytes(20),
-				VolumeId:           testVolumeID,
-				VolumeContext:      nil,
-				AccessibleTopology: stdTopology,
-			},
+			expErrCode: codes.InvalidArgument,
 		},
 		{
 			name: "fail with mount/MULTI_NODE_MULTI_WRITER capabilities",

--- a/pkg/gce-pd-csi-driver/utils.go
+++ b/pkg/gce-pd-csi-driver/utils.go
@@ -160,6 +160,31 @@ func getMultiWriterFromCapabilities(vcs []*csi.VolumeCapability) (bool, error) {
 	return false, nil
 }
 
+func getReadOnlyFromCapability(vc *csi.VolumeCapability) (bool, error) {
+	if vc.GetAccessMode() == nil {
+		return false, errors.New("access mode is nil")
+	}
+	mode := vc.GetAccessMode().GetMode()
+	return (mode == csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY ||
+		mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY), nil
+}
+
+func getReadOnlyFromCapabilities(vcs []*csi.VolumeCapability) (bool, error) {
+	if vcs == nil {
+		return false, errors.New("volume capabilities is nil")
+	}
+	for _, vc := range vcs {
+		readOnly, err := getReadOnlyFromCapability(vc)
+		if err != nil {
+			return false, err
+		}
+		if readOnly {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func collectMountOptions(fsType string, mntFlags []string) []string {
 	var options []string
 


### PR DESCRIPTION
turn on controller-publish-readonly flag  and add validation in pd-csi driver for when readonly is on

if mounting a read-only ext3 or ext4 disk, use `noload` to prevent mount failure caused by journal replay 

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
when ROX accessMode is specified, csi.Readonly is currently not set. this PR fix that, and at the same time validate that a content source is set when readonly modes are specified at provision time.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #872

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Dynamically provisioning for Read only PVs will fail now unless a volume source (either restore from snapshot or volume cloning) is specified. 
```
