### PR TITLE
Use noatime as test mount option

### DIFF
--- a/test/k8s-integration/config/test-config-template.in
+++ b/test/k8s-integration/config/test-config-template.in
@@ -22,6 +22,7 @@ DriverInfo:
     NumRestarts: 10
   SupportedMountOption:
     debug:
+    noatime:
   SupportedSizeRange:
     Min: {{.MinimumVolumeSize}}
     Max: 64Ti


### PR DESCRIPTION
I pulled the trigger too quickly on #1252, we can use the noatime option instead which works on ext4 and xfs.

See also https://github.com/kubernetes/cloud-provider-gcp/issues/557

/kind failing-test
```release-note
None
```

/assign @msau42 