### PR TITLE
Fix multiarch build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ endif
 all: gce-pd-driver gce-pd-driver-windows
 gce-pd-driver: require-GCE_PD_CSI_STAGING_VERSION
 	mkdir -p bin
-	go build -mod=vendor -gcflags=$(GCFLAGS) -ldflags "-linkmode 'external' -extldflags '-static' -X main.version=$(STAGINGVERSION)" -o bin/${DRIVERBINARY} ./cmd/gce-pd-csi-driver/
+	CGO_ENABLED=0 go build -mod=vendor -gcflags=$(GCFLAGS) -ldflags "-extldflags=static -X main.version=$(STAGINGVERSION)" -o bin/${DRIVERBINARY} ./cmd/gce-pd-csi-driver/
 
 gce-pd-driver-windows: require-GCE_PD_CSI_STAGING_VERSION
 ifeq (${GOARCH}, amd64)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Multiarch build was failing with:

```
[builder 4/4] RUN GOARCH=$(echo linux/arm64 | cut -f2 -d '/') GCE_PD_CSI_STAGING_VERSION=v1.9.0-xxx make gce-pd-driver
21.78 # sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/cmd/gce-pd-csi-driver
21.78 loadinternal: cannot find runtime/cgo
gi21.78 /usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Ran the following without errors:
```
docker buildx build  . --file=Dockerfile \
    --platform linux/arm64 \
    --build-arg STAGINGVERSION=test \
    --build-arg BUILDPLATFORM=linux/amd64 \
    --build-arg TARGETPLATFORM=linux/arm64  \
    --build-arg ARCH=arm64 
```

**Does this PR introduce a user-facing change?**:

```release-note
Fix multiarch build
```
