### PR TITLE
Change to distroless base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,15 +23,44 @@ WORKDIR /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 ADD . .
 RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') GCE_PD_CSI_STAGING_VERSION=$STAGINGVERSION make gce-pd-driver
 
-# MAD HACKS: Build a version first so we can take the scsi_id bin and put it somewhere else in our real build
-FROM k8s.gcr.io/build-image/debian-base:buster-v1.9.0 as mad-hack
-RUN clean-install udev
-
-# Start from Kubernetes Debian base
-FROM k8s.gcr.io/build-image/debian-base:buster-v1.9.0
-COPY --from=builder /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/bin/gce-pd-csi-driver /gce-pd-csi-driver
+# Start from Kubernetes Debian base.
+FROM k8s.gcr.io/build-image/debian-base:buster-v1.9.0 as debian
 # Install necessary dependencies
 RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs
-COPY --from=mad-hack /lib/udev/scsi_id /lib/udev_containerized/scsi_id
+# Since we're leveraging apt to pull in dependencies, we use `gcr.io/distroless/base` because it includes glibc.
+FROM gcr.io/distroless/base-debian11
+# Copy necessary dependencies into distroless base.
+COPY --from=builder /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/bin/gce-pd-csi-driver /gce-pd-csi-driver
+COPY --from=debian /etc/mke2fs.conf /etc/mke2fs.conf
+COPY --from=debian /lib/udev/scsi_id /lib/udev_containerized/scsi_id
+COPY --from=debian /bin/mount /bin/mount
+COPY --from=debian /bin/umount /bin/umount
+COPY --from=debian /sbin/blkid /sbin/blkid
+COPY --from=debian /sbin/blockdev /sbin/blockdev
+COPY --from=debian /sbin/dumpe2fs /sbin/dumpe2fs
+COPY --from=debian /sbin/e* /sbin/
+COPY --from=debian /sbin/e2fsck /sbin/e2fsck
+COPY --from=debian /sbin/fsck /sbin/fsck
+COPY --from=debian /sbin/fsck* /sbin/
+COPY --from=debian /sbin/fsck.xfs /sbin/fsck.xfs
+COPY --from=debian /sbin/mke2fs /sbin/mke2fs
+COPY --from=debian /sbin/mkfs* /sbin/
+COPY --from=debian /sbin/resize2fs /sbin/resize2fs
+COPY --from=debian /sbin/xfs_repair /sbin/xfs_repair
+COPY --from=debian /usr/include/xfs /usr/include/xfs
+COPY --from=debian /usr/lib/xfsprogs/xfs* /usr/lib/xfsprogs/
+COPY --from=debian /usr/sbin/xfs* /usr/sbin/
+
+# Copy x86 shared libraries into distroless base.
+COPY --from=debian /lib/x86_64-linux-gnu/libblkid.so.1 /lib/x86_64-linux-gnu/libblkid.so.1
+COPY --from=debian /lib/x86_64-linux-gnu/libcom_err.so.2 /lib/x86_64-linux-gnu/libcom_err.so.2
+COPY --from=debian /lib/x86_64-linux-gnu/libext2fs.so.2 /lib/x86_64-linux-gnu/libext2fs.so.2
+COPY --from=debian /lib/x86_64-linux-gnu/libe2p.so.2 /lib/x86_64-linux-gnu/libe2p.so.2
+COPY --from=debian /lib/x86_64-linux-gnu/libmount.so.1 /lib/x86_64-linux-gnu/libmount.so.1
+COPY --from=debian /lib/x86_64-linux-gnu/libpcre.so.3 /lib/x86_64-linux-gnu/libpcre.so.3
+COPY --from=debian /lib/x86_64-linux-gnu/libreadline.so.5 /lib/x86_64-linux-gnu/libreadline.so.5
+COPY --from=debian /lib/x86_64-linux-gnu/libselinux.so.1 /lib/x86_64-linux-gnu/libselinux.so.1
+COPY --from=debian /lib/x86_64-linux-gnu/libtinfo.so.6 /lib/x86_64-linux-gnu/libtinfo.so.6
+COPY --from=debian /lib/x86_64-linux-gnu/libuuid.so.1 /lib/x86_64-linux-gnu/libuuid.so.1
 
 ENTRYPOINT ["/gce-pd-csi-driver"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,34 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BUILDPLATFORM
+
+FROM --platform=$BUILDPLATFORM golang:1.17.2 as builder
+
+ARG STAGINGVERSION
+ARG TARGETPLATFORM
+
+WORKDIR /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+ADD . .
+RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') GCE_PD_CSI_STAGING_VERSION=$STAGINGVERSION make gce-pd-driver
+
+# Start from Kubernetes Debian base
+# A distroless base is not used because it cannot be tested for ARM until GCE has ARM hardware
+FROM k8s.gcr.io/build-image/debian-base:buster-v1.9.0
+COPY --from=builder /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/bin/gce-pd-csi-driver /gce-pd-csi-driver
+# Install necessary dependencies
+RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs
+COPY /lib/udev/scsi_id /lib/udev_containerized/scsi_id
+
+ENTRYPOINT ["/gce-pd-csi-driver"]

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ build-and-push-container-linux-amd64: require-GCE_PD_CSI_STAGING_IMAGE init-buil
 		--build-arg STAGINGVERSION=$(STAGINGVERSION) --push .
 
 build-and-push-container-linux-arm64: require-GCE_PD_CSI_STAGING_IMAGE init-buildx
-	$(DOCKER) buildx build --platform=linux/arm64 \
+	$(DOCKER) buildx build --file=Dockerfile.arm64 --platform=linux/arm64 \
 		-t $(STAGINGIMAGE):$(STAGINGVERSION)_linux_arm64 \
 		--build-arg BUILDPLATFORM=linux \
 		--build-arg STAGINGVERSION=$(STAGINGVERSION) --push .


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
We are changing pdcsi driver to be built from distroless base image instead of debian. Distroless images are much smaller as they only contain your application and its runtime dependencies. Restricting what's in your runtime container is a best practice, and it improves the signal to noise of scanners (e.g. CVE). See [distroless](https://github.com/GoogleContainerTools/distroless) for more information. 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
