### PR TITLE
Succeed unpublish when a zonal, underspecified PD is not found

### DIFF
--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -593,7 +593,8 @@ func (gceCS *GCEControllerServer) executeControllerUnpublishVolume(ctx context.C
 	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey)
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
-			return nil, status.Errorf(codes.NotFound, "ControllerUnpublishVolume could not find volume with ID %v: %v", volumeID, err.Error())
+			klog.Warningf("Treating volume %v as unpublished because it could not be found", volumeID)
+			return &csi.ControllerUnpublishVolumeResponse{}, nil
 		}
 		return nil, LoggedError("ControllerUnpublishVolume error repairing underspecified volume key: ", err)
 	}

--- a/test/e2e/tests/setup_e2e_test.go
+++ b/test/e2e/tests/setup_e2e_test.go
@@ -56,7 +56,6 @@ func init() {
 }
 
 func TestE2E(t *testing.T) {
-
 	flag.Parse()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Google Compute Engine Persistent Disk Container Storage Interface Driver Tests")
@@ -91,53 +90,23 @@ var _ = BeforeSuite(func() {
 	Expect(*project).ToNot(BeEmpty(), "Project should not be empty")
 	Expect(*serviceAccount).ToNot(BeEmpty(), "Service account should not be empty")
 
-	klog.Infof("Running in project %v with service account %v\n\n", *project, *serviceAccount)
+	klog.Infof("Running in project %v with service account %v", *project, *serviceAccount)
 
 	for _, zone := range zones {
 		go func(curZone string) {
 			defer GinkgoRecover()
-			nodeID := fmt.Sprintf("gce-pd-csi-e2e-%s", curZone)
-			klog.Infof("Setting up node %s\n", nodeID)
-
-			i, err := remote.SetupInstance(*project, *architecture, curZone, nodeID, *machineType, *serviceAccount, *imageURL, computeService)
-			if err != nil {
-				klog.Fatalf("Failed to setup instance %v: %w", nodeID, err)
-			}
-
-			err = testutils.MkdirAll(i, "/lib/udev_containerized")
-			if err != nil {
-				klog.Fatalf("Could not make scsi_id containerized directory: %w", err)
-			}
-
-			err = testutils.CopyFile(i, "/lib/udev/scsi_id", "/lib/udev_containerized/scsi_id")
-			if err != nil {
-				klog.Fatalf("could not copy scsi_id to containerized directory: %w", err)
-			}
-
-			err = testutils.CopyFile(i, "/lib/udev/google_nvme_id", "/lib/udev_containerized/google_nvme_id")
-			if err != nil {
-				klog.Fatalf("could not copy google_nvme_id to containerized directory: %w", err)
-			}
-
-			klog.Infof("Creating new driver and client for node %s\n", i.GetName())
-			// Create new driver and client
-			testContext, err := testutils.GCEClientAndDriverSetup(i, "")
-			if err != nil {
-				klog.Fatalf("Failed to set up Test Context for instance %v: %w", i.GetName(), err)
-			}
-			tcc <- testContext
+			tcc <- NewTestContext(curZone)
 		}(zone)
 	}
 
 	for i := 0; i < len(zones); i++ {
 		tc := <-tcc
-		klog.Infof("Test Context for node %s set up\n", tc.Instance.GetName())
 		testContexts = append(testContexts, tc)
+		klog.Infof("Added TestContext for node %s", tc.Instance.GetName())
 	}
 })
 
 var _ = AfterSuite(func() {
-
 	for _, tc := range testContexts {
 		err := remote.TeardownDriverAndClient(tc)
 		Expect(err).To(BeNil(), "Teardown Driver and Client failed with error")
@@ -146,6 +115,40 @@ var _ = AfterSuite(func() {
 		}
 	}
 })
+
+func NewTestContext(zone string) *remote.TestContext {
+	nodeID := fmt.Sprintf("gce-pd-csi-e2e-%s", zone)
+	klog.Infof("Setting up node %s", nodeID)
+
+	i, err := remote.SetupInstance(*project, *architecture, zone, nodeID, *machineType, *serviceAccount, *imageURL, computeService)
+	if err != nil {
+		klog.Fatalf("Failed to setup instance %v: %w", nodeID, err)
+	}
+
+	err = testutils.MkdirAll(i, "/lib/udev_containerized")
+	if err != nil {
+		klog.Fatalf("Failed to make scsi_id containerized directory: %w", err)
+	}
+
+	err = testutils.CopyFile(i, "/lib/udev/scsi_id", "/lib/udev_containerized/scsi_id")
+	if err != nil {
+		klog.Fatalf("Failed to copy scsi_id to containerized directory: %w", err)
+	}
+
+	err = testutils.CopyFile(i, "/lib/udev/google_nvme_id", "/lib/udev_containerized/google_nvme_id")
+	if err != nil {
+		klog.Fatalf("Failed to copy google_nvme_id to containerized directory: %w", err)
+	}
+
+	klog.Infof("Creating new driver and client for node %s", i.GetName())
+	tc, err := testutils.GCEClientAndDriverSetup(i, "")
+	if err != nil {
+		klog.Fatalf("Failed to set up TestContext for instance %v: %w", i.GetName(), err)
+	}
+
+	klog.Infof("Finished creating TestContext for node %s", tc.Instance.GetName())
+	return tc
+}
 
 func getRandomTestContext() *remote.TestContext {
 	Expect(testContexts).ToNot(BeEmpty())


### PR DESCRIPTION
/kind bug

This PR specifically targets non-existent zonal disks with underspecified volume IDs. The case of missing nodes and missing PDs with fully specified volume IDs already succeeds the unpublish step.

- Add test case for fully specified, not found PDs during unpublish.
- Clean up the testing structure by introducing a backoffTestDriver generator, which can be reused by both publish and unpublish tests.
- Remove redundant comments from the test code.

Fixes #1108 

**Release note:**
```release-note
NONE
```
