### PR TITLE
Add tests for ROX mode during Node Stage 

### DIFF
--- a/docs/kubernetes/development.md
+++ b/docs/kubernetes/development.md
@@ -102,9 +102,6 @@ You may see errors during driver deployment.
 
 ### Sanity tests
 
-> ***NOTE:*** Sanity tests are currently failing, tracked by
-> https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/990.
-
 ```
 ./test/run-sanity.sh
 ```

--- a/pkg/deviceutils/fake-device-utils.go
+++ b/pkg/deviceutils/fake-device-utils.go
@@ -17,12 +17,16 @@ package deviceutils
 import "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/resizefs"
 
 type fakeDeviceUtils struct {
+	skipResize bool
 }
 
-var _ DeviceUtils = &fakeDeviceUtils{}
+var _ DeviceUtils = &fakeDeviceUtils{
+}
 
-func NewFakeDeviceUtils() *fakeDeviceUtils {
-	return &fakeDeviceUtils{}
+func NewFakeDeviceUtils(skipResize bool) *fakeDeviceUtils {
+	return &fakeDeviceUtils{
+		skipResize: skipResize,
+	}
 }
 
 // Returns list of all /dev/disk/by-id/* paths for given PD.
@@ -41,6 +45,9 @@ func (_ *fakeDeviceUtils) DisableDevice(devicePath string) error {
 	return nil
 }
 
-func (_ *fakeDeviceUtils) Resize(resizer resizefs.Resizefs, devicePath string, deviceMountPath string) (bool, error) {
-	return false, nil
+func (du *fakeDeviceUtils) Resize(resizer resizefs.Resizefs, devicePath string, deviceMountPath string) (bool, error) {
+	if du.skipResize {
+		return false, nil
+	}
+	return resizer.Resize(devicePath, deviceMountPath)
 }

--- a/pkg/deviceutils/fake-device-utils.go
+++ b/pkg/deviceutils/fake-device-utils.go
@@ -20,8 +20,7 @@ type fakeDeviceUtils struct {
 	skipResize bool
 }
 
-var _ DeviceUtils = &fakeDeviceUtils{
-}
+var _ DeviceUtils = &fakeDeviceUtils{}
 
 func NewFakeDeviceUtils(skipResize bool) *fakeDeviceUtils {
 	return &fakeDeviceUtils{

--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -342,10 +342,12 @@ func (ns *GCENodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStage
 
 	// Part 4: Resize filesystem.
 	// https://github.com/kubernetes/kubernetes/issues/94929
-	resizer := resizefs.NewResizeFs(ns.Mounter)
-	_, err = ns.DeviceUtils.Resize(resizer, devicePath, stagingTargetPath)
-	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("error when resizing volume %s from device '%s' at path '%s': %v", volumeID, devicePath, stagingTargetPath, err.Error()))
+	if !readonly {
+		resizer := resizefs.NewResizeFs(ns.Mounter)
+		_, err = ns.DeviceUtils.Resize(resizer, devicePath, stagingTargetPath)
+		if err != nil {
+			return nil, status.Error(codes.Internal, fmt.Sprintf("error when resizing volume %s from device '%s' at path '%s': %v", volumeID, devicePath, stagingTargetPath, err.Error()))
+		}
 	}
 
 	klog.V(4).Infof("NodeStageVolume succeeded on %v to %s", volumeID, stagingTargetPath)
@@ -499,6 +501,15 @@ func (ns *GCENodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpa
 		if blk := volumeCapability.GetBlock(); blk != nil {
 			// Noop for Block NodeExpandVolume
 			klog.V(4).Infof("NodeExpandVolume succeeded on %v to %s, capability is block so this is a no-op", volumeID, volumePath)
+			return &csi.NodeExpandVolumeResponse{}, nil
+		}
+
+		readonly, err := getReadOnlyFromCapability(volumeCapability)
+		if err != nil {
+			return nil, status.Error(codes.Internal, fmt.Sprintf("failed to check if capability for volume %s is readonly: %v", volumeID, err))
+		}
+		if readonly {
+			klog.V(4).Infof("NodeExpandVolume succeeded on %v to %s, capability access is readonly so this is a no-op", volumeID, volumePath)
 			return &csi.NodeExpandVolumeResponse{}, nil
 		}
 	}

--- a/pkg/gce-pd-csi-driver/node_test.go
+++ b/pkg/gce-pd-csi-driver/node_test.go
@@ -598,8 +598,11 @@ func TestNodeStageVolume(t *testing.T) {
 		if tc.expErrCode != codes.OK {
 			t.Fatalf("Expected error: %v, got no error", tc.expErrCode)
 		}
-		if tc.expResize != resizeCalled {
-			t.Fatalf("Test expected resize to be called: %t but was it called: %t", tc.expResize, resizeCalled)
+		if tc.expResize == true && resizeCalled == false {
+			t.Fatalf("Test did not call resize, but it was expected.")
+		}
+		if tc.expResize == false && resizeCalled == true {
+			t.Fatalf("Test called resize, but it was not expected.")
 		}
 	}
 }

--- a/pkg/gce-pd-csi-driver/node_test.go
+++ b/pkg/gce-pd-csi-driver/node_test.go
@@ -427,6 +427,18 @@ func TestNodeStageVolume(t *testing.T) {
 			expResize:   true,
 		},
 		{
+			name: "Valid request, no resize bc readonly capability",
+			req: &csi.NodeStageVolumeRequest{
+				VolumeId:          volumeID,
+				StagingTargetPath: stagingPath,
+				VolumeCapability:  createVolumeCapability(csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY),
+			},
+			deviceSize:  5,
+			blockExtSize:     1,
+			readonlyBit: "0",
+			expResize:   false,
+		},
+		{
 			name: "Invalid request (Bad Access Mode)",
 			req: &csi.NodeStageVolumeRequest{
 				VolumeId:          volumeID,

--- a/pkg/gce-pd-csi-driver/node_test.go
+++ b/pkg/gce-pd-csi-driver/node_test.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"k8s.io/utils/exec"
@@ -40,11 +41,11 @@ const defaultTargetPath = "/mnt/test"
 const defaultStagingPath = "/staging"
 
 func getTestGCEDriver(t *testing.T) *GCEDriver {
-	return getCustomTestGCEDriver(t, mountmanager.NewFakeSafeMounter(), deviceutils.NewFakeDeviceUtils(), metadataservice.NewFakeService())
+	return getCustomTestGCEDriver(t, mountmanager.NewFakeSafeMounter(), deviceutils.NewFakeDeviceUtils(false), metadataservice.NewFakeService())
 }
 
 func getTestGCEDriverWithCustomMounter(t *testing.T, mounter *mount.SafeFormatAndMount) *GCEDriver {
-	return getCustomTestGCEDriver(t, mounter, deviceutils.NewFakeDeviceUtils(), metadataservice.NewFakeService())
+	return getCustomTestGCEDriver(t, mounter, deviceutils.NewFakeDeviceUtils(false), metadataservice.NewFakeService())
 }
 
 func getCustomTestGCEDriver(t *testing.T, mounter *mount.SafeFormatAndMount, deviceUtils deviceutils.DeviceUtils, metaService metadataservice.MetadataService) *GCEDriver {
@@ -60,7 +61,7 @@ func getCustomTestGCEDriver(t *testing.T, mounter *mount.SafeFormatAndMount, dev
 func getTestBlockingGCEDriver(t *testing.T, readyToExecute chan chan struct{}) *GCEDriver {
 	gceDriver := GetGCEDriver()
 	mounter := mountmanager.NewFakeSafeBlockingMounter(readyToExecute)
-	nodeServer := NewNodeServer(gceDriver, mounter, deviceutils.NewFakeDeviceUtils(), metadataservice.NewFakeService(), mountmanager.NewFakeStatter(mounter))
+	nodeServer := NewNodeServer(gceDriver, mounter, deviceutils.NewFakeDeviceUtils(false), metadataservice.NewFakeService(), mountmanager.NewFakeStatter(mounter))
 	err := gceDriver.SetupGCEDriver(driver, "test-vendor", nil, nil, nil, nodeServer)
 	if err != nil {
 		t.Fatalf("Failed to setup GCE Driver: %v", err)
@@ -381,26 +382,49 @@ func TestNodeStageVolume(t *testing.T) {
 	stagingPath := filepath.Join(tempDir, defaultStagingPath)
 
 	testCases := []struct {
-		name       string
-		req        *csi.NodeStageVolumeRequest
-		expErrCode codes.Code
+		name          string
+		req           *csi.NodeStageVolumeRequest
+		deviceSize    int
+		blockExtSize       int
+		readonlyBit   string
+		expResize     bool
+		expErrCode    codes.Code
 	}{
 		{
-			name: "Valid request",
+			name: "Valid request, no resize bc size",
 			req: &csi.NodeStageVolumeRequest{
 				VolumeId:          volumeID,
 				StagingTargetPath: stagingPath,
 				VolumeCapability:  stdVolCap,
 			},
+			deviceSize:  1,
+			blockExtSize:     1,
+			readonlyBit: "0",
+			expResize:   false,
 		},
 		{
-			name: "Invalid request (Bad Access Mode)",
+			name: "Valid request, no resize bc readonly",
 			req: &csi.NodeStageVolumeRequest{
 				VolumeId:          volumeID,
 				StagingTargetPath: stagingPath,
-				VolumeCapability:  createVolumeCapability(csi.VolumeCapability_AccessMode_UNKNOWN),
+				VolumeCapability:  stdVolCap,
 			},
-			expErrCode: codes.InvalidArgument,
+			deviceSize:  1,
+			blockExtSize:     1,
+			readonlyBit: "1",
+			expResize:   false,
+		},
+		{
+			name: "Valid request, resize bc size",
+			req: &csi.NodeStageVolumeRequest{
+				VolumeId:          volumeID,
+				StagingTargetPath: stagingPath,
+				VolumeCapability:  stdVolCap,
+			},
+			deviceSize:  5,
+			blockExtSize:     1,
+			readonlyBit: "0",
+			expResize:   true,
 		},
 		{
 			name: "Invalid request (Bad Access Mode)",
@@ -448,6 +472,7 @@ func TestNodeStageVolume(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Logf("Test case: %s", tc.name)
+		resizeCalled := false
 		actionList := []testingexec.FakeCommandAction{
 			makeFakeCmd(
 				&testingexec.FakeCmd{
@@ -458,26 +483,40 @@ func TestNodeStageVolume(t *testing.T) {
 					},
 				},
 				"blkid",
+				strings.Split("-p -s TYPE -s PTTYPE -o export /dev/disk/fake-path", " ")...,
 			),
 			makeFakeCmd(
 				&testingexec.FakeCmd{
 					CombinedOutputScript: []testingexec.FakeAction{
 						func() ([]byte, []byte, error) {
-							return []byte("1"), nil, nil
+							return []byte(""), nil, nil
 						},
 					},
 				},
-				"blockdev",
+				"fsck",
+				strings.Split("-a /dev/disk/fake-path", " ")...,
 			),
 			makeFakeCmd(
 				&testingexec.FakeCmd{
 					CombinedOutputScript: []testingexec.FakeAction{
 						func() ([]byte, []byte, error) {
-							return []byte("1"), nil, nil
+							return []byte(tc.readonlyBit), nil, nil
 						},
 					},
 				},
 				"blockdev",
+				strings.Split("--getro /dev/disk/fake-path", " ")...,
+			),
+			makeFakeCmd(
+				&testingexec.FakeCmd{
+					CombinedOutputScript: []testingexec.FakeAction{
+						func() ([]byte, []byte, error) {
+							return []byte(fmt.Sprintf("%d", tc.deviceSize)), nil, nil
+						},
+					},
+				},
+				"blockdev",
+				strings.Split("--getsize64 /dev/disk/fake-path", " ")...,
 			),
 			makeFakeCmd(
 				&testingexec.FakeCmd{
@@ -488,17 +527,47 @@ func TestNodeStageVolume(t *testing.T) {
 					},
 				},
 				"blkid",
+				strings.Split("-p -s TYPE -s PTTYPE -o export /dev/disk/fake-path", " ")...,
 			),
 			makeFakeCmd(
 				&testingexec.FakeCmd{
 					CombinedOutputScript: []testingexec.FakeAction{
 						func() ([]byte, []byte, error) {
-							return []byte(fmt.Sprintf("block size: 1\nblock count: 1")), nil, nil
+							return []byte(fmt.Sprintf("block size: %d\nblock count: 1", tc.blockExtSize)), nil, nil
 						},
 					},
 				},
 				"dumpe2fs",
+				strings.Split("-h /dev/disk/fake-path", " ")...,
 			),
+		}
+
+		if tc.expResize {
+			actionList = append(actionList, []testingexec.FakeCommandAction{
+				makeFakeCmd(
+					&testingexec.FakeCmd{
+						CombinedOutputScript: []testingexec.FakeAction{
+							func() ([]byte, []byte, error) {
+								return []byte(fmt.Sprintf("DEVNAME=/dev/sdb\nTYPE=ext4")), nil, nil
+							},
+						},
+					},
+					"blkid",
+					strings.Split("-p -s TYPE -s PTTYPE -o export /dev/disk/fake-path", " ")...,
+				),
+				makeFakeCmd(
+					&testingexec.FakeCmd{
+						CombinedOutputScript: []testingexec.FakeAction{
+							func() ([]byte, []byte, error) {
+								resizeCalled = true
+								return []byte(fmt.Sprintf("DEVNAME=/dev/sdb\nTYPE=ext4")), nil, nil
+							},
+						},
+					},
+					"resize2fs",
+					strings.Split("/dev/disk/fake-path", " ")...,
+				),
+			}...)
 		}
 		mounter := mountmanager.NewFakeSafeMounterWithCustomExec(&testingexec.FakeExec{CommandScript: actionList})
 		gceDriver := getTestGCEDriverWithCustomMounter(t, mounter)
@@ -516,6 +585,9 @@ func TestNodeStageVolume(t *testing.T) {
 		}
 		if tc.expErrCode != codes.OK {
 			t.Fatalf("Expected error: %v, got no error", tc.expErrCode)
+		}
+		if tc.expResize != resizeCalled {
+			t.Fatalf("Test expected resize to be called: %t but was it called: %t", tc.expResize, resizeCalled)
 		}
 	}
 }

--- a/pkg/gce-pd-csi-driver/node_test.go
+++ b/pkg/gce-pd-csi-driver/node_test.go
@@ -391,7 +391,7 @@ func TestNodeStageVolume(t *testing.T) {
 		expErrCode   codes.Code
 	}{
 		{
-                        name: "Valid request, no resize because block and filesystem sizes match",
+			name: "Valid request, no resize because block and filesystem sizes match",
 			req: &csi.NodeStageVolumeRequest{
 				VolumeId:          volumeID,
 				StagingTargetPath: stagingPath,

--- a/pkg/gce-pd-csi-driver/node_test.go
+++ b/pkg/gce-pd-csi-driver/node_test.go
@@ -382,13 +382,13 @@ func TestNodeStageVolume(t *testing.T) {
 	stagingPath := filepath.Join(tempDir, defaultStagingPath)
 
 	testCases := []struct {
-		name          string
-		req           *csi.NodeStageVolumeRequest
-		deviceSize    int
-		blockExtSize       int
-		readonlyBit   string
-		expResize     bool
-		expErrCode    codes.Code
+		name         string
+		req          *csi.NodeStageVolumeRequest
+		deviceSize   int
+		blockExtSize int
+		readonlyBit  string
+		expResize    bool
+		expErrCode   codes.Code
 	}{
 		{
 			name: "Valid request, no resize bc size",
@@ -397,10 +397,10 @@ func TestNodeStageVolume(t *testing.T) {
 				StagingTargetPath: stagingPath,
 				VolumeCapability:  stdVolCap,
 			},
-			deviceSize:  1,
-			blockExtSize:     1,
-			readonlyBit: "0",
-			expResize:   false,
+			deviceSize:   1,
+			blockExtSize: 1,
+			readonlyBit:  "0",
+			expResize:    false,
 		},
 		{
 			name: "Valid request, no resize bc readonly",
@@ -409,10 +409,10 @@ func TestNodeStageVolume(t *testing.T) {
 				StagingTargetPath: stagingPath,
 				VolumeCapability:  stdVolCap,
 			},
-			deviceSize:  1,
-			blockExtSize:     1,
-			readonlyBit: "1",
-			expResize:   false,
+			deviceSize:   1,
+			blockExtSize: 1,
+			readonlyBit:  "1",
+			expResize:    false,
 		},
 		{
 			name: "Valid request, resize bc size",
@@ -421,10 +421,10 @@ func TestNodeStageVolume(t *testing.T) {
 				StagingTargetPath: stagingPath,
 				VolumeCapability:  stdVolCap,
 			},
-			deviceSize:  5,
-			blockExtSize:     1,
-			readonlyBit: "0",
-			expResize:   true,
+			deviceSize:   5,
+			blockExtSize: 1,
+			readonlyBit:  "0",
+			expResize:    true,
 		},
 		{
 			name: "Valid request, no resize bc readonly capability",
@@ -433,10 +433,10 @@ func TestNodeStageVolume(t *testing.T) {
 				StagingTargetPath: stagingPath,
 				VolumeCapability:  createVolumeCapability(csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY),
 			},
-			deviceSize:  5,
-			blockExtSize:     1,
-			readonlyBit: "0",
-			expResize:   false,
+			deviceSize:   5,
+			blockExtSize: 1,
+			readonlyBit:  "0",
+			expResize:    false,
 		},
 		{
 			name: "Invalid request (Bad Access Mode)",

--- a/pkg/gce-pd-csi-driver/node_test.go
+++ b/pkg/gce-pd-csi-driver/node_test.go
@@ -391,7 +391,7 @@ func TestNodeStageVolume(t *testing.T) {
 		expErrCode   codes.Code
 	}{
 		{
-			name: "Valid request, no resize bc size",
+                        name: "Valid request, no resize because block and filesystem sizes match",
 			req: &csi.NodeStageVolumeRequest{
 				VolumeId:          volumeID,
 				StagingTargetPath: stagingPath,

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -62,7 +62,7 @@ func TestSanity(t *testing.T) {
 	}
 
 	mounter := mountmanager.NewFakeSafeMounter()
-	deviceUtils := deviceutils.NewFakeDeviceUtils()
+	deviceUtils := deviceutils.NewFakeDeviceUtils(true)
 
 	//Initialize GCE Driver
 	identityServer := driver.NewIdentityServer(gceDriver)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This is a follow up to https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/1088 which does 2 things:
1. Adds more fine grained testing for whether or not resize is attempted under certain scenarios during node stage.
2. Skips resize attempt if volume capability from request indicates readonly

**Which issue(s) this PR fixes**:
Fixes #1088

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Skips resize attempt if volume capability from request indicates readonly.
```