### PR TITLE
Skip node skew tests using ephemeral containers

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -620,6 +620,15 @@ func generateGKETestSkip(testParams *testParameters) string {
 		(!testParams.useGKEManagedDriver && (*curVer).lessThan(mustParseVersion("1.17.0"))) {
 		skipString = skipString + "|VolumeSnapshotDataSource"
 	}
+
+	// Starting in 1.23, the storage framework uses ephemeral containers for
+	// testing data written to a pod. This is enabled by looking only at the
+	// control plane, so it breaks on node skew tests when ephemeral containers
+	// exist in the API but aren't supported on the node.
+	if nodeVer != nil && nodeVer.lessThan(mustParseVersion("1.23.0")) && mustParseVersion("1.23.0").lessThan(curVer) {
+		skipString = skipString + "|volumes.should.store.data|provisioning.should.provision.storage.with.snapshot.data.source"
+	}
+
 	return skipString
 }
 


### PR DESCRIPTION
/assign @leiyiz 

/kind failing-test

```release-note
None
```
