### PR TITLE
Skip snapshot and restore test 

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -598,6 +598,11 @@ func generateGKETestSkip(testParams *testParameters) string {
 		skipString = skipString + "|pvc.data.source"
 	}
 
+	// Snapshot and restore test fixes were introduced after 1.26 in PR#972.
+	if curVer.lessThan(mustParseVersion("1.26.0")) {
+		skipString = skipString + "|should.provision.correct.filesystem.size.when.restoring.snapshot.to.larger.size.pvc"
+	}
+
 	// "volumeMode should not mount / map unused volumes in a pod" tests a
 	// (https://github.com/kubernetes/kubernetes/pull/81163)
 	// bug-fix introduced in 1.16


### PR DESCRIPTION
Skip snapshot and restore test because test fix [PR#972](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/972) is not backported to 1.8-. The fix is only in 1.9+. This test is currently failing when I am trying to cherry pick CVE fixes back to 1.8 and 1.7. See [here](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1186#issuecomment-1508460418)

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
 /kind failing-test

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Skips Snapshot and Restore test for k8s versions less than 1.26. 
```
