### PR TITLE
Automated cherry pick of #930: golang:1.17.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17.2 as builder
+FROM golang:1.17.8 as builder
 
 ARG STAGINGVERSION
 

--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG BASE_IMAGE
-FROM --platform=$BUILDPLATFORM golang:1.13.15 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.17.8 AS builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
Cherry pick of #930 on release-1.2.

#930: golang:1.17.8

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
None
```