### PR TITLE
cherrypick #943 - Return error when queued

### DIFF
--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -396,12 +396,16 @@ func (gceCS *GCEControllerServer) ControllerPublishVolume(ctx context.Context, r
 		return gceCS.executeControllerPublishVolume(ctx, req)
 	}
 
-	// Node is marked so queue up the request
+	// Node is marked so queue up the request. Note the original gRPC context may get canceled,
+	// so a new one is created here.
+	//
+	// Note that the original context probably has a timeout (see csiAttach in external-attacher),
+	// which is ignored.
 	gceCS.queue.AddRateLimited(&workItem{
-		ctx:        ctx,
+		ctx:        context.Background(),
 		publishReq: req,
 	})
-	return &csi.ControllerPublishVolumeResponse{}, nil
+	return nil, status.Error(codes.Unavailable, "Request queued due to error condition on node")
 }
 
 func (gceCS *GCEControllerServer) validateControllerPublishVolumeRequest(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (string, *meta.Key, error) {


### PR DESCRIPTION
Change-Id: Ia4933278dba561697abccff8a6e0bc8ab0b98cc4

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This fix is needed in this feature testing branch to make the next set of changes for backoff logic fix
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
