### PR TITLE
Fix resize-related sanity test failures

### DIFF
--- a/cmd/gce-pd-csi-driver/main.go
+++ b/cmd/gce-pd-csi-driver/main.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/deviceutils"
 	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute"
 	metadataservice "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/metadata"
 	driver "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-pd-csi-driver"
@@ -134,7 +135,7 @@ func handle() {
 		if err != nil {
 			klog.Fatalf("Failed to get safe mounter: %w", err)
 		}
-		deviceUtils := mountmanager.NewDeviceUtils()
+		deviceUtils := deviceutils.NewDeviceUtils()
 		statter := mountmanager.NewStatter(mounter)
 		meta, err := metadataservice.NewMetadataService()
 		if err != nil {

--- a/pkg/deviceutils/device-utils.go
+++ b/pkg/deviceutils/device-utils.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package mountmanager
+package deviceutils
 
 import (
 	"fmt"
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	pathutils "k8s.io/utils/path"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/resizefs"
 )
 
 const (
@@ -84,6 +85,9 @@ type DeviceUtils interface {
 	// DisableDevice performs necessary disabling prior to a device being
 	// detached from a node. The path is that from GetDiskByIdPaths.
 	DisableDevice(devicePath string) error
+
+	// Resize returns whether or not a device needs resizing.
+	Resize(resizer resizefs.Resizefs, devicePath string, deviceMountPath string) (bool, error)
 }
 
 type deviceUtils struct {
@@ -272,6 +276,10 @@ func (m *deviceUtils) VerifyDevicePath(devicePaths []string, deviceName string) 
 	}
 
 	return devicePath, nil
+}
+
+func (m *deviceUtils) Resize(resizer resizefs.Resizefs, devicePath string, deviceMountPath string) (bool, error) {
+	return resizer.Resize(devicePath, deviceMountPath)
 }
 
 // getDevFsSerial returns the serial number of the /dev/* path at devFsPath.

--- a/pkg/deviceutils/device-utils_linux.go
+++ b/pkg/deviceutils/device-utils_linux.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package mountmanager
+package deviceutils
 
 import (
 	"fmt"

--- a/pkg/deviceutils/device-utils_test.go
+++ b/pkg/deviceutils/device-utils_test.go
@@ -1,4 +1,4 @@
-package mountmanager
+package deviceutils
 
 import (
 	"testing"

--- a/pkg/deviceutils/device-utils_windows.go
+++ b/pkg/deviceutils/device-utils_windows.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package mountmanager
+package deviceutils
 
 func (_ *deviceUtils) DisableDevice(devicePath string) error {
 	// No disabling is necessary on windows.

--- a/pkg/deviceutils/fake-device-utils.go
+++ b/pkg/deviceutils/fake-device-utils.go
@@ -12,7 +12,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package mountmanager
+package deviceutils
+
+import "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/resizefs"
 
 type fakeDeviceUtils struct {
 }
@@ -37,4 +39,8 @@ func (m *fakeDeviceUtils) VerifyDevicePath(devicePaths []string, diskName string
 func (_ *fakeDeviceUtils) DisableDevice(devicePath string) error {
 	// No-op for testing.
 	return nil
+}
+
+func (_ *fakeDeviceUtils) Resize(resizer resizefs.Resizefs, devicePath string, deviceMountPath string) (bool, error) {
+	return false, nil
 }

--- a/pkg/gce-pd-csi-driver/gce-pd-driver.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/mount-utils"
 	common "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/deviceutils"
 	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute"
 	metadataservice "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/metadata"
 	mountmanager "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/mount-manager"
@@ -137,7 +138,7 @@ func NewIdentityServer(gceDriver *GCEDriver) *GCEIdentityServer {
 	}
 }
 
-func NewNodeServer(gceDriver *GCEDriver, mounter *mount.SafeFormatAndMount, deviceUtils mountmanager.DeviceUtils, meta metadataservice.MetadataService, statter mountmanager.Statter) *GCENodeServer {
+func NewNodeServer(gceDriver *GCEDriver, mounter *mount.SafeFormatAndMount, deviceUtils deviceutils.DeviceUtils, meta metadataservice.MetadataService, statter mountmanager.Statter) *GCENodeServer {
 	return &GCENodeServer{
 		Driver:          gceDriver,
 		Mounter:         mounter,

--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/mount-utils"
 
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/deviceutils"
 	metadataservice "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/metadata"
 	mountmanager "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/mount-manager"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/resizefs"
@@ -38,7 +39,7 @@ import (
 type GCENodeServer struct {
 	Driver          *GCEDriver
 	Mounter         *mount.SafeFormatAndMount
-	DeviceUtils     mountmanager.DeviceUtils
+	DeviceUtils     deviceutils.DeviceUtils
 	VolumeStatter   mountmanager.Statter
 	MetadataService metadataservice.MetadataService
 
@@ -343,10 +344,9 @@ func (ns *GCENodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStage
 	// Part 4: Resize filesystem.
 	// https://github.com/kubernetes/kubernetes/issues/94929
 	resizer := resizefs.NewResizeFs(ns.Mounter)
-	_, err = resizer.Resize(devicePath, stagingTargetPath)
+	_, err = ns.DeviceUtils.Resize(resizer, devicePath, stagingTargetPath)
 	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("error when resizing volume %s: %v", volumeID, err))
-
+		return nil, status.Error(codes.Internal, fmt.Sprintf("error when resizing volume %s from device '%s' at path '%s': %v", volumeID, devicePath, stagingTargetPath, err))
 	}
 
 	klog.V(4).Infof("NodeStageVolume succeeded on %v to %s", volumeID, stagingTargetPath)
@@ -508,7 +508,7 @@ func (ns *GCENodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpa
 	resizer := resizefs.NewResizeFs(ns.Mounter)
 	_, err = resizer.Resize(devicePath, volumePath)
 	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("error when resizing volume %s: %v", volKey.String(), err))
+		return nil, status.Error(codes.Internal, fmt.Sprintf("error when resizing volume %s from device '%s' at path '%s': %v", volKey.String(), devicePath, volumePath, err))
 
 	}
 

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/deviceutils"
 	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute"
-	mountmanager "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/mount-manager"
 	testutils "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/test/e2e/utils"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/test/remote"
 
@@ -122,7 +122,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		}()
 
 		// MESS UP THE symlink
-		devicePaths := mountmanager.NewDeviceUtils().GetDiskByIdPaths(volName, "")
+		devicePaths := deviceutils.NewDeviceUtils().GetDiskByIdPaths(volName, "")
 		for _, devicePath := range devicePaths {
 			err = testutils.RmAll(instance, devicePath)
 			Expect(err).To(BeNil(), "failed to remove /dev/by-id folder")
@@ -194,7 +194,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		}()
 
 		// DELETE THE symlink
-		devicePaths := mountmanager.NewDeviceUtils().GetDiskByIdPaths(volName, "")
+		devicePaths := deviceutils.NewDeviceUtils().GetDiskByIdPaths(volName, "")
 		for _, devicePath := range devicePaths {
 			err = testutils.RmAll(instance, devicePath)
 			Expect(err).To(BeNil(), "failed to remove /dev/by-id folder")

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -28,6 +28,7 @@ import (
 	sanity "github.com/kubernetes-csi/csi-test/v4/pkg/sanity"
 	compute "google.golang.org/api/compute/v1"
 	common "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/deviceutils"
 	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute"
 	metadataservice "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/metadata"
 	driver "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-pd-csi-driver"
@@ -60,7 +61,7 @@ func TestSanity(t *testing.T) {
 	}
 
 	mounter := mountmanager.NewFakeSafeMounter()
-	deviceUtils := mountmanager.NewFakeDeviceUtils()
+	deviceUtils := deviceutils.NewFakeDeviceUtils()
 
 	//Initialize GCE Driver
 	identityServer := driver.NewIdentityServer(gceDriver)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:
Our sanity tests are currently failing 4 test cases: 1 because of go/pdcsi-oss-driver/issues/990 to be addressed in a follow up in another repo, and 3 others with the error:

```
Could not determine if filesystem \"/tmp/csi/stage\" needs to be resized: failed to parse size of device /dev/disk/fake-path
```
This PR fixes the latter 3 failures by mocking out the resize method.

Note this also required moving deviceutils into its own pkg to avoid a circular dependency from mountmanager (device utils) -> resize -> mountmanager (windows).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
