### PR TITLE
Add changelog for 1.9.2

### DIFF
--- a/CHANGELOG/CHANGELOG-1.9.md
+++ b/CHANGELOG/CHANGELOG-1.9.md
@@ -1,3 +1,12 @@
+# v1.9.2 - Changelog since v1.9.1
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Revert feature to add PV, PVC and namespace name as labels to the PD [#1090](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1090) ([#1174](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1174), [@sunnylovestiramisu](https://github.com/sunnylovestiramisu))
+
+
 # v1.9.1 - Changelog since v1.9.0
 
 ## Changes by Kind

--- a/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
+++ b/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
@@ -48,6 +48,6 @@ metadata:
 imageTag:
   name: k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
   newName: gcr.io/k8s-staging-cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.9.1-rc1"
+  newTag: "v1.9.2-rc1"
 ---
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:
Change log for v1.9.2, bake in https://k8s-testgrid.appspot.com/provider-gcp-compute-persistent-disk-csi-driver#Kubernetes%20Master%20Driver%20Latest%20Release%20Candidate

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
[GCR image v1.9.2-rc1](https://pantheon.corp.google.com/gcr/images/k8s-staging-cloud-provider-gcp/global/gcp-compute-persistent-disk-csi-driver@sha256:952cdebb219295408e2ec3e84936fb2671ee4cdc4989b391978d272feb50711e/details?e=-13802955&jsmode=o&mods=logs_tg_prod)

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
