### PR TITLE
satisfy volume cloning topology requirements when choosing zone for CreateVolume 

### DIFF
--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -20,6 +20,7 @@ import (
 	"math/rand"
 	"regexp"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -32,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/strings/slices"
 
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
 	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute"
@@ -98,6 +100,14 @@ type workItem struct {
 	unpublishReq *csi.ControllerUnpublishVolumeRequest
 }
 
+// locationRequirements are additional location topology requirements that must be respected when creating a volume.
+type locationRequirements struct {
+	srcVolRegion         string
+	srcVolZone           string
+	srcReplicationType   string
+	cloneReplicationType string
+}
+
 var _ csi.ControllerServer = &GCEControllerServer{}
 
 const (
@@ -142,6 +152,44 @@ func isDiskReady(disk *gce.CloudDisk) (bool, error) {
 	return false, nil
 }
 
+// cloningLocationRequirements returns additional location requirements to be applied to the given create volume requests topology.
+// If the CreateVolumeRequest will use volume cloning, location requirements in compliance with the volume cloning limitations
+// will be returned: https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/volume-cloning#limitations.
+func cloningLocationRequirements(req *csi.CreateVolumeRequest, cloneReplicationType string) (*locationRequirements, error) {
+	if !useVolumeCloning(req) {
+		return nil, nil
+	}
+	// If we are using volume cloning, this will be set.
+	volSrc := req.VolumeContentSource.GetVolume()
+	volSrcVolID := volSrc.GetVolumeId()
+
+	_, sourceVolKey, err := common.VolumeIDToKey(volSrcVolID)
+	if err != nil {
+		return nil, fmt.Errorf("volume ID is invalid: %w", err)
+	}
+
+	isZonalSrcVol := sourceVolKey.Type() == meta.Zonal
+	if isZonalSrcVol {
+		region, err := common.GetRegionFromZones([]string{sourceVolKey.Zone})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get region from zones: %w", err)
+		}
+		sourceVolKey.Region = region
+	}
+
+	srcReplicationType := replicationTypeNone
+	if !isZonalSrcVol {
+		srcReplicationType = replicationTypeRegionalPD
+	}
+
+	return &locationRequirements{srcVolZone: sourceVolKey.Zone, srcVolRegion: sourceVolKey.Region, srcReplicationType: srcReplicationType, cloneReplicationType: cloneReplicationType}, nil
+}
+
+// useVolumeCloning returns true if the create volume request should be created with volume cloning.
+func useVolumeCloning(req *csi.CreateVolumeRequest) bool {
+	return req.VolumeContentSource != nil && req.VolumeContentSource.GetVolume() != nil
+}
+
 func (gceCS *GCEControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	var err error
 	// Validate arguments
@@ -177,12 +225,21 @@ func (gceCS *GCEControllerServer) CreateVolume(ctx context.Context, req *csi.Cre
 	if multiWriter {
 		gceAPIVersion = gce.GCEAPIVersionBeta
 	}
+
+	var locationTopReq *locationRequirements
+	if useVolumeCloning(req) {
+		locationTopReq, err = cloningLocationRequirements(req, params.ReplicationType)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "failed to get location requirements: %v", err.Error())
+		}
+	}
+
 	// Determine the zone or zones+region of the disk
 	var zones []string
 	var volKey *meta.Key
 	switch params.ReplicationType {
 	case replicationTypeNone:
-		zones, err = pickZones(ctx, gceCS, req.GetAccessibilityRequirements(), 1)
+		zones, err = pickZones(ctx, gceCS, req.GetAccessibilityRequirements(), 1, locationTopReq)
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "CreateVolume failed to pick zones for disk: %v", err.Error())
 		}
@@ -192,7 +249,7 @@ func (gceCS *GCEControllerServer) CreateVolume(ctx context.Context, req *csi.Cre
 		volKey = meta.ZonalKey(name, zones[0])
 
 	case replicationTypeRegionalPD:
-		zones, err = pickZones(ctx, gceCS, req.GetAccessibilityRequirements(), 2)
+		zones, err = pickZones(ctx, gceCS, req.GetAccessibilityRequirements(), 2, locationTopReq)
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "CreateVolume failed to pick zones for disk: %v", err.Error())
 		}
@@ -1358,7 +1415,29 @@ func diskIsAttachedAndCompatible(deviceName string, instance *compute.Instance, 
 	return false, nil
 }
 
-func pickZonesFromTopology(top *csi.TopologyRequirement, numZones int) ([]string, error) {
+// pickZonesInRegion will remove any zones that are not in the given region.
+func pickZonesInRegion(region string, zones []string) []string {
+	refinedZones := []string{}
+	for _, zone := range zones {
+		if strings.Contains(zone, region) {
+			refinedZones = append(refinedZones, zone)
+		}
+	}
+	return refinedZones
+}
+
+func prependZone(zone string, zones []string) []string {
+	newZones := []string{zone}
+	for i := 0; i < len(zones); i++ {
+		// Do not add a zone if it is equal to the zone that is already prepended to newZones.
+		if zones[i] != zone {
+			newZones = append(newZones, zones[i])
+		}
+	}
+	return newZones
+}
+
+func pickZonesFromTopology(top *csi.TopologyRequirement, numZones int, locationTopReq *locationRequirements) ([]string, error) {
 	reqZones, err := getZonesFromTopology(top.GetRequisite())
 	if err != nil {
 		return nil, fmt.Errorf("could not get zones from requisite topology: %w", err)
@@ -1366,6 +1445,39 @@ func pickZonesFromTopology(top *csi.TopologyRequirement, numZones int) ([]string
 	prefZones, err := getZonesFromTopology(top.GetPreferred())
 	if err != nil {
 		return nil, fmt.Errorf("could not get zones from preferred topology: %w", err)
+	}
+
+	if locationTopReq != nil {
+		srcVolZone := locationTopReq.srcVolZone
+		switch locationTopReq.cloneReplicationType {
+		// For zonal -> zonal cloning, the source disk zone must match the destination disk zone.
+		case replicationTypeNone:
+			// If the source volume zone is not in the topology requirement, we return an error.
+			if !slices.Contains(prefZones, srcVolZone) && !slices.Contains(reqZones, srcVolZone) {
+				volumeCloningReq := fmt.Sprintf("clone zone must match source disk zone: %s", srcVolZone)
+				return nil, fmt.Errorf("failed to find zone from topology %v: %s", top, volumeCloningReq)
+			}
+			return []string{srcVolZone}, nil
+		// For zonal or regional -> regional disk cloning, the source disk region must match the destination disk region.
+		case replicationTypeRegionalPD:
+			srcVolRegion := locationTopReq.srcVolRegion
+			prefZones = pickZonesInRegion(srcVolRegion, prefZones)
+			reqZones = pickZonesInRegion(srcVolRegion, reqZones)
+
+			if len(prefZones) == 0 && len(reqZones) == 0 {
+				volumeCloningReq := fmt.Sprintf("clone zone must reside in source disk region %s", srcVolRegion)
+				return nil, fmt.Errorf("failed to find zone from topology %v: %s", top, volumeCloningReq)
+			}
+
+			// For zonal -> regional disk cloning, one of the replicated zones must match the source zone.
+			if locationTopReq.srcReplicationType == replicationTypeNone {
+				if !slices.Contains(prefZones, srcVolZone) && !slices.Contains(reqZones, srcVolZone) {
+					volumeCloningReq := fmt.Sprintf("one of the replica zones of the clone must match the source disk zone: %s", srcVolZone)
+					return nil, fmt.Errorf("failed to find zone from topology %v: %s", top, volumeCloningReq)
+				}
+				prefZones = prependZone(srcVolZone, prefZones)
+			}
+		}
 	}
 
 	if numZones <= len(prefZones) {
@@ -1426,16 +1538,25 @@ func getZoneFromSegment(seg map[string]string) (string, error) {
 	return zone, nil
 }
 
-func pickZones(ctx context.Context, gceCS *GCEControllerServer, top *csi.TopologyRequirement, numZones int) ([]string, error) {
+func pickZones(ctx context.Context, gceCS *GCEControllerServer, top *csi.TopologyRequirement, numZones int, locationTopReq *locationRequirements) ([]string, error) {
 	var zones []string
 	var err error
 	if top != nil {
-		zones, err = pickZonesFromTopology(top, numZones)
+		zones, err = pickZonesFromTopology(top, numZones, locationTopReq)
 		if err != nil {
 			return nil, fmt.Errorf("failed to pick zones from topology: %w", err)
 		}
 	} else {
-		zones, err = getDefaultZonesInRegion(ctx, gceCS, []string{gceCS.CloudProvider.GetDefaultZone()}, numZones)
+		existingZones := []string{gceCS.CloudProvider.GetDefaultZone()}
+		// We set existingZones to the source volume zone so that for zonal -> zonal cloning, the clone is provisioned
+		// in the same zone as the source volume, and for zonal -> regional, one of the replicated zones will always
+		// be the zone of the source volume. For regional -> regional cloning, the srcVolZone will not be set, so we
+		// just use the default zone.
+		if locationTopReq != nil && locationTopReq.srcReplicationType == replicationTypeNone {
+			existingZones = []string{locationTopReq.srcVolZone}
+		}
+		// If topology is nil, then the Immediate binding mode was used without setting allowedTopologies in the storageclass.
+		zones, err = getDefaultZonesInRegion(ctx, gceCS, existingZones, numZones)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get default %v zones in region: %w", numZones, err)
 		}

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -1118,8 +1118,112 @@ func TestCreateVolumeWithVolumeSourceFromSnapshot(t *testing.T) {
 	}
 }
 
+func TestCloningLocationRequirements(t *testing.T) {
+	testSourceVolumeName := "test-volume-source-name"
+	testZonalVolumeSourceID := fmt.Sprintf("projects/%s/zones/%s/disks/%s", project, zone, testSourceVolumeName)
+	testRegionalVolumeSourceID := fmt.Sprintf("projects/%s/regions/%s/disks/%s", project, region, testSourceVolumeName)
+
+	testCases := []struct {
+		name                         string
+		sourceVolumeID               string
+		nilVolumeContentSource       bool
+		reqParameters                map[string]string
+		requestCapacityRange         *csi.CapacityRange
+		replicationType              string
+		expectedLocationRequirements *locationRequirements
+		expectedErr                  bool
+	}{
+		{
+			name:                 "success zonal disk clone of zonal source disk",
+			sourceVolumeID:       testZonalVolumeSourceID,
+			requestCapacityRange: stdCapRange,
+			reqParameters: map[string]string{
+				common.ParameterKeyReplicationType: replicationTypeNone,
+			},
+			replicationType:              replicationTypeNone,
+			expectedLocationRequirements: &locationRequirements{srcVolRegion: region, srcVolZone: zone, srcReplicationType: replicationTypeNone, cloneReplicationType: replicationTypeNone},
+			expectedErr:                  false,
+		},
+		{
+			name:                 "success regional disk clone of regional source disk",
+			sourceVolumeID:       testRegionalVolumeSourceID,
+			requestCapacityRange: stdCapRange,
+			reqParameters: map[string]string{
+				common.ParameterKeyReplicationType: replicationTypeRegionalPD,
+			},
+			replicationType:              replicationTypeRegionalPD,
+			expectedLocationRequirements: &locationRequirements{srcVolRegion: region, srcVolZone: "", srcReplicationType: replicationTypeRegionalPD, cloneReplicationType: replicationTypeRegionalPD},
+			expectedErr:                  false,
+		},
+		{
+			name:                 "success regional disk clone of zonal data source",
+			sourceVolumeID:       testZonalVolumeSourceID,
+			requestCapacityRange: stdCapRange,
+			reqParameters: map[string]string{
+				common.ParameterKeyReplicationType: replicationTypeRegionalPD,
+			},
+			replicationType:              replicationTypeRegionalPD,
+			expectedLocationRequirements: &locationRequirements{srcVolRegion: region, srcVolZone: zone, srcReplicationType: replicationTypeNone, cloneReplicationType: replicationTypeRegionalPD},
+			expectedErr:                  false,
+		},
+		{
+			name:                   "non-cloning CreateVolumeRequest",
+			nilVolumeContentSource: true,
+			requestCapacityRange:   stdCapRange,
+			reqParameters: map[string]string{
+				common.ParameterKeyReplicationType: replicationTypeRegionalPD,
+			},
+			replicationType:              replicationTypeRegionalPD,
+			expectedLocationRequirements: nil,
+			expectedErr:                  false,
+		},
+		{
+			name:                 "failure invalid volumeID",
+			sourceVolumeID:       fmt.Sprintf("projects/%s/disks/%s", project, testSourceVolumeName),
+			requestCapacityRange: stdCapRange,
+			reqParameters: map[string]string{
+				common.ParameterKeyReplicationType: replicationTypeNone,
+			},
+			replicationType:              replicationTypeNone,
+			expectedLocationRequirements: nil,
+			expectedErr:                  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Logf("test case: %s", tc.name)
+		req := &csi.CreateVolumeRequest{
+			Name:               name,
+			CapacityRange:      tc.requestCapacityRange,
+			VolumeCapabilities: stdVolCaps,
+			Parameters:         tc.reqParameters,
+			VolumeContentSource: &csi.VolumeContentSource{
+				Type: &csi.VolumeContentSource_Volume{
+					Volume: &csi.VolumeContentSource_VolumeSource{
+						VolumeId: tc.sourceVolumeID,
+					},
+				},
+			},
+		}
+		if tc.nilVolumeContentSource {
+			req.VolumeContentSource = nil
+		}
+
+		locationRequirements, err := cloningLocationRequirements(req, tc.replicationType)
+
+		if err != nil != tc.expectedErr {
+			t.Fatalf("Got error %v, expected error %t", err, tc.expectedErr)
+		}
+		input := fmt.Sprintf("cloningLocationRequirements(%v, %s", req, tc.replicationType)
+		if fmt.Sprintf("%v", tc.expectedLocationRequirements) != fmt.Sprintf("%v", locationRequirements) {
+			t.Fatalf("%s returned unexpected diff got: %v, want %v", input, locationRequirements, tc.expectedLocationRequirements)
+		}
+	}
+}
+
 func TestCreateVolumeWithVolumeSourceFromVolume(t *testing.T) {
 	testSourceVolumeName := "test-volume-source-name"
+	testCloneVolumeName := "test-volume-clone"
 	testZonalVolumeSourceID := fmt.Sprintf("projects/%s/zones/%s/disks/%s", project, zone, testSourceVolumeName)
 	testRegionalVolumeSourceID := fmt.Sprintf("projects/%s/regions/%s/disks/%s", project, region, testSourceVolumeName)
 	testSecondZonalVolumeSourceID := fmt.Sprintf("projects/%s/zones/%s/disks/%s", project, "different-zone1", testSourceVolumeName)
@@ -1131,14 +1235,33 @@ func TestCreateVolumeWithVolumeSourceFromVolume(t *testing.T) {
 		common.ParameterKeyType: "test-type", common.ParameterKeyReplicationType: replicationTypeRegionalPD,
 		common.ParameterKeyDiskEncryptionKmsKey: "encryption-key",
 	}
-	topology := &csi.TopologyRequirement{
-		Requisite: []*csi.Topology{
-			{
-				Segments: map[string]string{common.TopologyKeyZone: zone},
-			},
-			{
-				Segments: map[string]string{common.TopologyKeyZone: secondZone},
-			},
+	requisiteTopology := []*csi.Topology{
+		{
+			Segments: map[string]string{common.TopologyKeyZone: zone},
+		},
+		{
+			Segments: map[string]string{common.TopologyKeyZone: secondZone},
+		},
+	}
+
+	requisiteAllRegionZonesTopology := []*csi.Topology{
+		{
+			Segments: map[string]string{common.TopologyKeyZone: "country-region-fakethirdzone"},
+		},
+		{
+			Segments: map[string]string{common.TopologyKeyZone: zone},
+		},
+		{
+			Segments: map[string]string{common.TopologyKeyZone: secondZone},
+		},
+	}
+
+	prefTopology := []*csi.Topology{
+		{
+			Segments: map[string]string{common.TopologyKeyZone: zone},
+		},
+		{
+			Segments: map[string]string{common.TopologyKeyZone: secondZone},
 		},
 	}
 
@@ -1153,39 +1276,326 @@ func TestCreateVolumeWithVolumeSourceFromVolume(t *testing.T) {
 		requestCapacityRange *csi.CapacityRange
 		sourceTopology       *csi.TopologyRequirement
 		requestTopology      *csi.TopologyRequirement
+		expCloneKey          *meta.Key
+		// Accessible topologies validates that the replica zones are valid for regional disk clones.
+		expAccessibleTop []*csi.Topology
 	}{
+
 		{
-			name:                 "success zonal disk clone of zonal source disk",
+			name:                 "success zonal -> zonal cloning, nil topology: immediate binding w/ no allowedTopologies",
 			volumeOnCloud:        true,
 			sourceVolumeID:       testZonalVolumeSourceID,
 			requestCapacityRange: stdCapRange,
 			sourceCapacityRange:  stdCapRange,
 			reqParameters:        zonalParams,
 			sourceReqParameters:  zonalParams,
-			sourceTopology:       topology,
-			requestTopology:      topology,
+			// Source volume will be in the zone that is the first element of preferred topologies (country-region-zone)
+			sourceTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			requestTopology: nil,
+			expCloneKey:     &meta.Key{Name: testCloneVolumeName, Zone: zone, Region: ""},
+			expAccessibleTop: []*csi.Topology{
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-zone"},
+				},
+			},
 		},
 		{
-			name:                 "success regional disk clone of regional source disk",
+			name:                 "success zonal -> zonal cloning, req = allowedTopologies, pref = req w/ randomly selected zone as first element: immediate binding w/ allowedTopologies",
 			volumeOnCloud:        true,
-			sourceVolumeID:       testRegionalVolumeSourceID,
+			sourceVolumeID:       testZonalVolumeSourceID,
 			requestCapacityRange: stdCapRange,
 			sourceCapacityRange:  stdCapRange,
-			reqParameters:        regionalParams,
-			sourceReqParameters:  regionalParams,
-			sourceTopology:       topology,
-			requestTopology:      topology,
+			reqParameters:        zonalParams,
+			sourceReqParameters:  zonalParams,
+			// Source volume will be in the zone that is the first element of preferred topologies (country-region-zone)
+			sourceTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			requestTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{common.TopologyKeyZone: secondZone},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: zone},
+					},
+				},
+			},
+			expCloneKey: &meta.Key{Name: testCloneVolumeName, Zone: zone, Region: ""},
+			expAccessibleTop: []*csi.Topology{
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-zone"},
+				},
+			},
 		},
 		{
-			name:                 "success regional disk clone of zonal data source",
+			name:                 "success zonal -> zonal cloning, req = allowedTopologies, pref = req w/ src zone as first element: delayed binding w/ allowedTopologies",
+			volumeOnCloud:        true,
+			sourceVolumeID:       testZonalVolumeSourceID,
+			requestCapacityRange: stdCapRange,
+			sourceCapacityRange:  stdCapRange,
+			reqParameters:        zonalParams,
+			sourceReqParameters:  zonalParams,
+			// Source volume will be in the zone that is the first element of preferred topologies (country-region-zone)
+			sourceTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			requestTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			expCloneKey: &meta.Key{Name: testCloneVolumeName, Zone: zone, Region: ""},
+			expAccessibleTop: []*csi.Topology{
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-zone"},
+				},
+			},
+		},
+		{
+			name:                 "success zonal -> zonal cloning, req = all zones in region, pref = req w/ src zone as first element: delayed binding without allowedTopologies",
+			volumeOnCloud:        true,
+			sourceVolumeID:       testZonalVolumeSourceID,
+			requestCapacityRange: stdCapRange,
+			sourceCapacityRange:  stdCapRange,
+			reqParameters:        zonalParams,
+			sourceReqParameters:  zonalParams,
+			// Source volume will be in the zone that is the first element of preferred topologies (country-region-zone)
+			sourceTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			requestTopology: &csi.TopologyRequirement{
+				Requisite: requisiteAllRegionZonesTopology,
+				Preferred: prefTopology,
+			},
+			expCloneKey: &meta.Key{Name: testCloneVolumeName, Zone: zone, Region: ""},
+			expAccessibleTop: []*csi.Topology{
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-zone"},
+				},
+			},
+		},
+		{
+			name:                 "success zonal -> regional cloning, nil topology: immediate binding w/ no allowedTopologies",
 			volumeOnCloud:        true,
 			sourceVolumeID:       testZonalVolumeSourceID,
 			requestCapacityRange: stdCapRange,
 			sourceCapacityRange:  stdCapRange,
 			reqParameters:        regionalParams,
 			sourceReqParameters:  zonalParams,
-			sourceTopology:       topology,
-			requestTopology:      topology,
+			sourceTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			requestTopology: nil,
+			expCloneKey:     &meta.Key{Name: testCloneVolumeName, Zone: "", Region: "country-region"},
+			expAccessibleTop: []*csi.Topology{
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-zone"},
+				},
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-fakesecondzone"},
+				},
+			},
+		},
+		{
+			name:                 "success zonal -> regional cloning, req = allowedTopologies, pref = req w/ randomly selected zone as first element: immediate binding w/ allowedTopologies",
+			volumeOnCloud:        true,
+			sourceVolumeID:       testZonalVolumeSourceID,
+			requestCapacityRange: stdCapRange,
+			sourceCapacityRange:  stdCapRange,
+			reqParameters:        regionalParams,
+			sourceReqParameters:  zonalParams,
+			sourceTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			requestTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{common.TopologyKeyZone: secondZone},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: zone},
+					},
+				},
+			},
+			expCloneKey: &meta.Key{Name: testCloneVolumeName, Zone: "", Region: "country-region"},
+			expAccessibleTop: []*csi.Topology{
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-zone"},
+				},
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-fakesecondzone"},
+				},
+			},
+		},
+		{
+			name:                 "success zonal -> regional cloning, req = allowedTopologies, pref = req w/ src zone as first element: delayed binding w/ allowedTopologies",
+			volumeOnCloud:        true,
+			sourceVolumeID:       testZonalVolumeSourceID,
+			requestCapacityRange: stdCapRange,
+			sourceCapacityRange:  stdCapRange,
+			reqParameters:        regionalParams,
+			sourceReqParameters:  zonalParams,
+			sourceTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			requestTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			expCloneKey: &meta.Key{Name: testCloneVolumeName, Zone: "", Region: "country-region"},
+			expAccessibleTop: []*csi.Topology{
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-zone"},
+				},
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-fakesecondzone"},
+				},
+			},
+		},
+		{
+			name:                 "success zonal -> regional cloning, req = all zones in region, pref = req w/ src zone as first element: delayed binding without allowedTopologies",
+			volumeOnCloud:        true,
+			sourceVolumeID:       testZonalVolumeSourceID,
+			requestCapacityRange: stdCapRange,
+			sourceCapacityRange:  stdCapRange,
+			reqParameters:        regionalParams,
+			sourceReqParameters:  zonalParams,
+			sourceTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			requestTopology: &csi.TopologyRequirement{
+				Requisite: requisiteAllRegionZonesTopology,
+				Preferred: prefTopology,
+			},
+			expCloneKey: &meta.Key{Name: testCloneVolumeName, Zone: "", Region: "country-region"},
+			expAccessibleTop: []*csi.Topology{
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-zone"},
+				},
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-fakesecondzone"},
+				},
+			},
+		},
+		{
+			name:                 "success regional -> regional cloning, nil topology: immediate binding w/ no allowedTopologies",
+			volumeOnCloud:        true,
+			sourceVolumeID:       testRegionalVolumeSourceID,
+			requestCapacityRange: stdCapRange,
+			sourceCapacityRange:  stdCapRange,
+			reqParameters:        regionalParams,
+			sourceReqParameters:  regionalParams,
+			sourceTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			requestTopology: nil,
+			expCloneKey:     &meta.Key{Name: testCloneVolumeName, Zone: "", Region: "country-region"},
+			expAccessibleTop: []*csi.Topology{
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-zone"},
+				},
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-fakesecondzone"},
+				},
+			},
+		},
+		{
+			name:                 "success regional -> regional cloning, req = allowedTopologies, pref = req w/ randomly selected zone as first element: immediate binding w/ allowedTopologies",
+			volumeOnCloud:        true,
+			sourceVolumeID:       testRegionalVolumeSourceID,
+			requestCapacityRange: stdCapRange,
+			sourceCapacityRange:  stdCapRange,
+			reqParameters:        regionalParams,
+			sourceReqParameters:  regionalParams,
+			sourceTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			requestTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{common.TopologyKeyZone: secondZone},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: zone},
+					},
+				},
+			},
+			expCloneKey: &meta.Key{Name: testCloneVolumeName, Zone: "", Region: "country-region"},
+			expAccessibleTop: []*csi.Topology{
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-zone"},
+				},
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-fakesecondzone"},
+				},
+			},
+		},
+		{
+			name:                 "success regional -> regional cloning, req = allowedTopologies, pref = req w/ src zone as first element: delayed binding w/ allowedTopologies",
+			volumeOnCloud:        true,
+			sourceVolumeID:       testRegionalVolumeSourceID,
+			requestCapacityRange: stdCapRange,
+			sourceCapacityRange:  stdCapRange,
+			reqParameters:        regionalParams,
+			sourceReqParameters:  regionalParams,
+			sourceTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			requestTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			expCloneKey: &meta.Key{Name: testCloneVolumeName, Zone: "", Region: "country-region"},
+			expAccessibleTop: []*csi.Topology{
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-zone"},
+				},
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-fakesecondzone"},
+				},
+			},
+		},
+		{
+			name:                 "success regional -> regional cloning, req = all zones in region, pref = req w/ src zone as first element: delayed binding without allowedTopologies",
+			volumeOnCloud:        true,
+			sourceVolumeID:       testRegionalVolumeSourceID,
+			requestCapacityRange: stdCapRange,
+			sourceCapacityRange:  stdCapRange,
+			reqParameters:        regionalParams,
+			sourceReqParameters:  regionalParams,
+			sourceTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			requestTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			expCloneKey: &meta.Key{Name: testCloneVolumeName, Zone: "", Region: "country-region"},
+			expAccessibleTop: []*csi.Topology{
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-zone"},
+				},
+				{
+					Segments: map[string]string{common.TopologyKeyZone: "country-region-fakesecondzone"},
+				},
+			},
 		},
 		{
 			name:                 "fail regional disk clone with no matching replica zone of zonal data source",
@@ -1196,7 +1606,10 @@ func TestCreateVolumeWithVolumeSourceFromVolume(t *testing.T) {
 			sourceCapacityRange:  stdCapRange,
 			reqParameters:        regionalParams,
 			sourceReqParameters:  zonalParams,
-			sourceTopology:       topology,
+			sourceTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
 			requestTopology: &csi.TopologyRequirement{
 				Requisite: []*csi.Topology{
 					{
@@ -1219,8 +1632,14 @@ func TestCreateVolumeWithVolumeSourceFromVolume(t *testing.T) {
 			sourceReqParameters: map[string]string{
 				common.ParameterKeyType: "different-type",
 			},
-			sourceTopology:  topology,
-			requestTopology: topology,
+			sourceTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			requestTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
 		},
 		{
 			name:                 "fail zonal disk clone with different DiskEncryptionKMSKey",
@@ -1234,8 +1653,14 @@ func TestCreateVolumeWithVolumeSourceFromVolume(t *testing.T) {
 				common.ParameterKeyType: "test-type", common.ParameterKeyReplicationType: replicationTypeNone,
 				common.ParameterKeyDiskEncryptionKmsKey: "different-encryption-key",
 			},
-			sourceTopology:  topology,
-			requestTopology: topology,
+			sourceTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			requestTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
 		},
 		{
 			name:                 "fail zonal disk clone with different zone",
@@ -1256,7 +1681,10 @@ func TestCreateVolumeWithVolumeSourceFromVolume(t *testing.T) {
 					},
 				},
 			},
-			requestTopology: topology,
+			requestTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
 		},
 		{
 			name:                 "fail zonal disk clone of regional data source",
@@ -1267,8 +1695,14 @@ func TestCreateVolumeWithVolumeSourceFromVolume(t *testing.T) {
 			sourceCapacityRange:  stdCapRange,
 			reqParameters:        zonalParams,
 			sourceReqParameters:  regionalParams,
-			sourceTopology:       topology,
-			requestTopology:      topology,
+			sourceTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			requestTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
 		},
 
 		{
@@ -1280,7 +1714,10 @@ func TestCreateVolumeWithVolumeSourceFromVolume(t *testing.T) {
 			sourceCapacityRange:  stdCapRange,
 			reqParameters:        stdParams,
 			sourceReqParameters:  stdParams,
-			requestTopology:      topology,
+			requestTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
 		},
 		{
 			name:                 "fail invalid source disk volume id format",
@@ -1291,7 +1728,10 @@ func TestCreateVolumeWithVolumeSourceFromVolume(t *testing.T) {
 			sourceCapacityRange:  stdCapRange,
 			reqParameters:        stdParams,
 			sourceReqParameters:  stdParams,
-			requestTopology:      topology,
+			requestTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
 		},
 		{
 			name:                 "fail zonal disk clone with smaller disk capacity",
@@ -1304,16 +1744,23 @@ func TestCreateVolumeWithVolumeSourceFromVolume(t *testing.T) {
 			},
 			reqParameters:       zonalParams,
 			sourceReqParameters: zonalParams,
-			sourceTopology:      topology,
-			requestTopology:     topology,
-		}}
+			sourceTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+			requestTopology: &csi.TopologyRequirement{
+				Requisite: requisiteTopology,
+				Preferred: prefTopology,
+			},
+		},
+	}
 
 	for _, tc := range testCases {
 		t.Logf("test case: %s", tc.name)
 		gceDriver := initGCEDriver(t, nil)
 
 		req := &csi.CreateVolumeRequest{
-			Name:               name,
+			Name:               testCloneVolumeName,
 			CapacityRange:      tc.requestCapacityRange,
 			VolumeCapabilities: stdVolCaps,
 			Parameters:         tc.reqParameters,
@@ -1348,7 +1795,6 @@ func TestCreateVolumeWithVolumeSourceFromVolume(t *testing.T) {
 		}
 
 		resp, err := gceDriver.cs.CreateVolume(context.Background(), req)
-		t.Logf("response: %v err: %v", resp, err)
 		if err != nil {
 			serverError, ok := status.FromError(err)
 			if !ok {
@@ -1364,12 +1810,37 @@ func TestCreateVolumeWithVolumeSourceFromVolume(t *testing.T) {
 		}
 
 		// Make sure the response has the source volume.
-		sourceVolume := resp.GetVolume()
-		if sourceVolume.ContentSource == nil || sourceVolume.ContentSource.Type == nil ||
-			sourceVolume.ContentSource.GetVolume() == nil || sourceVolume.ContentSource.GetVolume().VolumeId == "" {
+		respVolume := resp.GetVolume()
+		if respVolume.ContentSource == nil || respVolume.ContentSource.Type == nil ||
+			respVolume.ContentSource.GetVolume() == nil || respVolume.ContentSource.GetVolume().VolumeId == "" {
 			t.Fatalf("Expected volume content source to have volume ID, got none")
 		}
+		// Validate that the cloned volume is in the region/zone that we expect
+		cloneVolID := respVolume.VolumeId
+		_, cloneVolKey, err := common.VolumeIDToKey(cloneVolID)
+		if err != nil {
+			t.Fatalf("failed to get key from volume id %q: %v", cloneVolID, err)
+		}
+		if cloneVolKey.String() != tc.expCloneKey.String() {
+			t.Fatalf("got clone volume key: %q, expected clone volume key: %q", cloneVolKey.String(), tc.expCloneKey.String())
+		}
+		if !accessibleTopologiesEqual(respVolume.AccessibleTopology, tc.expAccessibleTop) {
+			t.Fatalf("got accessible topology: %q, expected accessible topology: %q", fmt.Sprintf("%+v", respVolume.AccessibleTopology), fmt.Sprintf("%+v", tc.expAccessibleTop))
+
+		}
 	}
+}
+
+func sortTopologies(in []*csi.Topology) {
+	sort.Slice(in, func(i, j int) bool {
+		return in[i].Segments[common.TopologyKeyZone] < in[j].Segments[common.TopologyKeyZone]
+	})
+}
+
+func accessibleTopologiesEqual(got []*csi.Topology, expected []*csi.Topology) bool {
+	sortTopologies(got)
+	sortTopologies(expected)
+	return fmt.Sprintf("%+v", got) == fmt.Sprintf("%+v", expected)
 }
 
 func TestCreateVolumeRandomRequisiteTopology(t *testing.T) {
@@ -1802,10 +2273,93 @@ func TestGetZonesFromTopology(t *testing.T) {
 	}
 }
 
+func TestPickZonesInRegion(t *testing.T) {
+	testCases := []struct {
+		name     string
+		region   string
+		zones    []string
+		expZones []string
+	}{
+		{
+			name:     "all zones in region",
+			region:   "us-central1",
+			zones:    []string{"us-central1-a", "us-central1-b", "us-central1-c"},
+			expZones: []string{"us-central1-a", "us-central1-b", "us-central1-c"},
+		},
+		{
+			name:     "removes zones not in region",
+			region:   "us-central1",
+			zones:    []string{"us-central1-a", "us-central1-b", "us-central1-c", "us-east1-a, us-west1-a"},
+			expZones: []string{"us-central1-a", "us-central1-b", "us-central1-c"},
+		},
+		{
+			name:     "region not in zones",
+			region:   "us-west1",
+			zones:    []string{"us-central1-a", "us-central1-b", "us-central1-c"},
+			expZones: []string{},
+		},
+		{
+			name:     "empty zones",
+			region:   "us-central1",
+			zones:    []string{},
+			expZones: []string{},
+		},
+	}
+	for _, tc := range testCases {
+		t.Logf("test case: %s", tc.name)
+		gotZones := pickZonesInRegion(tc.region, tc.zones)
+		if !sets.NewString(gotZones...).Equal(sets.NewString(tc.expZones...)) {
+			t.Errorf("Got zones: %v, expected: %v", gotZones, tc.expZones)
+		}
+	}
+}
+
+func TestPrependZone(t *testing.T) {
+	testCases := []struct {
+		name     string
+		zone     string
+		zones    []string
+		expZones []string
+	}{
+		{
+			name:     "zone already at index 0",
+			zone:     "us-central1-a",
+			zones:    []string{"us-central1-a", "us-central1-b", "us-central1-c"},
+			expZones: []string{"us-central1-a", "us-central1-b", "us-central1-c"},
+		},
+		{
+			name:     "zone at index 1",
+			zone:     "us-central1-b",
+			zones:    []string{"us-central1-a", "us-central1-b", "us-central1-c"},
+			expZones: []string{"us-central1-b", "us-central1-a", "us-central1-c"},
+		},
+		{
+			name:     "zone not in zones",
+			zone:     "us-central1-f",
+			zones:    []string{"us-central1-a", "us-central1-b", "us-central1-c"},
+			expZones: []string{"us-central1-f", "us-central1-a", "us-central1-b", "us-central1-c"},
+		},
+		{
+			name:     "empty zones",
+			zone:     "us-central1-a",
+			zones:    []string{},
+			expZones: []string{"us-central1-a"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Logf("test case: %s", tc.name)
+		gotZones := prependZone(tc.zone, tc.zones)
+		if !zonesEqual(gotZones, tc.expZones) {
+			t.Errorf("Got zones: %v, expected: %v", gotZones, tc.expZones)
+		}
+	}
+}
+
 func TestPickZonesFromTopology(t *testing.T) {
 	testCases := []struct {
 		name     string
 		top      *csi.TopologyRequirement
+		locReq   *locationRequirements
 		numZones int
 		expZones []string
 		expErr   bool
@@ -1838,6 +2392,36 @@ func TestPickZonesFromTopology(t *testing.T) {
 			},
 			numZones: 2,
 			expZones: []string{"topology-zone2", "topology-zone3"},
+		},
+		{
+			name: "success: preferred, locationRequirements[region:us-central1, zone:us-central1-a, srcReplicationType:none, cloneReplicationType:none]",
+			top: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-c"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-a"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-b"},
+					},
+				},
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-b"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-c"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-a"},
+					},
+				},
+			},
+			locReq:   &locationRequirements{srcVolRegion: "us-central1", srcVolZone: "us-central1-a", srcReplicationType: replicationTypeNone, cloneReplicationType: replicationTypeNone},
+			numZones: 1,
+			expZones: []string{"us-central1-a"},
 		},
 		{
 			name: "success: preferred and requisite",
@@ -1875,6 +2459,72 @@ func TestPickZonesFromTopology(t *testing.T) {
 			expZones: []string{"topology-zone2", "topology-zone3", "topology-zone1", "topology-zone5", "topology-zone6"},
 		},
 		{
+			name: "success: preferred and requisite, locationRequirements[region:us-central1, zone:us-central1-a, srcReplicationType:regional-pd, cloneReplicationType:regional-pd]",
+			top: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-c"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-d"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-f"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-west1-a"},
+					},
+				},
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-b"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-a"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-east1-a"},
+					},
+				},
+			},
+			locReq:   &locationRequirements{srcVolRegion: "us-central1", srcVolZone: "us-central1-a", srcReplicationType: replicationTypeRegionalPD, cloneReplicationType: replicationTypeRegionalPD},
+			numZones: 5,
+			expZones: []string{"us-central1-b", "us-central1-c", "us-central1-a", "us-central1-d", "us-central1-f"},
+		},
+		{
+			name: "success: preferred and requisite, locationRequirements[region:us-central1, zone:us-central1-a, srcReplicationType:none, cloneReplicationType:regional-pd]",
+			top: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-c"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-d"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-f"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-west1-a"},
+					},
+				},
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-b"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-a"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-east1-a"},
+					},
+				},
+			},
+			locReq:   &locationRequirements{srcVolRegion: "us-central1", srcVolZone: "us-central1-a", srcReplicationType: replicationTypeNone, cloneReplicationType: replicationTypeRegionalPD},
+			numZones: 5,
+			expZones: []string{"us-central1-a", "us-central1-b", "us-central1-c", "us-central1-d", "us-central1-f"},
+		},
+		{
 			name: "fail: not enough topologies",
 			top: &csi.TopologyRequirement{
 				Requisite: []*csi.Topology{
@@ -1904,6 +2554,114 @@ func TestPickZonesFromTopology(t *testing.T) {
 			expErr:   true,
 		},
 		{
+			name: "fail: no topologies that match locationRequirment, locationRequirements[region:us-east1, zone:us-east1-a, replicationType:none]",
+			top: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-c"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-a"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-b"},
+					},
+				},
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-b"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-c"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-a"},
+					},
+				},
+			},
+			locReq:   &locationRequirements{srcVolRegion: "us-east1", srcVolZone: "us-east1-a", cloneReplicationType: replicationTypeNone},
+			numZones: 1,
+			expErr:   true,
+		},
+		{
+			name: "fail: no topologies that match locationRequirment, locationRequirements[region:us-east1, zone:us-east1-a, replicationType:regional-pd]",
+			top: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-c"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-a"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-b"},
+					},
+				},
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-b"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-c"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-a"},
+					},
+				},
+			},
+			locReq:   &locationRequirements{srcVolRegion: "us-east1", srcVolZone: "us-east1-a", cloneReplicationType: replicationTypeRegionalPD},
+			numZones: 2,
+			expErr:   true,
+		},
+		{
+			name: "fail: not enough topologies, locationRequirements[region:us-central1, zone:us-central1-a, replicationType:regional-pd]",
+			top: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-c"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-a"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-b"},
+					},
+				},
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-b"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-c"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-a"},
+					},
+				},
+			},
+			locReq:   &locationRequirements{srcVolRegion: "us-central1", srcVolZone: "us-central1-a", cloneReplicationType: replicationTypeRegionalPD},
+			numZones: 4,
+			expErr:   true,
+		},
+		{
+			name: "success: only requisite, locationRequirements[region:us-central1, zone:us-central1-a, replicationType:regional-pd",
+			top: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-c"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-a"},
+					},
+					{
+						Segments: map[string]string{common.TopologyKeyZone: "us-central1-b"},
+					},
+				},
+			},
+			numZones: 3,
+			expZones: []string{"us-central1-b", "us-central1-c", "us-central1-a"},
+		},
+		{
 			name: "success: only requisite",
 			top: &csi.TopologyRequirement{
 				Requisite: []*csi.Topology{
@@ -1924,17 +2682,29 @@ func TestPickZonesFromTopology(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Logf("test case: %s", tc.name)
-		gotZones, err := pickZonesFromTopology(tc.top, tc.numZones)
+		gotZones, err := pickZonesFromTopology(tc.top, tc.numZones, tc.locReq)
 		if err != nil && !tc.expErr {
-			t.Errorf("Did not expect error but got: %v", err)
+			t.Errorf("got error: %v, but did not expect error", err)
 		}
 		if err == nil && tc.expErr {
-			t.Errorf("Expected error but got none")
+			t.Errorf("got no error, but expected error")
 		}
 		if !sets.NewString(gotZones...).Equal(sets.NewString(tc.expZones...)) {
 			t.Errorf("Expected zones: %v, but got: %v", tc.expZones, gotZones)
 		}
 	}
+}
+
+func zonesEqual(gotZones, expectedZones []string) bool {
+	if len(gotZones) != len(expectedZones) {
+		return false
+	}
+	for i := 0; i < len(gotZones); i++ {
+		if gotZones[i] != expectedZones[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestPickRandAndConsecutive(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
[Flakey unit tests](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-gcp-compute-persistent-disk-csi-driver-unit) discovered an issue in the way volume cloning chooses the zone to clone the volume into. The test fails when the [random logic](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/master/pkg/gce-pd-csi-driver/controller.go#L1387) picks a source zone that does not satisfy [the volume cloning limitations](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/volume-cloning#limitations).


Volume cloning should satisfy the following topology requirements: 
1. For zonal->zonal cloning, the zone of the clone must match the zone of the source disk
2. For zonal->regional cloning, one of the clone's replicated zones must match the source disk zone. 
    - The zonal to regional disk clone is broken for pantheon gcloud, so I am not sure what will happen  (if the clone regional disk replica zones gets overrideen or not in the event that neither replicazone matches the source disk zone, so we will just follow the [documentation](https://cloud.google.com/compute/docs/disks/create-disk-from-source#restrictions) and enforce this. 
3. For regional->regional cloning, the source disk replicated zones must match the destination replicated zones. If the replicated zones do not match, gce will override the clone replicated zones to match the source replicated zones, so nothing is needed here to validate before Creating the disk.


**Which issue(s) this PR fixes**:
Fixes #1137 

**Does this PR introduce a user-facing change?**:
```release-note
It is no longer necessary to specify allowedTopologies for zonal -> zonal cloning and zonal/regional -> regional cloning to ensure that the clone zone is compatible with the GCE volume cloning requirements.
```
