### PR TITLE
Use the compiled kubernetes binaries in the e2e tests in CI

### DIFF
--- a/test/k8s-integration/fs.go
+++ b/test/k8s-integration/fs.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// CopyFile copies a file from src to dst
+func CopyFile(src, dst string) (err error) {
+	// get source information
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	return copyFile(src, dst, info)
+}
+
+func copyFile(src, dst string, info os.FileInfo) error {
+	// open src for reading
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		closeErr := in.Close()
+		// if we weren't returning an error
+		if err == nil {
+			err = closeErr
+		}
+	}()
+	if err := os.MkdirAll(filepath.Dir(dst), os.ModePerm); err != nil {
+		return err
+	}
+	// create dst file
+	// this is like f, err := os.Create(dst); os.Chmod(f.Name(), src.Mode())
+	out, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return err
+	}
+	// make sure we close the file
+	defer func() {
+		closeErr := out.Close()
+		// if we weren't returning an error
+		if err == nil {
+			err = closeErr
+		}
+	}()
+	// actually copy
+	if _, err = io.Copy(out, in); err != nil {
+		return err
+	}
+	err = out.Sync()
+	return err
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug

**What this PR does / why we need it**:

When the kubetest2 flags are created it'll detect if we're trying to run the e2e test from master, if so then it'll assume that the cluster was created by compiling a kubernetes release or kubernetes master and that the binaries to use in the e2e tests should be the ones generated during the compilation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Might help https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/892

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @mattcary @jingxu97 