### PR TITLE
Automated cherry pick of #1134: Remove debug.PrintStack()

### DIFF
--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"runtime/debug"
 	"sort"
 	"strings"
 	"time"
@@ -412,13 +411,11 @@ func (gceCS *GCEControllerServer) ControllerPublishVolume(ctx context.Context, r
 	}
 
 	resp, err := gceCS.executeControllerPublishVolume(ctx, req)
-	debug.PrintStack()
 	if err != nil {
 		klog.Infof("For node %s adding backoff due to error for volume %s: %v", req.NodeId, req.VolumeId, err.Error())
 		gceCS.errorBackoff.next(backoffId)
 	} else {
 		klog.Infof("For node %s clear backoff due to successful publish of volume %v", req.NodeId, req.VolumeId)
-		debug.PrintStack()
 		gceCS.errorBackoff.reset(backoffId)
 	}
 	return resp, err


### PR DESCRIPTION
Cherry pick of #1134 on release-1.8.

#1134: Remove debug.PrintStack()

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```