### PR TITLE
Automated cherry pick of #986: Remove workaround to add os.version to the manifest for

### DIFF
--- a/manifest_osversion.sh
+++ b/manifest_osversion.sh
@@ -32,8 +32,8 @@ for ((i=0;i<${#imagetags[@]};++i)); do
   image_folder=$(echo "${IMAGETAG}" | sed "s|/|_|g" | sed "s/:/-/")
   echo ${manifest_folder}
 
-  sed -i -r "s/(\"os\"\:\"windows\")/\0,\"os.version\":$full_version/" \
-  "${HOME}/.docker/manifests/${manifest_folder}/${image_folder}"
+  # sed -i -r "s/(\"os\"\:\"windows\")/\0,\"os.version\":$full_version/" \
+  # "${HOME}/.docker/manifests/${manifest_folder}/${image_folder}"
 
   # manifest after transformations
   cat "${HOME}/.docker/manifests/${manifest_folder}/${image_folder}"


### PR DESCRIPTION
Cherry pick of #986 on release-1.7.

#986: Remove workaround to add os.version to the manifest for

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

**Does this PR introduce a user-facing change?:**
```release-note
NONE
```