### PR TITLE
fix: copy compiled binary into final image

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -33,6 +33,7 @@ FROM k8s.gcr.io/build-image/debian-base-amd64:buster-v1.5.0
 # Copy source code too to correlate the binary and the breakpoints
 WORKDIR /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 ADD . .
+COPY --from=builder /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/bin/gce-pd-csi-driver /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/bin/gce-pd-csi-driver
 
 COPY --from=builder /go/bin/dlv /go/bin/dlv
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What does the PR do?**

The Debug Dockerfile doesn't copy the built binary into the final image. Adding a single line to fix

```release-note
NONE
```