### PR TITLE
release-1.9 cut details for v1.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ lifecycle of Google Compute Engine Persistent Disks.
 ## Project Status
 
 Status: GA
-Latest stable image: `k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.8.2`
+Latest stable image: `k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.9.0`
 
 ### Test Status
 

--- a/deploy/kubernetes/images/stable-master/image.yaml
+++ b/deploy/kubernetes/images/stable-master/image.yaml
@@ -4,7 +4,7 @@ metadata:
   name: imagetag-csi-provisioner
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-provisioner
-  newTag: "v3.1.0"
+  newTag: "v3.4.0"
 
 ---
 apiVersion: builtin
@@ -13,7 +13,7 @@ metadata:
   name: imagetag-csi-attacher
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-attacher
-  newTag: "v3.4.0"
+  newTag: "v4.2.0"
 ---
 
 apiVersion: builtin
@@ -22,7 +22,7 @@ metadata:
   name: imagetag-csi-resizer
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-resizer
-  newTag: "v1.4.0"
+  newTag: "v1.7.0"
 ---
 
 apiVersion: builtin
@@ -31,7 +31,7 @@ metadata:
   name: imagetag-csi-snapshotter
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-snapshotter
-  newTag: "v4.0.1"
+  newTag: "v6.1.0"
 ---
 
 apiVersion: builtin
@@ -40,7 +40,7 @@ metadata:
   name: imagetag-csi-node-registrar
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-  newTag: "v2.5.0"
+  newTag: "v2.7.0"
 ---
 
 apiVersion: builtin
@@ -52,5 +52,5 @@ imageTag:
   # Don't change stable image without changing pdImagePlaceholder in
   # test/k8s-integration/main.go
   newName: k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.8.2"
+  newTag: "v1.9.0"
 ---

--- a/deploy/kubernetes/overlays/stable-master/default-fstype.yaml
+++ b/deploy/kubernetes/overlays/stable-master/default-fstype.yaml
@@ -1,0 +1,5 @@
+# Set default-fstype for attacher sidecar.
+- op: add
+  path: /spec/template/spec/containers/1/args/-
+  value: "--default-fstype=ext4"
+  

--- a/deploy/kubernetes/overlays/stable-master/kustomization.yaml
+++ b/deploy/kubernetes/overlays/stable-master/kustomization.yaml
@@ -4,5 +4,18 @@ namespace:
   gce-pd-csi-driver
 resources:
 - ../../base/
+patchesJson6902:
+- path: max-grpc-log-length.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: csi-gce-pd-controller
+    version: v1
+- path: default-fstype.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: csi-gce-pd-controller
+    version: v1
 transformers:
 - ../../images/stable-master

--- a/deploy/kubernetes/overlays/stable-master/max-grpc-log-length.yaml
+++ b/deploy/kubernetes/overlays/stable-master/max-grpc-log-length.yaml
@@ -1,0 +1,5 @@
+# Set max-grpc-log-length for attacher sidecar.
+- op: add
+  path: /spec/template/spec/containers/1/args/-
+  value: "--max-grpc-log-length=10000"
+  


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
Put 1.9.0 release into stable-master. The sidecar update is based on [this](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1155/files).

RC passing testgrid since 02-22 20:08 PST (visible google internal only): https://k8s-testgrid.appspot.com/provider-gcp-compute-persistent-disk-csi-driver#Kubernetes%20Master%20Driver%20Latest%20Release%20Candidate


https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-gcp-compute-persistent-disk-csi-driver-release-staging-k8s-master-integration/1628728505032249344 with newest sidecar change.

Refer to https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/804

```release-note
None
```