### PR TITLE
Remove workaround to add os.version to the manifest for Windows images

### DIFF
--- a/manifest_osversion.sh
+++ b/manifest_osversion.sh
@@ -32,8 +32,8 @@ for ((i=0;i<${#imagetags[@]};++i)); do
   image_folder=$(echo "${IMAGETAG}" | sed "s|/|_|g" | sed "s/:/-/")
   echo ${manifest_folder}
 
-  sed -i -r "s/(\"os\"\:\"windows\")/\0,\"os.version\":$full_version/" \
-  "${HOME}/.docker/manifests/${manifest_folder}/${image_folder}"
+  # sed -i -r "s/(\"os\"\:\"windows\")/\0,\"os.version\":$full_version/" \
+  # "${HOME}/.docker/manifests/${manifest_folder}/${image_folder}"
 
   # manifest after transformations
   cat "${HOME}/.docker/manifests/${manifest_folder}/${image_folder}"


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind bug

**What this PR does / why we need it**:

It looks like a recent version of docker in CI is adding `os.version` so the workaround to add it on our own is no longer needed, this was causing a double `os.version` to be added to the manifest as seen here:

```
I0512 18:36:46.423] {"Ref":"gcr.io/gce-cvm-upg-lat-1-3-ctl-skew/gcp-persistent-disk-csi-driver:d5486a25-280b-4d7e-a899-98a3f37b0818_ltsc2019","Descriptor":{"mediaType":"application/vnd.docker.distribution.manifest.v2+json","digest":"sha256:cb0b111aba51dfdfcf8fcdec778c20c3bf153c9180bcbaf597c7a5f58c886794","size":956,"platform":{"architecture":"amd64","os":"windows","os.version":"10.0.17763.2928",,"os.version":"10.0.17763.2928"}}, ...}
```

I'm commenting the part that performs the text replacement, if this works then eventually this file and its usages should be removed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #982 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/assign @saikat-royc 