### PR TITLE
Remove nouid32 which breaks xfs

### DIFF
--- a/test/k8s-integration/config/test-config-template.in
+++ b/test/k8s-integration/config/test-config-template.in
@@ -22,7 +22,6 @@ DriverInfo:
     NumRestarts: 10
   SupportedMountOption:
     debug:
-    nouid32:
   SupportedSizeRange:
     Min: {{.MinimumVolumeSize}}
     Max: 64Ti


### PR DESCRIPTION
See https://github.com/kubernetes/cloud-provider-gcp/issues/557 and [this example of a failing test](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-gcp-compute-persistent-disk-csi-driver-release-k8s-master-integration/1665792101725507584).

It appears the nouid32 mount option is not supported by XFS.

I guess it works with ext4 --- but brief internet searching didn't find anything about it, so I don't know if it's something we need to support?
/kind failing-test

```release-note
None
```

/assign @msau42 
