### PR TITLE
Pin the buildkit version to v0.10.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,10 +123,10 @@ ifndef GCE_PD_CSI_STAGING_VERSION
 endif
 
 init-buildx:
+	$(DOCKER) run --rm --privileged multiarch/qemu-user-static --reset --credential yes --persistent yes
 	# Ensure we use a builder that can leverage it (the default on linux will not)
 	-$(DOCKER) buildx rm multiarch-multiplatform-builder
-	$(DOCKER) buildx create --use --name=multiarch-multiplatform-builder
-	$(DOCKER) run --rm --privileged multiarch/qemu-user-static --reset --credential yes --persistent yes
+	$(DOCKER) buildx create --use --name=multiarch-multiplatform-builder --driver-opt network=host --driver-opt image=moby/buildkit:v0.10.6
 	# Register gcloud as a Docker credential helper.
 	# Required for "docker buildx build --push".
 	gcloud auth configure-docker --quiet


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Followup of #1124 and #1126. In https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-gce-pd-csi-driver-latest-k8s-master-windows-2019/1622984251899121664  `docker manifest create` is failing with 

```
I0207 11:50:07.220] DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create --amend gcr.io/e2e-gce-gci-ci-master/gcp-persistent-disk-csi-driver:ec610dec-b6e3-4e8e-b3ed-28dbf81dd659 gcr.io/e2e-gce-gci-ci-master/gcp-persistent-disk-csi-driver:ec610dec-b6e3-4e8e-b3ed-28dbf81dd659_linux_amd64 gcr.io/e2e-gce-gci-ci-master/gcp-persistent-disk-csi-driver:ec610dec-b6e3-4e8e-b3ed-28dbf81dd659_ltsc2019
W0207 11:50:09.546] gcr.io/e2e-gce-gci-ci-master/gcp-persistent-disk-csi-driver:ec610dec-b6e3-4e8e-b3ed-28dbf81dd659_linux_amd64 is a manifest list
W0207 11:50:09.552] make: *** [Makefile:64: build-and-push-multi-arch] Error 1
I0207 11:50:09.653] make: Leaving directory '/go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver'
W0207 11:50:11.650] F0207 11:50:11.650246    7131 main.go:196] Failed to run integration test: %!w(*errors.errorString=&{failed pushing image: failed to run make command for windows: err: exit status 2})
```

My only guess is that this is similar to the issue we saw internally too and I reported upstream in https://github.com/docker/cli/issues/3969, this is an attempt to see what happens in CI if we pin the version because I can't reproduce it locally.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @mattcary 