### PR TITLE
Add missing --migration-test=true flag

### DIFF
--- a/test/run-windows-k8s-migration.sh
+++ b/test/run-windows-k8s-migration.sh
@@ -51,6 +51,7 @@ ${PKGDIR}/bin/k8s-integration-test \
     --bringup-cluster=true \
     --teardown-cluster=true \
     --num-nodes=1 \
+    --migration-test=true \
     --num-windows-nodes="${num_windows_nodes}" \
     --teardown-driver="${teardown_driver}" \
     --do-driver-build="${do_driver_build}" \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug

**What this PR does / why we need it**:
Found out that `--kube-feature-gates` is not used anywhere in the test runner, instead the flag that runs the migration tests is `--migration-test=true`

Might probably need a followup PR to remove the flag `--kube-feature-gates` (which should be the env var KUBE_FEATURE_GATES).

Also the migration scripts for Linux and Windows are the same aside from the flags `--platform=windows --num-windows-nodes="${num_windows_nodes} --storageclass-files=sc-windows.yaml" and `export KUBE_BUILD_PLATFORMS=${KUBE_BUILD_PLATFORMS:-"linux/amd64 windows/amd64"}`, probably another followup PR is to have a single script and then set these values from env vars in the prow job for each platform.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/cc @mattcary 
