### PR TITLE
Remove linux/arm64 from Windows multi-arch builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ build-and-push-windows-container-20H2: require-GCE_PD_CSI_STAGING_IMAGE init-bui
 		--build-arg BASE_IMAGE=$(BASE_IMAGE_20H2) \
 		--build-arg STAGINGVERSION=$(STAGINGVERSION) --push .
 
-build-and-push-multi-arch: build-and-push-container-linux-amd64 build-and-push-container-linux-arm64 build-and-push-windows-container-ltsc2019 build-and-push-windows-container-20H2
+build-and-push-multi-arch: build-and-push-container-linux-amd64 build-and-push-windows-container-ltsc2019
 	$(DOCKER) manifest create --amend $(STAGINGIMAGE):$(STAGINGVERSION) $(STAGINGIMAGE):$(STAGINGVERSION)_linux_amd64 $(STAGINGIMAGE):$(STAGINGVERSION)_linux_arm64 $(STAGINGIMAGE):$(STAGINGVERSION)_20H2 $(STAGINGIMAGE):$(STAGINGVERSION)_ltsc2019
 	STAGINGIMAGE="$(STAGINGIMAGE)" STAGINGVERSION="$(STAGINGVERSION)" WINDOWS_IMAGE_TAGS="$(WINDOWS_IMAGE_TAGS)" WINDOWS_BASE_IMAGES="$(WINDOWS_BASE_IMAGES)" ./manifest_osversion.sh
 	$(DOCKER) manifest push -p $(STAGINGIMAGE):$(STAGINGVERSION)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

CI started failing for Windows in the `build-and-push-multi-arch` step, after looking into the logs it failed to build the linux/arm64 image, I'm removing it from the OSS Windows CI tests.

I think we might have problems building the linux/arm64 image internally the next time there's a release, just an FYI.

Relevant logs:

```
W0121 03:11:25.673] #14 [builder 4/4] RUN GOARCH=$(echo linux/amd64 | cut -f2 -d '/') GCE_PD_CSI_STAGING_VERSION=c5f6ebfd-01bb-435b-93b6-7bf7a7f158e9 make gce-pd-driver
W0121 03:11:55.618] #14 36.18 # sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/cmd/gce-pd-csi-driver
W0121 03:11:55.619] #14 36.18 /usr/bin/ld: /tmp/go-link-3732353106/000003.o: in function `mygetgrouplist':
W0121 03:11:55.619] #14 36.18 /_/os/user/getgrouplist_unix.go:15: warning: Using 'getgrouplist' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
W0121 03:11:55.619] #14 36.18 /usr/bin/ld: /tmp/go-link-3732353106/000002.o: in function `mygetgrgid_r':
W0121 03:11:55.619] #14 36.18 /_/os/user/cgo_lookup_unix.go:37: warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
W0121 03:11:55.620] #14 36.18 /usr/bin/ld: /tmp/go-link-3732353106/000002.o: in function `mygetgrnam_r':
W0121 03:11:55.620] #14 36.18 /_/os/user/cgo_lookup_unix.go:42: warning: Using 'getgrnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
W0121 03:11:55.620] #14 36.18 /usr/bin/ld: /tmp/go-link-3732353106/000002.o: in function `mygetpwnam_r':
W0121 03:11:55.620] #14 36.18 /_/os/user/cgo_lookup_unix.go:32: warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
W0121 03:11:55.620] #14 36.18 /usr/bin/ld: /tmp/go-link-3732353106/000002.o: in function `mygetpwuid_r':
W0121 03:11:55.621] #14 36.18 /_/os/user/cgo_lookup_unix.go:27: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
W0121 03:11:55.621] #14 36.18 /usr/bin/ld: /tmp/go-link-3732353106/000008.o: in function `_cgo_2ac87069779a_C2func_getaddrinfo':
W0121 03:11:55.621] #14 36.18 /tmp/go-build/cgo-gcc-prolog:58: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
W0121 03:11:56.520] #14 DONE 37.1s
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @mattcary 
