### PR TITLE
Run the k8s-integration-test binary without eval

### DIFF
--- a/test/run-windows-k8s-integration.sh
+++ b/test/run-windows-k8s-integration.sh
@@ -34,7 +34,7 @@ if [ "$use_kubetest2" = true ]; then
     go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
 fi
 
-base_cmd="${PKGDIR}/bin/k8s-integration-test \
+${PKGDIR}/bin/k8s-integration-test \
     --run-in-prow=true \
     --service-account-file=${E2E_GOOGLE_APPLICATION_CREDENTIALS} \
     --boskos-resource-type=${boskos_resource_type} \
@@ -53,6 +53,4 @@ base_cmd="${PKGDIR}/bin/k8s-integration-test \
     --storageclass-files=sc-windows.yaml \
     --snapshotclass-file=pd-volumesnapshotclass.yaml \
     --test-focus='External.Storage' \
-    --use-kubetest2=${use_kubetest2}"
-
-eval "$base_cmd"
+    --use-kubetest2=${use_kubetest2}

--- a/test/run-windows-k8s-migration.sh
+++ b/test/run-windows-k8s-migration.sh
@@ -41,7 +41,7 @@ readonly GCE_PD_TEST_FOCUS="PersistentVolumes\sGCEPD|[V|v]olume\sexpand|\[sig-st
 
 # TODO(#167): Enable reconstructions tests
 
-base_cmd="${PKGDIR}/bin/k8s-integration-test \
+${PKGDIR}/bin/k8s-integration-test \
     --run-in-prow=true \
     --service-account-file=${E2E_GOOGLE_APPLICATION_CREDENTIALS} \
     --boskos-resource-type=${boskos_resource_type} \
@@ -61,6 +61,4 @@ base_cmd="${PKGDIR}/bin/k8s-integration-test \
     --storageclass-files=sc-windows.yaml \
     --snapshotclass-file=pd-volumesnapshotclass.yaml \
     --test-focus=${GCE_PD_TEST_FOCUS} \
-    --use-kubetest2=${use_kubetest2}"
-
-eval "$base_cmd"
+    --use-kubetest2=${use_kubetest2}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug

**What this PR does / why we need it**:
The CI scripts for Windows integration passed! However I saw that the migration job failed, I think we should run the k8s-integration-test binary without eval, hopefully this is the last PR about making both Linux and Windows build strategies to be the same.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @mattcary @jingxu97 