### PR TITLE
Add guest-configs to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 )
 
 require (
+	github.com/GoogleCloudPlatform/guest-configs v0.0.0-20211028171426-a0dacef88470 // indirect
 	github.com/Microsoft/go-winio v0.4.16 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/GoogleCloudPlatform/guest-configs v0.0.0-20211028171426-a0dacef88470 h1:A+CGaqTTg3TSo8k4v90qMInYSZ52kJrnnHUlsCgHRVM=
+github.com/GoogleCloudPlatform/guest-configs v0.0.0-20211028171426-a0dacef88470/go.mod h1:PYz+owYRovKCp6mKRumuKgk77Ac9B5UNmlMHRlW0B1w=
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317 h1:JhyuWIqYrstW7KHMjk/fTqU0xtMpBOHuiTA2FVc7L4E=
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317/go.mod h1:DF8FZRxMHMGv/vP2lQP6h+dYzzjpuRn24VeRiYn3qjQ=
 github.com/GoogleCloudPlatform/testgrid v0.0.1-alpha.3/go.mod h1:f96W2HYy3tiBNV5zbbRc+NczwYHgG1PHXMQfoEWv680=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -3,6 +3,8 @@
 cloud.google.com/go/compute/metadata
 cloud.google.com/go/iam
 cloud.google.com/go/kms/apiv1
+# github.com/GoogleCloudPlatform/guest-configs v0.0.0-20211028171426-a0dacef88470
+## explicit
 # github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317
 ## explicit; go 1.13
 github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
To support symlink validation for NVMe, we need the google_nvme_id scripts and rules from GCP guest configs repro. This PR is to add the guest configs repro as dependency. Will upload the script and rules to pd csi driver image in next PR.


