### PR TITLE
Fix the kubetest version to 0e09086b60c122e1084edd2368d3d27fe36f384f

### DIFF
--- a/test/run-windows-k8s-integration.sh
+++ b/test/run-windows-k8s-integration.sh
@@ -28,10 +28,11 @@ export KUBE_BUILD_PLATFORMS=${KUBE_BUILD_PLATFORMS:-"linux/amd64 windows/amd64"}
 make -C "${PKGDIR}" test-k8s-integration
 
 if [ "$use_kubetest2" = true ]; then
-    go install sigs.k8s.io/kubetest2@latest;
-    go install sigs.k8s.io/kubetest2/kubetest2-gce@latest;
-    go install sigs.k8s.io/kubetest2/kubetest2-gke@latest;
-    go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
+    kt2_version=0e09086b60c122e1084edd2368d3d27fe36f384f
+    go install sigs.k8s.io/kubetest2@${kt2_version}
+    go install sigs.k8s.io/kubetest2/kubetest2-gce@${kt2_version}
+    go install sigs.k8s.io/kubetest2/kubetest2-gke@${kt2_version}
+    go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@${kt2_version}
 fi
 
 ${PKGDIR}/bin/k8s-integration-test \

--- a/test/run-windows-k8s-migration.sh
+++ b/test/run-windows-k8s-migration.sh
@@ -31,10 +31,11 @@ make -C "${PKGDIR}" test-k8s-integration
 
 if [ "$use_kubetest2" = true ]; then
     export GO111MODULE=on;
-    go get sigs.k8s.io/kubetest2@latest;
-    go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;
-    go get sigs.k8s.io/kubetest2/kubetest2-gke@latest;
-    go get sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
+    kt2_version=0e09086b60c122e1084edd2368d3d27fe36f384f
+    go install sigs.k8s.io/kubetest2@${kt2_version}
+    go install sigs.k8s.io/kubetest2/kubetest2-gce@${kt2_version}
+    go install sigs.k8s.io/kubetest2/kubetest2-gke@${kt2_version}
+    go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@${kt2_version}
 fi
 
 readonly GCE_PD_TEST_FOCUS="PersistentVolumes\sGCEPD|[V|v]olume\sexpand|\[sig-storage\]\sIn-tree\sVolumes\s\[Driver:\swindows-gcepd\]|allowedTopologies|Pod\sDisks|PersistentVolumes\sDefault"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Fixes the kubetest2 version in Windows tests just like the Linux tests.
Ref https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1024

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Attempts to solve #880

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @alexander-ding @mattcary 