### PR TITLE
Cherry-pick #1031: update go to 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG BUILDPLATFORM
 
-FROM --platform=$BUILDPLATFORM golang:1.17.8 as builder
+FROM --platform=$BUILDPLATFORM golang:1.18.4 as builder
 
 ARG STAGINGVERSION
 ARG TARGETPLATFORM


### PR DESCRIPTION
Cherrypick of #1031
/kind cleanup
```release-note
Update golang to 1.18.4
```
