### PR TITLE
Enable Kubernetes e2e tests for volume cloning

### DIFF
--- a/test/k8s-integration/config/test-config-template.in
+++ b/test/k8s-integration/config/test-config-template.in
@@ -4,6 +4,11 @@ StorageClass:
 SnapshotClass:
   FromFile: {{ .SnapshotClassFile }}
 {{end}}
+{{if .Timeouts}}
+Timeouts:
+  {{ range $key, $value := .Timeouts }}{{ $key }}: {{ $value }}
+  {{ end }}
+{{end}}
 DriverInfo:
   Name: csi-gcepd-{{.StorageClass}}
   SupportedFsType:

--- a/test/k8s-integration/driver-config.go
+++ b/test/k8s-integration/driver-config.go
@@ -17,12 +17,18 @@ type driverConfig struct {
 	SupportedFsType      []string
 	MinimumVolumeSize    string
 	NumAllowedTopologies int
+	Timeouts             map[string]string
 }
 
 const (
 	testConfigDir      = "test/k8s-integration/config"
 	configTemplateFile = "test-config-template.in"
 	configFile         = "test-config.yaml"
+	// configurable timeouts for the k8s e2e testsuites
+	dataSourceProvisionTimeout = "480s"
+
+	// These are keys for the configurable timeout map.
+	dataSourceProvisionTimeoutKey = "DataSourceProvision"
 )
 
 // generateDriverConfigFile loads a testdriver config template and creates a file
@@ -123,6 +129,9 @@ func generateDriverConfigFile(testParams *testParameters, storageClassFile strin
 		minimumVolumeSize = "200Gi"
 		numAllowedTopologies = 2
 	}
+	timeouts := map[string]string{
+		dataSourceProvisionTimeoutKey: dataSourceProvisionTimeout,
+	}
 	params := driverConfig{
 		StorageClassFile:     filepath.Join(testParams.pkgDir, testConfigDir, storageClassFile),
 		StorageClass:         storageClassFile[:strings.LastIndex(storageClassFile, ".")],
@@ -131,6 +140,7 @@ func generateDriverConfigFile(testParams *testParameters, storageClassFile strin
 		Capabilities:         caps,
 		MinimumVolumeSize:    minimumVolumeSize,
 		NumAllowedTopologies: numAllowedTopologies,
+		Timeouts:             timeouts,
 	}
 
 	// Write config file

--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -543,9 +543,7 @@ func generateGCETestSkip(testParams *testParameters) string {
 	if testParams.platform == "windows" {
 		skipString = skipString + "|\\[LinuxOnly\\]"
 	}
-	// Volume cloning has timeouts due to GCE disk cloning rate limits, and operation serialization
-	// race conditions where the cloning begins while the source disk is still being created.
-	skipString = skipString + "|provisioning\\sshould\\sprovision\\sstorage\\swith\\spvc\\sdata\\ssource[^|]*"
+
 	return skipString
 }
 
@@ -588,9 +586,6 @@ func generateGKETestSkip(testParams *testParameters) string {
 		(!testParams.useGKEManagedDriver && (*curVer).lessThan(mustParseVersion("1.17.0"))) {
 		skipString = skipString + "|VolumeSnapshotDataSource"
 	}
-	// Volume cloning has timeouts due to GCE disk cloning rate limits, and operation serialization
-	// race conditions where the cloning begins while the source disk is still being created.
-	skipString = skipString + "|provisioning\\sshould\\sprovision\\sstorage\\swith\\spvc\\sdata\\ssource[^|]*"
 	return skipString
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
This PR enables the kubernetes e2e tests for volume cloning. We skipped the volume cloning tests previously because changes to the [kubernetes e2e tests](https://github.com/kubernetes/kubernetes/pull/106322) was necessary first.  
**Which issue(s) this PR fixes**:
Fixes #161

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
