### PR TITLE
Skip disk image tests before 1.21

### DIFF
--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -1117,9 +1117,13 @@ func (cloud *CloudProvider) waitForSnapshotCreation(ctx context.Context, project
 
 // kmsKeyEqual returns true if fetchedKMSKey and storageClassKMSKey refer to the same key.
 // fetchedKMSKey - key returned by the server
-//        example: projects/{0}/locations/{1}/keyRings/{2}/cryptoKeys/{3}/cryptoKeyVersions/{4}
+//
+//	example: projects/{0}/locations/{1}/keyRings/{2}/cryptoKeys/{3}/cryptoKeyVersions/{4}
+//
 // storageClassKMSKey - key as provided by the client
-//        example: projects/{0}/locations/{1}/keyRings/{2}/cryptoKeys/{3}
+//
+//	example: projects/{0}/locations/{1}/keyRings/{2}/cryptoKeys/{3}
+//
 // cryptoKeyVersions should be disregarded if the rest of the key is identical.
 func KmsKeyEqual(fetchedKMSKey, storageClassKMSKey string) bool {
 	return removeCryptoKeyVersion(fetchedKMSKey) == removeCryptoKeyVersion(storageClassKMSKey)

--- a/pkg/gce-pd-csi-driver/node_test.go
+++ b/pkg/gce-pd-csi-driver/node_test.go
@@ -4,7 +4,9 @@ Copyright 2018 The Kubernetes Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/test/k8s-integration/version.go
+++ b/test/k8s-integration/version.go
@@ -131,9 +131,10 @@ func mustParseVersion(version string) *version {
 }
 
 // Helper function to compare versions.
-//  -1 -- if left  < right
-//   0 -- if left == right
-//   1 -- if left  > right
+//
+//	-1 -- if left  < right
+//	 0 -- if left == right
+//	 1 -- if left  > right
 func (v *version) compare(right *version) int {
 	for i, b := range v.version {
 		if b > right.version[i] {

--- a/test/k8s-integration/version.go
+++ b/test/k8s-integration/version.go
@@ -12,10 +12,11 @@ import (
 
 var (
 	versionNum           = `(0|[1-9][0-9]*)`
-	internalPatchVersion = `(\-[a-zA-Z0-9_.+-]+)`
+	internalPatchVersion = `(\-gke\.[0-9]+)`
 
 	versionRegex         = regexp.MustCompile(`^` + versionNum + `\.` + versionNum + `\.` + versionNum + internalPatchVersion + "?$")
 	minorVersionRegex    = regexp.MustCompile(`^` + versionNum + `\.` + versionNum + `$`)
+	alphaVersionRegex    = regexp.MustCompile(`^` + versionNum + `\.` + versionNum + `\.` + versionNum + `-alpha.*`)
 	gkeExtraVersionRegex = regexp.MustCompile(`^(?:gke)\.(0|[1-9][0-9]*)$`)
 )
 
@@ -24,7 +25,9 @@ type version struct {
 }
 
 func (v *version) String() string {
-	if v.version[3] != -1 {
+	if v.version[3] == -2 {
+		return fmt.Sprintf("%d.%d.%d-alpha", v.version[0], v.version[1], v.version[2])
+	} else if v.version[3] != -1 {
 		return fmt.Sprintf("%d.%d.%d-gke.%d", v.version[0], v.version[1], v.version[2], v.version[3])
 	}
 
@@ -82,6 +85,10 @@ func parseVersion(vs string) (*version, error) {
 	case versionRegex.MatchString(vs):
 		submatches = versionRegex.FindStringSubmatch(vs)
 		lastIndex = 4
+	case alphaVersionRegex.MatchString(vs):
+		submatches = alphaVersionRegex.FindStringSubmatch(vs)
+		v.version[3] = -2
+		lastIndex = 4
 	case minorVersionRegex.MatchString(vs):
 		submatches = minorVersionRegex.FindStringSubmatch(vs)
 		v.version[2] = -1
@@ -99,7 +106,7 @@ func parseVersion(vs string) (*version, error) {
 		}
 	}
 
-	if minorVersionRegex.MatchString(vs) {
+	if minorVersionRegex.MatchString(vs) || alphaVersionRegex.MatchString(vs) {
 		return &v, nil
 	}
 

--- a/test/k8s-integration/version_test.go
+++ b/test/k8s-integration/version_test.go
@@ -72,6 +72,12 @@ func TestParseVersion(t *testing.T) {
 				version: [4]int{1, 20, -1, -1},
 			},
 		},
+		{
+			version: "v1.26.0-alpha.0.293+6e3d62ca1c9e11",
+			expectedV: version{
+				version: [4]int{1, 26, 0, -2},
+			},
+		},
 		// Negative test cases
 		{
 			version:   "1",
@@ -106,11 +112,11 @@ func TestParseVersion(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			version:   "1.18.0-alpha.x",
+			version:   "1.18.0-beta.x",
 			expectErr: true,
 		},
 		{
-			version:   "1.18.0-alpha.beta.1",
+			version:   "1.18.0-beta.alpha.1",
 			expectErr: true,
 		},
 		{
@@ -119,10 +125,6 @@ func TestParseVersion(t *testing.T) {
 		},
 		{
 			version:   "1.18-alpha.3.673+73326ef01d2d7c",
-			expectErr: true,
-		},
-		{
-			version:   "1.18.3-alpha.3.673+73326ef01d2d7c",
 			expectErr: true,
 		},
 	}
@@ -138,7 +140,7 @@ func TestParseVersion(t *testing.T) {
 			}
 
 			if err == nil && tc.expectErr {
-				t.Fatal("Got no error but expected one")
+				t.Fatalf("Got no error but expected one with version %s", tc.version)
 				return
 			}
 


### PR DESCRIPTION
This fixes test failures in GKE stable.

/kind failing-test
/assign @amacaskill 

```release-note
None
```
