### PR TITLE
Backport maxprocs (#969)

### DIFF
--- a/cmd/gce-pd-csi-driver/main.go
+++ b/cmd/gce-pd-csi-driver/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"math/rand"
 	"os"
+	"runtime"
 	"time"
 
 	"k8s.io/klog"
@@ -40,7 +41,10 @@ var (
 	httpEndpoint         = flag.String("http-endpoint", "", "The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled.")
 	metricsPath          = flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.")
 	extraVolumeLabelsStr = flag.String("extra-labels", "", "Extra labels to attach to each PD created. It is a comma separated list of key value pairs like '<key1>=<value1>,<key2>=<value2>'. See https://cloud.google.com/compute/docs/labeling-resources for details")
-	version              string
+
+	maxprocs = flag.Int("maxprocs", 1, "GOMAXPROCS override")
+
+	version string
 )
 
 const (
@@ -66,6 +70,9 @@ func main() {
 
 func handle() {
 	var err error
+
+	runtime.GOMAXPROCS(*maxprocs)
+	klog.Infof("Sys info: NumCPU: %v MAXPROC: %v", runtime.NumCPU(), runtime.GOMAXPROCS(0))
 
 	if version == "" {
 		klog.Fatalf("version must be set at compile time")


### PR DESCRIPTION
Backport #969, which fixes memory issues (See #968).
/kind bug

```release-note
Backport of memory usage fix #969 for #968 (by setting go maxprocs to 1)
```

/assign @amacaskill 