### PR TITLE
Add pv labels

### DIFF
--- a/pkg/common/parameters.go
+++ b/pkg/common/parameters.go
@@ -141,6 +141,7 @@ func ExtractAndDefaultParameters(parameters map[string]string, driverName string
 			var pvc_name = strings.ToLower(v)
 			if len(pvc_name) > 63 {
 				pvc_name = pvc_name[:63]
+				klog.V(4).Info("The disk label for PVC-name is truncated to match label restriction (<64 characters allowed)")
 			}
 			_, err := ConvertLabelsStringToMap(labelKeyCreatedForClaimNamespace + "=" + pvc_name)
 			if err != nil {
@@ -164,6 +165,7 @@ func ExtractAndDefaultParameters(parameters map[string]string, driverName string
 			var pv_name = strings.ToLower(v)
 			if len(pv_name) > 63 {
 				pv_name = pv_name[:63]
+				klog.V(4).Info("The disk label for PV-name is truncated to match label restriction (<64 characters allowed)")
 			}
 			_, err := ConvertLabelsStringToMap(labelKeyCreatedForVolumeName + "=" + pv_name)
 			if err != nil {

--- a/pkg/common/parameters.go
+++ b/pkg/common/parameters.go
@@ -139,6 +139,9 @@ func ExtractAndDefaultParameters(parameters map[string]string, driverName string
 			p.Tags[tagKeyCreatedForClaimName] = v
 			// Verify that the parameters satisfy label restrictions before adding them as label
 			var pvc_name = strings.ToLower(v)
+			if len(pvc_name) > 63 {
+				pvc_name = pvc_name[:63]
+			}
 			_, err := ConvertLabelsStringToMap(labelKeyCreatedForClaimNamespace + "=" + pvc_name)
 			if err != nil {
 				klog.V(4).Info("Unable to add PVC name as a label", err)
@@ -159,6 +162,9 @@ func ExtractAndDefaultParameters(parameters map[string]string, driverName string
 			p.Tags[tagKeyCreatedForVolumeName] = v
 			// Verify that the parameters satisfy label restrictions before adding them as label
 			var pv_name = strings.ToLower(v)
+			if len(pv_name) > 63 {
+				pv_name = pv_name[:63]
+			}
 			_, err := ConvertLabelsStringToMap(labelKeyCreatedForVolumeName + "=" + pv_name)
 			if err != nil {
 				klog.V(4).Info("Unable to add PV name as a label", err)

--- a/pkg/common/parameters.go
+++ b/pkg/common/parameters.go
@@ -139,9 +139,6 @@ func ExtractAndDefaultParameters(parameters map[string]string, driverName string
 			p.Tags[tagKeyCreatedForClaimName] = v
 			// Verify that the parameters satisfy label restrictions before adding them as label
 			var pvc_name = strings.ToLower(v)
-			if len(pvc_name) > 63 {
-				pvc_name = pvc_name[:63]
-			}
 			_, err := ConvertLabelsStringToMap(labelKeyCreatedForClaimNamespace + "=" + pvc_name)
 			if err != nil {
 				klog.V(4).Info("Unable to add PVC name as a label", err)
@@ -162,9 +159,6 @@ func ExtractAndDefaultParameters(parameters map[string]string, driverName string
 			p.Tags[tagKeyCreatedForVolumeName] = v
 			// Verify that the parameters satisfy label restrictions before adding them as label
 			var pv_name = strings.ToLower(v)
-			if len(pv_name) > 63 {
-				pv_name = pv_name[:63]
-			}
 			_, err := ConvertLabelsStringToMap(labelKeyCreatedForVolumeName + "=" + pv_name)
 			if err != nil {
 				klog.V(4).Info("Unable to add PV name as a label", err)

--- a/pkg/common/parameters_test.go
+++ b/pkg/common/parameters_test.go
@@ -191,7 +191,7 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 			},
 		},
 		{
-			name:       "pv labels",
+			name:       "pv labels valid",
 			parameters: map[string]string{ParameterKeyPVCNamespace: "test-namespace-name-with-label-restrictions-allow_-and-63char", ParameterKeyPVName: "test-pv-name-with-label-restrictions-allow_-and-63char", ParameterKeyPVCName: "test-pvc-name-as-label-with-label-restriction-allow_-and-63char"},
 			labels:     map[string]string{},
 			expectParams: DiskParameters{

--- a/pkg/common/parameters_test.go
+++ b/pkg/common/parameters_test.go
@@ -187,7 +187,7 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 				ReplicationType:      "none",
 				DiskEncryptionKMSKey: "",
 				Tags:                 map[string]string{tagKeyCreatedForClaimNamespace: "test-namespace-name-as-labels-with-label-restrictions-does-not-allow*_--and-63+char", tagKeyCreatedForVolumeName: "test-pv-name-as-label-with-label-restriction-truncate-char-at63-these-are-additional_with*+", tagKeyCreatedForClaimName: "test-pvc-name-as-labels-with-label-restrictions-does-not-allow*_--and-63+char", tagKeyCreatedBy: "testDriver"},
-				Labels:               map[string]string{labelKeyCreatedForVolumeName: "test-pv-name-as-label-with-label-restriction-truncate-char-at63"},
+				Labels:               map[string]string{},
 			},
 		},
 		{

--- a/pkg/common/parameters_test.go
+++ b/pkg/common/parameters_test.go
@@ -139,7 +139,7 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 				ReplicationType:      "none",
 				DiskEncryptionKMSKey: "",
 				Tags:                 map[string]string{tagKeyCreatedForClaimName: "testPVCName", tagKeyCreatedForClaimNamespace: "testPVCNamespace", tagKeyCreatedForVolumeName: "testPVName", tagKeyCreatedBy: "testDriver"},
-				Labels:               map[string]string{},
+				Labels:               map[string]string{labelKeyCreatedForClaimNamespace: "testpvcnamespace", labelKeyCreatedForVolumeName: "testpvname", labelKeyCreatedForClaimName: "testpvcname"},
 			},
 		},
 		{
@@ -176,6 +176,30 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 				DiskEncryptionKMSKey: "",
 				Tags:                 map[string]string{},
 				Labels:               map[string]string{"key1": "value1", "label-1": "value-a", "label-2": "label-value-2"},
+			},
+		},
+		{
+			name:       "pv labels invalid",
+			parameters: map[string]string{ParameterKeyPVCNamespace: "test-namespace-name-as-labels-with-label-restrictions-does-not-allow*_--and-63+char", ParameterKeyPVName: "test-pv-name-as-label-with-label-restriction-truncate-char-at63-these-are-additional_with*+", ParameterKeyPVCName: "test-pvc-name-as-labels-with-label-restrictions-does-not-allow*_--and-63+char"},
+			labels:     map[string]string{},
+			expectParams: DiskParameters{
+				DiskType:             "pd-standard",
+				ReplicationType:      "none",
+				DiskEncryptionKMSKey: "",
+				Tags:                 map[string]string{tagKeyCreatedForClaimNamespace: "test-namespace-name-as-labels-with-label-restrictions-does-not-allow*_--and-63+char", tagKeyCreatedForVolumeName: "test-pv-name-as-label-with-label-restriction-truncate-char-at63-these-are-additional_with*+", tagKeyCreatedForClaimName: "test-pvc-name-as-labels-with-label-restrictions-does-not-allow*_--and-63+char", tagKeyCreatedBy: "testDriver"},
+				Labels:               map[string]string{labelKeyCreatedForVolumeName: "test-pv-name-as-label-with-label-restriction-truncate-char-at63"},
+			},
+		},
+		{
+			name:       "pv labels",
+			parameters: map[string]string{ParameterKeyPVCNamespace: "test-namespace-name-with-label-restrictions-allow_-and-63char", ParameterKeyPVName: "test-pv-name-with-label-restrictions-allow_-and-63char", ParameterKeyPVCName: "test-pvc-name-as-label-with-label-restriction-allow_-and-63char"},
+			labels:     map[string]string{},
+			expectParams: DiskParameters{
+				DiskType:             "pd-standard",
+				ReplicationType:      "none",
+				DiskEncryptionKMSKey: "",
+				Tags:                 map[string]string{tagKeyCreatedForClaimNamespace: "test-namespace-name-with-label-restrictions-allow_-and-63char", tagKeyCreatedForVolumeName: "test-pv-name-with-label-restrictions-allow_-and-63char", tagKeyCreatedForClaimName: "test-pvc-name-as-label-with-label-restriction-allow_-and-63char", tagKeyCreatedBy: "testDriver"},
+				Labels:               map[string]string{labelKeyCreatedForClaimNamespace: "test-namespace-name-with-label-restrictions-allow_-and-63char", labelKeyCreatedForVolumeName: "test-pv-name-with-label-restrictions-allow_-and-63char", labelKeyCreatedForClaimName: "test-pvc-name-as-label-with-label-restriction-allow_-and-63char"},
 			},
 		},
 	}

--- a/pkg/common/parameters_test.go
+++ b/pkg/common/parameters_test.go
@@ -187,7 +187,7 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 				ReplicationType:      "none",
 				DiskEncryptionKMSKey: "",
 				Tags:                 map[string]string{tagKeyCreatedForClaimNamespace: "test-namespace-name-as-labels-with-label-restrictions-does-not-allow*_--and-63+char", tagKeyCreatedForVolumeName: "test-pv-name-as-label-with-label-restriction-truncate-char-at63-these-are-additional_with*+", tagKeyCreatedForClaimName: "test-pvc-name-as-labels-with-label-restrictions-does-not-allow*_--and-63+char", tagKeyCreatedBy: "testDriver"},
-				Labels:               map[string]string{},
+				Labels:               map[string]string{labelKeyCreatedForVolumeName: "test-pv-name-as-label-with-label-restriction-truncate-char-at63"},
 			},
 		},
 		{


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
The PR adds "namespace, PV and PVC name" to PD labels. It validates the PV and PVC names against label restrictions and truncates any name with length >63 and drop any name containing invalid characters. 
**Which issue(s) this PR fixes**:
Fixes #1064 

**Special notes for your reviewer**:
This PR is an update on PR #1090 with required validations removing any blockages in Volume creation.
**Does this PR introduce a user-facing change?**:
Yes
```Adding PV/PVC and namespace "names" as labels to PD. PV/PVC "names" which do not follow the [label restrictions](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names) would not be added as labels. If a name is longer then allowed length (0-63 characters) it will be truncated at 63.

```
