### PR TITLE
Remove labels from test snapshot class

### DIFF
--- a/test/k8s-integration/config/image-volumesnapshotclass.yaml
+++ b/test/k8s-integration/config/image-volumesnapshotclass.yaml
@@ -7,5 +7,3 @@ deletionPolicy: Delete
 parameters:
   snapshot-type: images
   image-family: integration-test
-  # Add labels for testing.
-  labels: key1=value1,key2=value2

--- a/test/k8s-integration/config/pd-volumesnapshotclass.yaml
+++ b/test/k8s-integration/config/pd-volumesnapshotclass.yaml
@@ -4,6 +4,3 @@ metadata:
   name: csi-gce-pd-snapshot-class
 driver: pd.csi.storage.gke.io
 deletionPolicy: Delete
-parameters:
-  # Add labels for testing.
-  labels: key1=value1,key2=value2


### PR DESCRIPTION
/kind failing-test

This is not supported by older versions and causes tests to fail on clusters not using the most recent driver which supports snapshot labels.

```release-note
None
```
