### PR TITLE
Update buildkit version from 0.10.6 -> 0.11.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ init-buildx:
 	$(DOCKER) run --rm --privileged multiarch/qemu-user-static --reset --credential yes --persistent yes
 	# Ensure we use a builder that can leverage it (the default on linux will not)
 	-$(DOCKER) buildx rm multiarch-multiplatform-builder
-	$(DOCKER) buildx create --use --name=multiarch-multiplatform-builder --driver-opt network=host --driver-opt image=moby/buildkit:v0.10.6
+	$(DOCKER) buildx create --use --name=multiarch-multiplatform-builder --driver-opt network=host --driver-opt image=moby/buildkit:v0.11.3
 	# Register gcloud as a Docker credential helper.
 	# Required for "docker buildx build --push".
 	gcloud auth configure-docker --quiet


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
This updates the buildkit version from 0.10.6 -> 0.11.3. Version 0.11.3 contains a caching fix, which appears to be contributing to failures of the integration test (https://github.com/moby/buildkit/releases/tag/v0.11.3).

**Which issue(s) this PR fixes**:
Fixes #1217

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
