### PR TITLE
Automated cherry pick of #1189: Skip snapshot and restore test because test fix

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -589,6 +589,11 @@ func generateGKETestSkip(testParams *testParameters) string {
 		skipString = skipString + "|pvc.data.source"
 	}
 
+	// Snapshot and restore test fixes were introduced after 1.26 in PR#972.
+	if curVer.lessThan(mustParseVersion("1.26.0")) {
+		skipString = skipString + "|should.provision.correct.filesystem.size.when.restoring.snapshot.to.larger.size.pvc"
+	}
+
 	// "volumeMode should not mount / map unused volumes in a pod" tests a
 	// (https://github.com/kubernetes/kubernetes/pull/81163)
 	// bug-fix introduced in 1.16


### PR DESCRIPTION
Cherry pick of #1189 on release-1.7.

#1189: Skip snapshot and restore test because test fix

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
None
```