### PR TITLE
Update version download for current upstream capabilities

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -112,6 +112,11 @@ func main() {
 	flag.Set("logtostderr", "true")
 	flag.Parse()
 
+	if *useGKEManagedDriver {
+		*doDriverBuild = false
+		*teardownDriver = false
+	}
+
 	if !*inProw && *doDriverBuild {
 		ensureVariable(stagingImage, true, "staging-image is a required flag, please specify the name of image to stage to")
 	}
@@ -668,7 +673,7 @@ func runTestsWithConfig(testParams *testParameters, testConfigArg, reportPrefix 
 	}
 	kubeTest2Args = append(kubeTest2Args, "--")
 	if len(*testVersion) != 0 && *testVersion != "master" {
-		kubeTest2Args = append(kubeTest2Args, fmt.Sprintf("--test-package-version=v%s", *testVersion))
+		kubeTest2Args = append(kubeTest2Args, fmt.Sprintf("--test-package-marker=latest-%s.txt", *testVersion))
 	}
 	kubeTest2Args = append(kubeTest2Args, fmt.Sprintf("--focus-regex=%s", testParams.testFocus))
 	kubeTest2Args = append(kubeTest2Args, fmt.Sprintf("--skip-regex=%s", testParams.testSkip))


### PR DESCRIPTION
/kind failing-test

**What this PR does / why we need it**:
Upstream binary and code archives have drifted from what we had been using. This fixes it.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```

/assign @saikat-royc 