### PR TITLE
Automated cherry pick of #1162: Fix for CVEs
#1158: go version updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG BUILDPLATFORM
 
-FROM --platform=$BUILDPLATFORM golang:1.18.9 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19.6 as builder
 
 ARG STAGINGVERSION
 ARG TARGETPLATFORM

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ADD . .
 RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') GCE_PD_CSI_STAGING_VERSION=$STAGINGVERSION make gce-pd-driver
 
 # Start from Kubernetes Debian base.
-FROM k8s.gcr.io/build-image/debian-base:buster-v1.9.0 as debian
+FROM gke.gcr.io/debian-base:bullseye-v1.4.3-gke.0 as debian
 # Install necessary dependencies
 # google_nvme_id script depends on the following packages: nvme-cli, xxd, bash
 RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs nvme-cli xxd bash
@@ -74,28 +74,30 @@ COPY --from=debian /bin/ln /bin/ln
 COPY --from=debian /bin/udevadm /bin/udevadm
 
 # Copy shared libraries into distroless base.
-COPY --from=debian /lib/${LIB_DIR_PREFIX}-linux-gnu/libblkid.so.1 \
+COPY --from=debian /lib/${LIB_DIR_PREFIX}-linux-gnu/libpcre.so.3 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libselinux.so.1 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libtinfo.so.6 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libe2p.so.2 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libcom_err.so.2 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libdevmapper.so.1.02.1 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libe2p.so.2 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libext2fs.so.2 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libgcc_s.so.1 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/liblzma.so.5 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libmount.so.1 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libpcre.so.3 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libreadline.so.5 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libselinux.so.1 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libtinfo.so.6 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libudev.so.1 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libuuid.so.1 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libreadline.so.8 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libz.so.1 /lib/${LIB_DIR_PREFIX}-linux-gnu/
 
-COPY --from=debian /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libacl.so.1 \
+COPY --from=debian /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libblkid.so.1 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libinih.so.1 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libmount.so.1 \         
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libudev.so.1 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libuuid.so.1 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libacl.so.1 \
                    /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libattr.so.1 \
-                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libicudata.so.63 \
-                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libicui18n.so.63 \
-                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libicuuc.so.63 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libicudata.so.67 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libicui18n.so.67 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libicuuc.so.67 \
                    /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libkmod.so.2 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libpcre2-8.so.0 \
                    /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libstdc++.so.6 /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/
 
 # Copy NVME support required script and rules into distroless base.

--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 ARG BASE_IMAGE
+<<<<<<< HEAD
 FROM --platform=$BUILDPLATFORM golang:1.18.9 AS builder
+=======
+FROM --platform=$BUILDPLATFORM golang:1.19.6 AS builder
+>>>>>>> go version updates
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+<<<<<<< HEAD
 FROM golang:1.13.15 as builder
+=======
+FROM golang:1.19.6 as builder
+>>>>>>> go version updates
 WORKDIR /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 ADD . .
 


### PR DESCRIPTION
Cherry pick of #1162 #1158 on release-1.7.

#1162: Fix for CVEs
#1158: go version updates

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
None
```