### PR TITLE
Add changelog for 1.3.6

### DIFF
--- a/CHANGELOG/CHANGELOG-1.3.md
+++ b/CHANGELOG/CHANGELOG-1.3.md
@@ -1,3 +1,22 @@
+# v1.3.6 - Changelog since v1.3.5
+
+## Changes by Kind
+
+### Uncategorized
+
+- Cherry-pick #930: Update golang version to 1.17.8 for building drivers. ([#937](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/937), [@pwschuurman](https://github.com/pwschuurman))
+
+## Dependencies
+
+### Added
+_Nothing has changed._
+
+### Changed
+_Nothing has changed._
+
+### Removed
+_Nothing has changed._
+
 # v1.3.5 - Changelog since v1.3.4
 
 - Bump base image to buster-v1.10.0


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**: Changelog for patch release 1.3.6

**Does this PR introduce a user-facing change?**: No
```release-note
NONE
```