### PR TITLE
Run snapshot class tests separately from other tests

### DIFF
--- a/test/k8s-integration/driver-config.go
+++ b/test/k8s-integration/driver-config.go
@@ -34,7 +34,7 @@ const (
 
 // generateDriverConfigFile loads a testdriver config template and creates a file
 // with the test-specific configuration
-func generateDriverConfigFile(testParams *testParameters, storageClassFile string) (string, error) {
+func generateDriverConfigFile(testParams *testParameters) (string, error) {
 	// Load template
 	t, err := template.ParseFiles(filepath.Join(testParams.pkgDir, testConfigDir, configTemplateFile))
 	if err != nil {
@@ -130,16 +130,18 @@ func generateDriverConfigFile(testParams *testParameters, storageClassFile strin
 	caps = append(caps, "pvcDataSource")
 	minimumVolumeSize := "5Gi"
 	numAllowedTopologies := 1
-	if storageClassFile == regionalPDStorageClass {
+	if testParams.storageClassFile == regionalPDStorageClass {
 		minimumVolumeSize = "200Gi"
 		numAllowedTopologies = 2
 	}
 	timeouts := map[string]string{
 		dataSourceProvisionTimeoutKey: dataSourceProvisionTimeout,
 	}
+	extLoc := strings.LastIndex(testParams.storageClassFile, ".")
+	scName := testParams.storageClassFile[:extLoc]
 	params := driverConfig{
-		StorageClassFile:     filepath.Join(testParams.pkgDir, testConfigDir, storageClassFile),
-		StorageClass:         storageClassFile[:strings.LastIndex(storageClassFile, ".")],
+		StorageClassFile:     filepath.Join(testParams.pkgDir, testConfigDir, testParams.storageClassFile),
+		StorageClass:         scName,
 		SnapshotClassFile:    absSnapshotClassFilePath,
 		SnapshotClass:        snapshotClassName,
 		SupportedFsType:      fsTypes,

--- a/test/run-k8s-integration-ci.sh
+++ b/test/run-k8s-integration-ci.sh
@@ -29,7 +29,7 @@ readonly run_intree_plugin_tests=${RUN_INTREE_PLUGIN_TESTS:-false}
 readonly use_kubetest2=${USE_KUBETEST2:-true}
 readonly test_pd_labels=${TEST_PD_LABELS:-true}
 readonly migration_test=${MIGRATION_TEST:-false}
-readonly test_disk_image_snapshot=${TEST_DISK_IMAGE_SNAPSHOT:-false}
+readonly test_disk_image_snapshot=${TEST_DISK_IMAGE_SNAPSHOT:-true}
 
 readonly GCE_PD_TEST_FOCUS="PersistentVolumes\sGCEPD|[V|v]olume\sexpand|\[sig-storage\]\sIn-tree\sVolumes\s\[Driver:\sgcepd\]|allowedTopologies|Pod\sDisks|PersistentVolumes\sDefault"
 


### PR DESCRIPTION
Running all snapshot classes with all storage class is causing timeouts. Running the snapshot tests with just one storageclass does not substantially reduce the test coverage.

/kind failing-test

```release-note
None
```
