### PR TITLE
added labels for namespace and pvc names for a pv

### DIFF
--- a/pkg/common/parameters.go
+++ b/pkg/common/parameters.go
@@ -56,6 +56,11 @@ const (
 	tagKeyCreatedForSnapshotName        = "kubernetes.io/created-for/volumesnapshot/name"
 	tagKeyCreatedForSnapshotNamespace   = "kubernetes.io/created-for/volumesnapshot/namespace"
 	tagKeyCreatedForSnapshotContentName = "kubernetes.io/created-for/volumesnapshotcontent/name"
+
+	// Keys for labels to tag to PV
+	labelKeyCreatedForClaimNamespace = "kubernetes_io_created-for_pvc_namespace"
+	labelKeyCreatedForClaimName      = "kubernetes_io_created-for_pvc_name"
+	labelKeyCreatedForVolumeName     = "kubernetes_io_created-for_pv_name"
 )
 
 // DiskParameters contains normalized and defaulted disk parameters
@@ -120,12 +125,15 @@ func ExtractAndDefaultParameters(parameters map[string]string, driverName string
 		case ParameterKeyDiskEncryptionKmsKey:
 			// Resource names (e.g. "keyRings", "cryptoKeys", etc.) are case sensitive, so do not change case
 			p.DiskEncryptionKMSKey = v
-		case ParameterKeyPVCName:
-			p.Tags[tagKeyCreatedForClaimName] = v
-		case ParameterKeyPVCNamespace:
-			p.Tags[tagKeyCreatedForClaimNamespace] = v
-		case ParameterKeyPVName:
-			p.Tags[tagKeyCreatedForVolumeName] = v
+        case ParameterKeyPVCName:
+            p.Tags[tagKeyCreatedForClaimName] = v
+            p.Labels[labelKeyCreatedForClaimName] = v
+        case ParameterKeyPVCNamespace:
+            p.Tags[tagKeyCreatedForClaimNamespace] = v
+            p.Labels[labelKeyCreatedForClaimNamespace] = v
+        case ParameterKeyPVName:
+            p.Tags[tagKeyCreatedForVolumeName] = v
+            p.Labels[labelKeyCreatedForVolumeName] = v
 		case ParameterKeyLabels:
 			paramLabels, err := ConvertLabelsStringToMap(v)
 			if err != nil {

--- a/pkg/common/parameters.go
+++ b/pkg/common/parameters.go
@@ -125,15 +125,15 @@ func ExtractAndDefaultParameters(parameters map[string]string, driverName string
 		case ParameterKeyDiskEncryptionKmsKey:
 			// Resource names (e.g. "keyRings", "cryptoKeys", etc.) are case sensitive, so do not change case
 			p.DiskEncryptionKMSKey = v
-        case ParameterKeyPVCName:
-            p.Tags[tagKeyCreatedForClaimName] = v
-            p.Labels[labelKeyCreatedForClaimName] = v
-        case ParameterKeyPVCNamespace:
-            p.Tags[tagKeyCreatedForClaimNamespace] = v
-            p.Labels[labelKeyCreatedForClaimNamespace] = v
-        case ParameterKeyPVName:
-            p.Tags[tagKeyCreatedForVolumeName] = v
-            p.Labels[labelKeyCreatedForVolumeName] = v
+		case ParameterKeyPVCName:
+			p.Tags[tagKeyCreatedForClaimName] = v
+			p.Labels[labelKeyCreatedForClaimName] = v
+		case ParameterKeyPVCNamespace:
+			p.Tags[tagKeyCreatedForClaimNamespace] = v
+			p.Labels[labelKeyCreatedForClaimNamespace] = v
+		case ParameterKeyPVName:
+			p.Tags[tagKeyCreatedForVolumeName] = v
+			p.Labels[labelKeyCreatedForVolumeName] = v
 		case ParameterKeyLabels:
 			paramLabels, err := ConvertLabelsStringToMap(v)
 			if err != nil {

--- a/pkg/common/parameters_test.go
+++ b/pkg/common/parameters_test.go
@@ -146,6 +146,18 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 				Labels:               map[string]string{"key1": "value1", "label-1": "value-a", "label-2": "label-value-2"},
 			},
 		},
+        {
+            name:       "PVC labels",
+            parameters: map[string]string{ParameterKeyPVCName: "testPVCName", ParameterKeyPVCNamespace: "testPVCNamespace", ParameterKeyPVName: "testPVName"},
+            labels:     map[string]string{},
+            expectParams: DiskParameters{
+                DiskType:             "pd-standard",
+                ReplicationType:      "none",
+                DiskEncryptionKMSKey: "",
+                Tags:                 map[string]string{},
+                Labels:               map[string]string{labelKeyCreatedForClaimName: "testPVCName", labelKeyCreatedForClaimNamespace: "testPVCNamespace", labelKeyCreatedForVolumeName: "testPVName"},
+            },
+        },
 	}
 
 	for _, tc := range tests {

--- a/pkg/common/parameters_test.go
+++ b/pkg/common/parameters_test.go
@@ -107,7 +107,7 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 				ReplicationType:      "none",
 				DiskEncryptionKMSKey: "",
 				Tags:                 map[string]string{tagKeyCreatedForClaimName: "testPVCName", tagKeyCreatedForClaimNamespace: "testPVCNamespace", tagKeyCreatedForVolumeName: "testPVName", tagKeyCreatedBy: "testDriver"},
-				Labels:               map[string]string{},
+				Labels:               map[string]string{labelKeyCreatedForClaimName: "testPVCName", labelKeyCreatedForClaimNamespace: "testPVCNamespace", labelKeyCreatedForVolumeName: "testPVName"},
 			},
 		},
 		{
@@ -146,18 +146,30 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 				Labels:               map[string]string{"key1": "value1", "label-1": "value-a", "label-2": "label-value-2"},
 			},
 		},
-        {
-            name:       "PVC labels",
-            parameters: map[string]string{ParameterKeyPVCName: "testPVCName", ParameterKeyPVCNamespace: "testPVCNamespace", ParameterKeyPVName: "testPVName"},
-            labels:     map[string]string{},
-            expectParams: DiskParameters{
-                DiskType:             "pd-standard",
-                ReplicationType:      "none",
-                DiskEncryptionKMSKey: "",
-                Tags:                 map[string]string{},
-                Labels:               map[string]string{labelKeyCreatedForClaimName: "testPVCName", labelKeyCreatedForClaimNamespace: "testPVCNamespace", labelKeyCreatedForVolumeName: "testPVName"},
-            },
-        },
+		{
+			name:       "PVC labels",
+			parameters: map[string]string{ParameterKeyPVCName: "testPVCName", ParameterKeyPVCNamespace: "testPVCNamespace", ParameterKeyPVName: "testPVName"},
+			labels:     map[string]string{},
+			expectParams: DiskParameters{
+				DiskType:             "pd-standard",
+				ReplicationType:      "none",
+				DiskEncryptionKMSKey: "",
+				Tags:                 map[string]string{tagKeyCreatedForClaimName: "testPVCName", tagKeyCreatedForClaimNamespace: "testPVCNamespace", tagKeyCreatedForVolumeName: "testPVName", tagKeyCreatedBy: "testDriver"},
+				Labels:               map[string]string{labelKeyCreatedForClaimName: "testPVCName", labelKeyCreatedForClaimNamespace: "testPVCNamespace", labelKeyCreatedForVolumeName: "testPVName"},
+			},
+		},
+		{
+			name:       "PVC labels-override",
+			parameters: map[string]string{ParameterKeyPVCName: "testPVCName", ParameterKeyPVCNamespace: "testPVCNamespace", ParameterKeyPVName: "testPVName"},
+			labels:     map[string]string{labelKeyCreatedForClaimNamespace: "test-override"},
+			expectParams: DiskParameters{
+				DiskType:             "pd-standard",
+				ReplicationType:      "none",
+				DiskEncryptionKMSKey: "",
+				Tags:                 map[string]string{tagKeyCreatedForClaimName: "testPVCName", tagKeyCreatedForClaimNamespace: "testPVCNamespace", tagKeyCreatedForVolumeName: "testPVName", tagKeyCreatedBy: "testDriver"},
+				Labels:               map[string]string{labelKeyCreatedForClaimName: "testPVCName", labelKeyCreatedForClaimNamespace: "testPVCNamespace", labelKeyCreatedForVolumeName: "testPVName"},
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
The PR adds namespace and PVC names as labels to PVs
**Which issue(s) this PR fixes**:
Fixes #1064

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
Yes
```release-note
Adding auto-stamped details like PV, PVC and namespace name from PV description as labels for the PVs/PDs
```
