### PR TITLE
Automated cherry pick of #1144: Update csi-attacher to v4.2.0

### DIFF
--- a/deploy/kubernetes/base/controller/kustomization.yaml
+++ b/deploy/kubernetes/base/controller/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - cluster_setup.yaml
 - controller.yaml
 - v1_csidriver.yaml
+

--- a/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
+++ b/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
@@ -15,7 +15,7 @@ metadata:
   name: imagetag-csi-attacher-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-attacher
-  newTag: "v3.5.0"
+  newTag: "v4.2.0"
 ---
 apiVersion: builtin
 kind: ImageTagTransformer

--- a/deploy/kubernetes/overlays/prow-stable-sidecar-rc-master/default-fstype.yaml
+++ b/deploy/kubernetes/overlays/prow-stable-sidecar-rc-master/default-fstype.yaml
@@ -1,0 +1,5 @@
+# Set default-fstype for attacher sidecar.
+- op: add
+  path: /spec/template/spec/containers/1/args/-
+  value: "--default-fstype=ext4"
+  

--- a/deploy/kubernetes/overlays/prow-stable-sidecar-rc-master/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-stable-sidecar-rc-master/kustomization.yaml
@@ -12,5 +12,17 @@ patchesJson6902:
     kind: Deployment
     name: csi-gce-pd-controller
   path: disk_labels.yaml
+- path: max-grpc-log-length.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: csi-gce-pd-controller
+    version: v1
+- path: default-fstype.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: csi-gce-pd-controller
+    version: v1
 transformers:
 - ../../images/prow-stable-sidecar-rc-master

--- a/deploy/kubernetes/overlays/prow-stable-sidecar-rc-master/max-grpc-log-length.yaml
+++ b/deploy/kubernetes/overlays/prow-stable-sidecar-rc-master/max-grpc-log-length.yaml
@@ -1,0 +1,5 @@
+# Set max-grpc-log-length for attacher sidecar.
+- op: add
+  path: /spec/template/spec/containers/1/args/-
+  value: "--max-grpc-log-length=10000"
+  


### PR DESCRIPTION
Cherry pick of #1144 on release-1.9.

#1144: Update csi-attacher to v4.2.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```