### PR TITLE
Add changelog for v1.7.8

### DIFF
--- a/CHANGELOG/CHANGELOG-1.7.md
+++ b/CHANGELOG/CHANGELOG-1.7.md
@@ -1,3 +1,12 @@
+# v1.7.8 - Changelog since v1.7.7
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Separate user errors from internal errors. ([#1092](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1092), [@sunnylovestiramisu](https://github.com/sunnylovestiramisu))
+- Upgrade klog v1 to v2 and fix error wrapping. ([#1084](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1084), [@sunnylovestiramisu](https://github.com/sunnylovestiramisu))
+
 # v1.7.7 - Changelog since v1.7.6
 
 ## Changes by Kind


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**Special notes for your reviewer**:
Backport exception has been approved.

**Does this PR introduce a user-facing change?**:

```release-note
None
```

https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/tree/v1.7.8
