### PR TITLE
Add Makefile target that validates the Dockerfile images contain the correct shared library dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ENV LIB_DIR_PREFIX x86_64
 FROM distroless-base AS distroless-arm64
 ENV LIB_DIR_PREFIX aarch64
 
-FROM distroless-$TARGETARCH
+FROM distroless-$TARGETARCH as output-image
 
 # Copy necessary dependencies into distroless base.
 COPY --from=builder /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/bin/gce-pd-csi-driver /gce-pd-csi-driver
@@ -97,5 +97,17 @@ COPY --from=debian /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libacl.so.1 \
 
 # Copy NVME support required script and rules into distroless base.
 COPY deploy/kubernetes/udev/google_nvme_id /lib/udev_containerized/google_nvme_id
+
+# Build stage used for validation of the output-image
+# See validate-container-linux-* targets in Makefile
+FROM output-image as validation-image
+
+COPY --from=debian /usr/bin/ldd /usr/bin/find /usr/bin/xargs /usr/bin/
+COPY --from=builder /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/hack/print-missing-deps.sh /print-missing-deps.sh
+SHELL ["/bin/bash", "-c"]
+RUN /print-missing-deps.sh
+
+# Final build stage, create the real Docker image with ENTRYPOINT
+FROM output-image
 
 ENTRYPOINT ["/gce-pd-csi-driver"]

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,22 @@ build-and-push-multi-arch-debug: build-and-push-container-linux-debug build-and-
 
 push-container: build-container
 
+# Used by hack/verify-docker-deps.sh, not used for building artifacts
+validate-container-linux-amd64: init-buildx
+	$(DOCKER) buildx build --platform=linux/amd64 \
+		-t validation_linux_amd64 \
+		--target validation-image \
+		--build-arg BUILDPLATFORM=linux \
+		--build-arg STAGINGVERSION=$(STAGINGVERSION) .
+
+# Used by hack/verify-docker-deps.sh, not used for building artifacts
+validate-container-linux-arm64: init-buildx
+	$(DOCKER) buildx build --platform=linux/arm64 \
+		-t validation_linux_arm64 \
+		--target validation-image \
+		--build-arg BUILDPLATFORM=linux \
+		--build-arg STAGINGVERSION=$(STAGINGVERSION) .
+
 build-and-push-container-linux-amd64: require-GCE_PD_CSI_STAGING_IMAGE init-buildx
 	$(DOCKER) buildx build --platform=linux/amd64 \
 		-t $(STAGINGIMAGE):$(STAGINGVERSION)_linux_amd64 \

--- a/hack/print-missing-deps.sh
+++ b/hack/print-missing-deps.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "Verifying Docker Executables have appropriate dependencies"
+
+printMissingDep() {
+  if /usr/bin/ldd "$@" | grep "not found"; then
+    echo "!!! Missing deps for $@ !!!"
+    exit 1
+  fi
+}
+
+export -f printMissingDep
+
+/usr/bin/find / -type f -executable -print | /usr/bin/xargs -I {} /bin/bash -c 'printMissingDep "{}"'

--- a/hack/verify-docker-deps.sh
+++ b/hack/verify-docker-deps.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "Verifying Docker Image Dependencies"
+
+PKG_ROOT=$(git rev-parse --show-toplevel)
+
+make -C "${PKG_ROOT}" validate-container-linux-amd64 validate-container-linux-arm64


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**: This uses ldd on the target architecture (amd64/arm64) to validate if all direct and indirect dependencies of a program. The underlying logic leverages ldd to find dependencies that are "not found". This is helpful to catch in presubmit issues where all the runtime libs were not included. See #974 as an example of this.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
