### PR TITLE
Update csi-attacher to v4.2.0

### DIFF
--- a/deploy/kubernetes/base/controller/kustomization.yaml
+++ b/deploy/kubernetes/base/controller/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - cluster_setup.yaml
 - controller.yaml
 - v1_csidriver.yaml
+

--- a/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
+++ b/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
@@ -15,7 +15,7 @@ metadata:
   name: imagetag-csi-attacher-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-attacher
-  newTag: "v3.5.0"
+  newTag: "v4.2.0"
 ---
 apiVersion: builtin
 kind: ImageTagTransformer

--- a/deploy/kubernetes/overlays/prow-stable-sidecar-rc-master/default-fstype.yaml
+++ b/deploy/kubernetes/overlays/prow-stable-sidecar-rc-master/default-fstype.yaml
@@ -1,0 +1,5 @@
+# Set default-fstype for attacher sidecar.
+- op: add
+  path: /spec/template/spec/containers/1/args/-
+  value: "--default-fstype=ext4"
+  

--- a/deploy/kubernetes/overlays/prow-stable-sidecar-rc-master/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-stable-sidecar-rc-master/kustomization.yaml
@@ -12,5 +12,17 @@ patchesJson6902:
     kind: Deployment
     name: csi-gce-pd-controller
   path: disk_labels.yaml
+- path: max-grpc-log-length.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: csi-gce-pd-controller
+    version: v1
+- path: default-fstype.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: csi-gce-pd-controller
+    version: v1
 transformers:
 - ../../images/prow-stable-sidecar-rc-master

--- a/deploy/kubernetes/overlays/prow-stable-sidecar-rc-master/max-grpc-log-length.yaml
+++ b/deploy/kubernetes/overlays/prow-stable-sidecar-rc-master/max-grpc-log-length.yaml
@@ -1,0 +1,5 @@
+# Set max-grpc-log-length for attacher sidecar.
+- op: add
+  path: /spec/template/spec/containers/1/args/-
+  value: "--max-grpc-log-length=10000"
+  


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Update csi-attacher to https://github.com/kubernetes-csi/external-attacher/releases/tag/v4.2.0

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

* The rbac file hasn't changed for [3 years](https://github.com/kubernetes-csi/external-attacher/tree/master/deploy/kubernetes).

* Changelog from [3.5.0 to 4.2.0](https://github.com/kubernetes-csi/external-attacher/tree/master/CHANGELOG) shows that the added flag is: --max-grpc-log-length. In external-attacher it is [set to -1](https://github.com/kubernetes-csi/external-attacher/pull/411/files). But in the driver there is a [default 10000](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/commit/f7af69f3665cb77ee5033d17b142a8ab0982577d). We need to set this value at the csi-attacher side.

* The breaking change from 3.x.x to 4.x.x is [--default-fstype](https://github.com/kubernetes-csi/external-attacher/blob/master/CHANGELOG/CHANGELOG-4.0.md#no-really-you-must-read-this-before-you-upgrade), and we need to set that value [here](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/master/deploy/kubernetes/base/controller/controller.yaml#L64). For windows, we've had an explicit storageclass that sets the [fstype to ntfs](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/master/test/k8s-integration/config/sc-windows.yaml), the default-fstype flag will not do anything for windows.

**Does this PR introduce a user-facing change?**:

```release-note
Update csi-attacher to v4.2.0

```
