### PR TITLE
Upgrade csi snapshotter to v4.1.1 in release testing

### DIFF
--- a/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
+++ b/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
@@ -31,7 +31,7 @@ metadata:
   name: imagetag-csi-snapshotter-prow-head
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-snapshotter
-  newTag: "v4.0.1"
+  newTag: "v4.1.1"
 ---
 apiVersion: builtin
 kind: ImageTagTransformer


### PR DESCRIPTION
/kind cleanup

Update staging with new sidecar versions. After the [staging prow](https://testgrid.corp.google.com/gcp-compute-persistent-disk-csi-driver#pd-master-sidecars-staging-k8s-master-on-gce) (internal google only), which was recently moved to the OSS testgrid [here](https://testgrid.k8s.io/provider-gcp-compute-persistent-disk-csi-driver#Kubernetes%20Master%20Driver%20Latest%20Canary%20Sidecars), is green. 

/assign @mattcary 

**Does this PR introduce a user-facing change?**:
```release-note
None
```
