### PR TITLE
Automated cherry pick of #1177: Fix xfs_io error while loading shared libraries: libedit.so.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,7 @@ COPY --from=debian /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libblkid.so.1 \
                    /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libuuid.so.1 \
                    /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libacl.so.1 \
                    /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libattr.so.1 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libedit.so.2 \
                    /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libicudata.so.67 \
                    /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libicui18n.so.67 \
                    /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libicuuc.so.67 \


### PR DESCRIPTION
Cherry pick of #1177 on release-1.7.

#1177: Fix xfs_io error while loading shared libraries: libedit.so.2

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
None
```
