### PR TITLE
Fix incorrect example in installation README

### DIFF
--- a/docs/kubernetes/user-guides/driver-install.md
+++ b/docs/kubernetes/user-guides/driver-install.md
@@ -50,7 +50,7 @@ specified service account
 
 ```console
 $ GCE_PD_SA_DIR=/my/safe/credentials/directory    # Directory to get the service account key
-$ GCE_PD_DRIVER_VERSION=stable                    # Driver version to deploy
+$ GCE_PD_DRIVER_VERSION=stable-master             # Driver version to deploy
 $ ./deploy/kubernetes/deploy-driver.sh
 ```
 


### PR DESCRIPTION
Currently there is no `stable` overlay available, example in README should use [`stable-master`](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/tree/master/deploy/kubernetes/overlays/stable-master) instead.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design

/kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fixes incorrect documentation for installing the driver.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
