### PR TITLE
Increase prepull image timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ gce-pd-driver: require-GCE_PD_CSI_STAGING_VERSION
 	go build -mod=vendor -gcflags=$(GCFLAGS) -ldflags "-X main.version=$(STAGINGVERSION)" -o bin/${DRIVERBINARY} ./cmd/gce-pd-csi-driver/
 
 gce-pd-driver-windows: require-GCE_PD_CSI_STAGING_VERSION
-ifeq (GOARCH, amd64)
+ifeq (${GOARCH}, amd64)
 	mkdir -p bin
 	GOOS=windows go build -mod=vendor -ldflags -X=main.version=$(STAGINGVERSION) -o bin/${DRIVERWINDOWSBINARY} ./cmd/gce-pd-csi-driver/
 else

--- a/test/k8s-integration/prepull-image.sh
+++ b/test/k8s-integration/prepull-image.sh
@@ -9,8 +9,8 @@ readonly prepull_daemonset=prepull-test-containers
 
 wait_on_prepull()
 {
-    # Wait up to 15 minutes for the test images to be pulled onto the nodes.
-    retries=90
+    # Wait up to 30 minutes for the test images to be pulled onto the nodes.
+    retries=180
     while [[ $retries -ge 0 ]];do
         ready=$(kubectl get daemonset "${prepull_daemonset}" -o jsonpath="{.status.numberReady}")
         required=$(kubectl get daemonset "${prepull_daemonset}" -o jsonpath="{.status.desiredNumberScheduled}")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Increases the agnhost image pull timeout from 15m to 30m, ref this comment https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/892#issuecomment-1117599792, it also fixes doing builds on the windows binary.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @mattcary @DW2022511 
