### PR TITLE
Add runtime libraries necessary for sed (dependency of lib/udev_conta…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,8 @@ COPY --from=debian /lib/x86_64-linux-gnu/libreadline.so.5 /lib/x86_64-linux-gnu/
 COPY --from=debian /lib/x86_64-linux-gnu/libselinux.so.1 /lib/x86_64-linux-gnu/libselinux.so.1
 COPY --from=debian /lib/x86_64-linux-gnu/libtinfo.so.6 /lib/x86_64-linux-gnu/libtinfo.so.6
 COPY --from=debian /lib/x86_64-linux-gnu/libuuid.so.1 /lib/x86_64-linux-gnu/libuuid.so.1
+COPY --from=debian /usr/lib/x86_64-linux-gnu/libattr.so.1 /usr/lib/x86_64-linux-gnu/libattr.so.1
+COPY --from=debian /usr/lib/x86_64-linux-gnu/libacl.so.1 /usr/lib/x86_64-linux-gnu/libacl.so.1
 
 # Copy NVME support required script and rules into distroless base.
 COPY deploy/kubernetes/udev/google_nvme_id /lib/udev_containerized/google_nvme_id


### PR DESCRIPTION
Add runtime libraries necessary for sed (dependency of lib/udev_containerized/google_nvme_id)

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: This adds necessary dependencies for the 'sed' script that is used by /lib/udev_containerized/google_nvme_id

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
