### PR TITLE
update go builder to 1.18.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG BUILDPLATFORM
 
-FROM --platform=$BUILDPLATFORM golang:1.17.8 as builder
+FROM --platform=$BUILDPLATFORM golang:1.18.4 as builder
 
 ARG STAGINGVERSION
 ARG TARGETPLATFORM


### PR DESCRIPTION
/kind cleanup
```release-note
Go builder updated from 1.17 to 1.18.4. This fixes several CVEs, CVE-2022-24675, CVE-2022-28327, CVE-2022-2068.
```

/assign @leiyiz 