### PR TITLE
Add support for extra-create-metadata when creating snapshots

### DIFF
--- a/pkg/common/parameters_test.go
+++ b/pkg/common/parameters_test.go
@@ -175,12 +175,25 @@ func TestSnapshotParameters(t *testing.T) {
 		expectError             bool
 	}{
 		{
-			desc:       "valid parameter",
-			parameters: map[string]string{ParameterKeyStorageLocations: "ASIA ", ParameterKeySnapshotType: "images", ParameterKeyImageFamily: "test-family"},
+			desc: "valid parameter",
+			parameters: map[string]string{
+				ParameterKeyStorageLocations:          "ASIA ",
+				ParameterKeySnapshotType:              "images",
+				ParameterKeyImageFamily:               "test-family",
+				ParameterKeyVolumeSnapshotName:        "snapshot-name",
+				ParameterKeyVolumeSnapshotContentName: "snapshot-content-name",
+				ParameterKeyVolumeSnapshotNamespace:   "snapshot-namespace",
+			},
 			expectedSnapshotParames: SnapshotParameters{
 				StorageLocations: []string{"asia"},
 				SnapshotType:     DiskImageType,
 				ImageFamily:      "test-family",
+				Tags: map[string]string{
+					tagKeyCreatedForSnapshotName:        "snapshot-name",
+					tagKeyCreatedForSnapshotContentName: "snapshot-content-name",
+					tagKeyCreatedForSnapshotNamespace:   "snapshot-namespace",
+					tagKeyCreatedBy:                     "test-driver",
+				},
 			},
 			expectError: false,
 		},
@@ -190,6 +203,7 @@ func TestSnapshotParameters(t *testing.T) {
 			expectedSnapshotParames: SnapshotParameters{
 				StorageLocations: []string{},
 				SnapshotType:     DiskSnapshotType,
+				Tags:             make(map[string]string),
 			},
 			expectError: false,
 		},
@@ -201,7 +215,7 @@ func TestSnapshotParameters(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			p, err := ExtractAndDefaultSnapshotParameters(tc.parameters)
+			p, err := ExtractAndDefaultSnapshotParameters(tc.parameters, "test-driver")
 			if err != nil && !tc.expectError {
 				t.Errorf("Got error %v; expect no error", err)
 			}

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -811,7 +811,7 @@ func (gceCS *GCEControllerServer) CreateSnapshot(ctx context.Context, req *csi.C
 		return nil, status.Error(codes.Internal, fmt.Sprintf("CreateSnapshot unknown get disk error: %v", err))
 	}
 
-	snapshotParams, err := common.ExtractAndDefaultSnapshotParameters(req.GetParameters())
+	snapshotParams, err := common.ExtractAndDefaultSnapshotParameters(req.GetParameters(), gceCS.Driver.name)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("Invalid snapshot parameters: %v", err))
 	}

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -940,7 +940,7 @@ func TestCreateVolumeWithVolumeSourceFromSnapshot(t *testing.T) {
 		// Setup new driver each time so no interference
 		gceDriver := initGCEDriver(t, nil)
 
-		snapshotParams, err := common.ExtractAndDefaultSnapshotParameters(nil)
+		snapshotParams, err := common.ExtractAndDefaultSnapshotParameters(nil, gceDriver.name)
 		if err != nil {
 			t.Errorf("Got error extracting snapshot parameters: %v", err)
 		}

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -839,7 +839,12 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		// This is safe because we hardcode the zones.
 		snapshotLocation := z[:len(z)-2]
 
-		snapshotParams := map[string]string{common.ParameterKeyStorageLocations: snapshotLocation}
+		snapshotParams := map[string]string{
+			common.ParameterKeyStorageLocations:          snapshotLocation,
+			common.ParameterKeyVolumeSnapshotName:        "test-volumesnapshot-name",
+			common.ParameterKeyVolumeSnapshotNamespace:   "test-volumesnapshot-namespace",
+			common.ParameterKeyVolumeSnapshotContentName: "test-volumesnapshotcontent-name",
+		}
 		snapshotID, err := client.CreateSnapshot(snapshotName, volID, snapshotParams)
 		Expect(err).To(BeNil(), "CreateSnapshot failed with error: %v", err)
 
@@ -847,6 +852,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		snapshot, err := computeService.Snapshots.Get(p, snapshotName).Do()
 		Expect(err).To(BeNil(), "Could not get snapshot from cloud directly")
 		Expect(snapshot.Name).To(Equal(snapshotName))
+		Expect(snapshot.Description).To(Equal("{\"kubernetes.io/created-for/volumesnapshot/name\":\"test-volumesnapshot-name\",\"kubernetes.io/created-for/volumesnapshot/namespace\":\"test-volumesnapshot-namespace\",\"kubernetes.io/created-for/volumesnapshotcontent/name\":\"test-volumesnapshotcontent-name\",\"storage.gke.io/created-by\":\"pd.csi.storage.gke.io\"}"))
 
 		err = wait.Poll(10*time.Second, 3*time.Minute, func() (bool, error) {
 			snapshot, err := computeService.Snapshots.Get(p, snapshotName).Do()


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds metadata in the description field for Snapshots and Images created from the CreateSnapshot CSI method when the external-snapshotter is run with the `--extra-create-metadata` flag.

**Which issue(s) this PR fixes**:
Fixes #695 

**Does this PR introduce a user-facing change?**:
```release-note
Description field for Images and Snapshots will be filled with JSON encoded metadata containing the name and namespace of the VolumeSnapshot and the name of the VolumeSnapshot content.
```
