### PR TITLE
Update sidecar based on internal versions

### DIFF
--- a/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
+++ b/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
@@ -7,7 +7,7 @@ metadata:
   name: imagetag-csi-provisioner-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-provisioner
-  newTag: "v3.2.1"
+  newTag: "v3.4.0"
 ---
 apiVersion: builtin
 kind: ImageTagTransformer
@@ -23,7 +23,7 @@ metadata:
   name: imagetag-csi-resize-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-resizer
-  newTag: "v1.5.0"
+  newTag: "v1.7.0"
 ---
 apiVersion: builtin
 kind: ImageTagTransformer
@@ -31,7 +31,7 @@ metadata:
   name: imagetag-csi-snapshotter-prow-head
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-snapshotter
-  newTag: "v6.0.1"
+  newTag: "v6.1.0"
 ---
 apiVersion: builtin
 kind: ImageTagTransformer
@@ -39,7 +39,7 @@ metadata:
   name: imagetag-csi-node-registrar-prow-rc
 imageTag:
   name: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-  newTag: "v2.5.1"
+  newTag: "v2.7.0"
 ---
 apiVersion: builtin
 kind: ImageTagTransformer


### PR DESCRIPTION
**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:

Match internal sidecar versions:

- csi-snapshotter v6.1.0 [1. diff](https://github.com/kubernetes-csi/external-snapshotter/compare/v6.0.1...v6.1.0)  [2. change log](https://github.com/kubernetes-csi/external-snapshotter/tree/master/CHANGELOG)
- csi-provisioner v3.4.0 [1. diff](https://github.com/kubernetes-csi/external-provisioner/compare/v3.2.1...v3.4.0) [2. change log](https://github.com/kubernetes-csi/external-provisioner/tree/master/CHANGELOG)

    Added --enable-pprof option but we are not using it.
 
- csi-resizer v1.7.0 [1. diff](https://github.com/kubernetes-csi/external-resizer/compare/v1.5.0...v1.7.0) [2. change log](https://github.com/kubernetes-csi/external-resizer/tree/master/CHANGELOG)
- csi-attacher v4.1.0 or above
- csi-node-driver-registrar v2.7.0 [1. diff](https://github.com/kubernetes-csi/node-driver-registrar/compare/v2.5.1...v2.7.0) [2. change logs](https://github.com/kubernetes-csi/node-driver-registrar/tree/master/CHANGELOG)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Update sidecar versions to catch up internal versions

```
