### PR TITLE
Automated cherry pick of #1085: limit grpc loging info to a configurable char limit

### DIFF
--- a/cmd/gce-pd-csi-driver/main.go
+++ b/cmd/gce-pd-csi-driver/main.go
@@ -40,6 +40,7 @@ var (
 	runNodeService       = flag.Bool("run-node-service", true, "If set to false then the CSI driver does not activate its node service (default: true)")
 	httpEndpoint         = flag.String("http-endpoint", "", "The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled.")
 	metricsPath          = flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.")
+	grpcLogCharCap       = flag.Int("grpc-log-char-cap", 10000, "The maximum amount of characters logged for every grpc responses")
 
 	extraVolumeLabelsStr = flag.String("extra-labels", "", "Extra labels to attach to each PD created. It is a comma separated list of key value pairs like '<key1>=<value1>,<key2>=<value2>'. See https://cloud.google.com/compute/docs/labeling-resources for details")
 
@@ -159,5 +160,5 @@ func handle() {
 	gce.WaitForOpBackoff.Steps = *waitForOpBackoffSteps
 	gce.WaitForOpBackoff.Cap = *waitForOpBackoffCap
 
-	gceDriver.Run(*endpoint)
+	gceDriver.Run(*endpoint, *grpcLogCharCap)
 }

--- a/pkg/gce-pd-csi-driver/gce-pd-driver.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver.go
@@ -28,6 +28,8 @@ import (
 	mountmanager "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/mount-manager"
 )
 
+var maxLogChar int
+
 type GCEDriver struct {
 	name              string
 	vendorVersion     string
@@ -158,7 +160,9 @@ func NewControllerServer(gceDriver *GCEDriver, cloudProvider gce.GCECompute) *GC
 	}
 }
 
-func (gceDriver *GCEDriver) Run(endpoint string) {
+func (gceDriver *GCEDriver) Run(endpoint string, grpcLogCharCap int) {
+	maxLogChar = grpcLogCharCap
+
 	klog.V(4).Infof("Driver: %v", gceDriver.name)
 	//Start the nonblocking GRPC
 	s := NewNonBlockingGRPCServer()

--- a/pkg/gce-pd-csi-driver/utils.go
+++ b/pkg/gce-pd-csi-driver/utils.go
@@ -69,7 +69,11 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 	if err != nil {
 		klog.Errorf("%s returned with error: %v", info.FullMethod, err)
 	} else {
-		klog.V(4).Infof("%s returned with response: %s", info.FullMethod, resp)
+		cappedStr := fmt.Sprintf("%v", resp)
+		if len(cappedStr) > maxLogChar {
+			cappedStr = cappedStr[:maxLogChar] + fmt.Sprintf(" [response body too large, log capped to %d chars]", maxLogChar)
+		}
+		klog.V(4).Infof("%s returned with response: %s", info.FullMethod, cappedStr)
 	}
 	return resp, err
 }

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -90,7 +90,7 @@ func TestSanity(t *testing.T) {
 	}()
 
 	go func() {
-		gceDriver.Run(endpoint)
+		gceDriver.Run(endpoint, 10000)
 	}()
 
 	// TODO(#818): Fix failing tests and remove test skip flag.


### PR DESCRIPTION
Cherry pick of #1085 on release-1.8.

#1085: limit grpc loging info to a configurable char limit

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```