### PR TITLE
skip volume cloning tests until we backport

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -554,10 +554,16 @@ func generateGCETestSkip(testParams *testParameters) string {
 
 func generateGKETestSkip(testParams *testParameters) string {
 	skipString := "\\[Disruptive\\]|\\[Serial\\]"
+
 	curVer := mustParseVersion(testParams.clusterVersion)
 	var nodeVer *version
 	if testParams.nodeVersion != "" {
 		nodeVer = mustParseVersion(testParams.nodeVersion)
+	}
+
+	// Cloning test fixes were introduced after 1.23.
+	if curVer.lessThan(mustParseVersion("1.24.0")) {
+		skipString = skipString + "|\\[Feature:VolumeSnapshotDataSource\\]|pvc.data.source"
 	}
 
 	// "volumeMode should not mount / map unused volumes in a pod" tests a


### PR DESCRIPTION
/kind failing-test

**What this PR does / why we need it**:

The volume cloning tests are fixed in head, but we need these test skips until we backport them (see https://github.com/kubernetes/kubernetes/pull/106322).

I've tested this PR with a local integration test run.

```release-note
None
```

/assign @saikat-royc 