### PR TITLE
Automated cherry pick of #930: golang:1.17.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG BUILDPLATFORM
 
-FROM --platform=$BUILDPLATFORM golang:1.17.2 as builder
+FROM --platform=$BUILDPLATFORM golang:1.17.8 as builder
 
 ARG STAGINGVERSION
 ARG TARGETPLATFORM

--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG BASE_IMAGE
-FROM --platform=$BUILDPLATFORM golang:1.13.15 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.17.8 AS builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -14,7 +14,7 @@
 
 ARG BUILDPLATFORM
 
-FROM --platform=$BUILDPLATFORM golang:1.17.2 as builder
+FROM --platform=$BUILDPLATFORM golang:1.17.8 as builder
 
 ARG STAGINGVERSION
 ARG TARGETPLATFORM


### PR DESCRIPTION
Cherry pick of #930 on release-1.4.

#930: golang:1.17.8

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
None
```