### PR TITLE
add beta/v1 suffix to passed-in compute endpoint

### DIFF
--- a/pkg/gce-cloud-provider/compute/gce.go
+++ b/pkg/gce-cloud-provider/compute/gce.go
@@ -163,7 +163,8 @@ func createBetaCloudService(ctx context.Context, vendorVersion string, tokenSour
 
 	computeOpts := []option.ClientOption{option.WithHTTPClient(client)}
 	if computeEndpoint != "" {
-		computeOpts = append(computeOpts, option.WithEndpoint(computeEndpoint))
+		betaEndpoint := fmt.Sprintf("%s/compute/beta/", computeEndpoint)
+		computeOpts = append(computeOpts, option.WithEndpoint(betaEndpoint))
 	}
 	service, err := computebeta.NewService(ctx, computeOpts...)
 	if err != nil {
@@ -186,7 +187,8 @@ func createCloudServiceWithDefaultServiceAccount(ctx context.Context, vendorVers
 
 	computeOpts := []option.ClientOption{option.WithHTTPClient(client)}
 	if computeEndpoint != "" {
-		computeOpts = append(computeOpts, option.WithEndpoint(computeEndpoint))
+		v1Endpoint := fmt.Sprintf("%s/compute/v1/", computeEndpoint)
+		computeOpts = append(computeOpts, option.WithEndpoint(v1Endpoint))
 	}
 	service, err := compute.NewService(ctx, computeOpts...)
 	if err != nil {

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -1150,7 +1150,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		Expect(err.Error()).To(ContainSubstring("no such host"), "expected error when passed invalid compute url")
 
 		// Create new driver and client w/ valid, passed-in endpoint
-		tcValid, err := testutils.GCEClientAndDriverSetup(i, "https://compute.googleapis.com/compute/v1/")
+		tcValid, err := testutils.GCEClientAndDriverSetup(i, "https://compute.googleapis.com")
 		if err != nil {
 			klog.Fatalf("Failed to set up Test Context for instance %v: %v", i.GetName(), err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This is a follow up to github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1077 which added a configurable compute endpoint to pdcsi driver. It adds the /compute/{beta/v1} suffix to the endpoint since we can't expect that from the caller.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
