### PR TITLE
Unify the build/test strategy of OSS GCE PD CSI Driver for Linux and Windows

### DIFF
--- a/test/k8s-integration/utils.go
+++ b/test/k8s-integration/utils.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -14,8 +13,9 @@ func runCommand(action string, cmd *exec.Cmd) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 
-	fmt.Printf("%s\n", action)
-	fmt.Printf("%s\n", cmd.Args)
+	klog.Infof("%s", action)
+	klog.Infof("cmd env=%v", cmd.Env)
+	klog.Infof("cmd args=%s", cmd.Args)
 
 	err := cmd.Start()
 	if err != nil {

--- a/test/run-k8s-integration-ci.sh
+++ b/test/run-k8s-integration-ci.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # Optional environment variables
 # GCE_PD_OVERLAY_NAME: which Kustomize overlay to deploy with
@@ -6,6 +6,7 @@
 #   use the driver version from the overlay
 # GCE_PD_BOSKOS_RESOURCE_TYPE: name of the boskos resource type to reserve
 
+set -o xtrace
 set -o nounset
 set -o errexit
 

--- a/test/run-k8s-integration.sh
+++ b/test/run-k8s-integration.sh
@@ -6,6 +6,7 @@
 #   use the driver version from the overlay
 # GCE_PD_BOSKOS_RESOURCE_TYPE: name of the boskos resource type to reserve
 
+set -o xtrace
 set -o nounset
 set -o errexit
 

--- a/test/run-windows-k8s-integration.sh
+++ b/test/run-windows-k8s-integration.sh
@@ -11,7 +11,7 @@ set -o nounset
 set -o errexit
 
 readonly PKGDIR=${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
-readonly overlay_name="${GCE_PD_OVERLAY_NAME:-noauth}"
+readonly overlay_name="${GCE_PD_OVERLAY_NAME:-stable-master}"
 readonly do_driver_build="${GCE_PD_DO_DRIVER_BUILD:-true}"
 readonly deployment_strategy=${DEPLOYMENT_STRATEGY:-gce}
 readonly kube_version=${GCE_PD_KUBE_VERSION:-master}
@@ -22,7 +22,7 @@ readonly use_kubetest2=${USE_KUBETEST2:-true}
 readonly num_windows_nodes=${NUM_WINDOWS_NODES:-3}
 
 # build platforms for `make quick-release`
-export KUBE_BUILD_PLATFORMS="linux/amd64 windows/amd64"
+export KUBE_BUILD_PLATFORMS=${KUBE_BUILD_PLATFORMS:-"linux/amd64 windows/amd64"}
 
 make -C "${PKGDIR}" test-k8s-integration
 
@@ -33,21 +33,8 @@ if [ "$use_kubetest2" = true ]; then
     go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
 fi
 
-# TODO(mauriciopoppe): remove this assignment
-E2E_GOOGLE_APPLICATION_CREDENTIALS=sa
-
-# TODO(mauriciopoppe): change run-in-prow=true
-
-# TODO(mauriciopoppe): change overlay back to stable-master
-
-# TODO(mauriciopoppe): remove --staging-image and this flag
-GCE_PD_CSI_STAGING_IMAGE=gcr.io/mauriciopoppe-gke-dev/gcp-compute-persistent-disk-csi-driver
-
-# TODO(mauriciopoppe): change to --do-driver-build=${do_driver_build} \
-
 base_cmd="${PKGDIR}/bin/k8s-integration-test \
-    --staging-image="${GCE_PD_CSI_STAGING_IMAGE}" \
-    --run-in-prow=false \
+    --run-in-prow=true \
     --service-account-file=${E2E_GOOGLE_APPLICATION_CREDENTIALS} \
     --deployment-strategy=${deployment_strategy} \
     --gce-zone=${gce_zone} \
@@ -57,7 +44,7 @@ base_cmd="${PKGDIR}/bin/k8s-integration-test \
     --num-nodes=1 \
     --num-windows-nodes=${num_windows_nodes} \
     --teardown-driver=${teardown_driver} \
-    --do-driver-build=true \
+    --do-driver-build=${do_driver_build} \
     --deploy-overlay-name=${overlay_name} \
     --test-version=${test_version} \
     --kube-version=${kube_version} \

--- a/test/run-windows-k8s-integration.sh
+++ b/test/run-windows-k8s-integration.sh
@@ -12,12 +12,12 @@ set -o errexit
 
 readonly PKGDIR=${GOPATH}/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 readonly overlay_name="${GCE_PD_OVERLAY_NAME:-stable-master}"
+readonly boskos_resource_type="${GCE_PD_BOSKOS_RESOURCE_TYPE:-gce-project}"
 readonly do_driver_build="${GCE_PD_DO_DRIVER_BUILD:-true}"
 readonly deployment_strategy=${DEPLOYMENT_STRATEGY:-gce}
 readonly kube_version=${GCE_PD_KUBE_VERSION:-master}
 readonly test_version=${TEST_VERSION:-master}
 readonly gce_zone=${GCE_CLUSTER_ZONE:-us-central1-b}
-readonly teardown_driver=${GCE_PD_TEARDOWN_DRIVER:-true}
 readonly use_kubetest2=${USE_KUBETEST2:-true}
 readonly num_windows_nodes=${NUM_WINDOWS_NODES:-3}
 
@@ -36,6 +36,7 @@ fi
 base_cmd="${PKGDIR}/bin/k8s-integration-test \
     --run-in-prow=true \
     --service-account-file=${E2E_GOOGLE_APPLICATION_CREDENTIALS} \
+    --boskos-resource-type=${boskos_resource_type} \
     --deployment-strategy=${deployment_strategy} \
     --gce-zone=${gce_zone} \
     --platform=windows \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind cleanup
/kind feature

**What this PR does / why we need it**:
Unifies the build/test strategy of OSS GCE PD CSI Driver for Linux and Windows

Implementation steps:
- Update the shell script for Windows CI runs setting `--kube-version=master --bringup-cluster=true --teardown-cluster=true`, that way the k8s-integration binary will download and compile the kubernetes codebase, bringup and teardown the cluster.
- Changes to k8s-integration
  - Remove the condition to get a project from Boskos only for Linux, this should apply to Windows too
  - During the cluster bootstrap add a variable to control the number of Windows nodes in addition to the Linux nodes
- Update the test-infra configs for the Windows CI jobs removing the bootstrap scenario and making them similar to the Linux configuration.

Next steps:

- Before merging it I'll update the Windows presubmit job first and then all the periodic jobs in test-infra, run it again and remove the hold

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Another step to fix #892

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/hold
/cc @mattcary @jingxu97