### PR TITLE
Add force attach to storage class

### DIFF
--- a/pkg/common/parameters.go
+++ b/pkg/common/parameters.go
@@ -29,6 +29,7 @@ const (
 	ParameterKeyLabels                        = "labels"
 	ParameterKeyProvisionedIOPSOnCreate       = "provisioned-iops-on-create"
 	ParameterKeyProvisionedThroughputOnCreate = "provisioned-throughput-on-create"
+	ParameterAvailabilityClass                = "availability-class"
 
 	// Parameters for VolumeSnapshotClass
 	ParameterKeyStorageLocations = "storage-locations"
@@ -37,6 +38,10 @@ const (
 	DiskSnapshotType             = "snapshots"
 	DiskImageType                = "images"
 	replicationTypeNone          = "none"
+
+	// Parameters for AvailabilityClass
+	ParameterNoAvailabilityClass       = "none"
+	ParameterRegionalHardFailoverClass = "regional-hard-failover"
 
 	// Keys for PV and PVC parameters as reported by external-provisioner
 	ParameterKeyPVCName      = "csi.storage.k8s.io/pvc/name"
@@ -83,6 +88,8 @@ type DiskParameters struct {
 	// Values: {int64}
 	// Default: none
 	ProvisionedThroughputOnCreate int64
+	// Default: false
+	ForceAttach bool
 }
 
 // SnapshotParameters contains normalized and defaulted parameters for snapshots
@@ -155,6 +162,14 @@ func ExtractAndDefaultParameters(parameters map[string]string, driverName string
 				return p, fmt.Errorf("parameters contain invalid provisionedThroughputOnCreate parameter: %w", err)
 			}
 			p.ProvisionedThroughputOnCreate = paramProvisionedThroughputOnCreate
+		case ParameterAvailabilityClass:
+			paramAvailabilityClass, err := ConvertStringToAvailabilityClass(v)
+			if err != nil {
+				return p, fmt.Errorf("parameters contain invalid availability class parameter: %w", err)
+			}
+			if paramAvailabilityClass == ParameterRegionalHardFailoverClass {
+				p.ForceAttach = true
+			}
 		default:
 			return p, fmt.Errorf("parameters contains invalid option %q", k)
 		}

--- a/pkg/common/parameters_test.go
+++ b/pkg/common/parameters_test.go
@@ -178,6 +178,27 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 				Labels:               map[string]string{"key1": "value1", "label-1": "value-a", "label-2": "label-value-2"},
 			},
 		},
+		{
+			name:       "availability class parameters",
+			parameters: map[string]string{ParameterAvailabilityClass: ParameterRegionalHardFailoverClass},
+			expectParams: DiskParameters{
+				DiskType:        "pd-standard",
+				ReplicationType: "none",
+				ForceAttach:     true,
+				Tags:            map[string]string{},
+				Labels:          map[string]string{},
+			},
+		},
+		{
+			name:       "no force attach parameters",
+			parameters: map[string]string{ParameterAvailabilityClass: ParameterNoAvailabilityClass},
+			expectParams: DiskParameters{
+				DiskType:        "pd-standard",
+				ReplicationType: "none",
+				Tags:            map[string]string{},
+				Labels:          map[string]string{},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -284,6 +284,28 @@ func ConvertMiStringToInt64(str string) (int64, error) {
 	return volumehelpers.RoundUpToMiB(quantity)
 }
 
+// ConvertStringToBool converts a string to a boolean.
+func ConvertStringToBool(str string) (bool, error) {
+	switch strings.ToLower(str) {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	}
+	return false, fmt.Errorf("Unexpected boolean string %s", str)
+}
+
+// ConvertStringToAvailabilityClass converts a string to an availability class string.
+func ConvertStringToAvailabilityClass(str string) (string, error) {
+	switch strings.ToLower(str) {
+	case ParameterNoAvailabilityClass:
+		return ParameterNoAvailabilityClass, nil
+	case ParameterRegionalHardFailoverClass:
+		return ParameterRegionalHardFailoverClass, nil
+	}
+	return "", fmt.Errorf("Unexpected boolean string %s", str)
+}
+
 // ParseMachineType returns an extracted machineType from a URL, or empty if not found.
 // machineTypeUrl: Full or partial URL of the machine type resource, in the format:
 //

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -806,6 +806,114 @@ func TestConvertMiStringToInt64(t *testing.T) {
 	}
 }
 
+func TestConvertStringToBool(t *testing.T) {
+	tests := []struct {
+		desc        string
+		inputStr    string
+		expected    bool
+		expectError bool
+	}{
+		{
+			desc:        "valid true",
+			inputStr:    "true",
+			expected:    true,
+			expectError: false,
+		},
+		{
+			desc:        "valid mixed case true",
+			inputStr:    "True",
+			expected:    true,
+			expectError: false,
+		},
+		{
+			desc:        "valid false",
+			inputStr:    "false",
+			expected:    false,
+			expectError: false,
+		},
+		{
+			desc:        "valid mixed case false",
+			inputStr:    "False",
+			expected:    false,
+			expectError: false,
+		},
+		{
+			desc:        "invalid",
+			inputStr:    "yes",
+			expected:    false,
+			expectError: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := ConvertStringToBool(tc.inputStr)
+			if err != nil && !tc.expectError {
+				t.Errorf("Got error %v converting string to bool %s; expect no error", err, tc.inputStr)
+			}
+			if err == nil && tc.expectError {
+				t.Errorf("Got no error converting string to bool %s; expect an error", tc.inputStr)
+			}
+			if err == nil && got != tc.expected {
+				t.Errorf("Got %v for converting string to bool; expect %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestConvertStringToAvailabilityClass(t *testing.T) {
+	tests := []struct {
+		desc        string
+		inputStr    string
+		expected    string
+		expectError bool
+	}{
+		{
+			desc:        "valid none",
+			inputStr:    "none",
+			expected:    ParameterNoAvailabilityClass,
+			expectError: false,
+		},
+		{
+			desc:        "valid mixed case none",
+			inputStr:    "None",
+			expected:    ParameterNoAvailabilityClass,
+			expectError: false,
+		},
+		{
+			desc:        "valid failover",
+			inputStr:    "regional-hard-failover",
+			expected:    ParameterRegionalHardFailoverClass,
+			expectError: false,
+		},
+		{
+			desc:        "valid mixed case failover",
+			inputStr:    "Regional-Hard-Failover",
+			expected:    ParameterRegionalHardFailoverClass,
+			expectError: false,
+		},
+		{
+			desc:        "invalid",
+			inputStr:    "yes",
+			expected:    "",
+			expectError: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := ConvertStringToAvailabilityClass(tc.inputStr)
+			if err != nil && !tc.expectError {
+				t.Errorf("Got error %v converting string to availablity class %s; expect no error", err, tc.inputStr)
+			}
+			if err == nil && tc.expectError {
+				t.Errorf("Got no error converting string to availablity class %s; expect an error", tc.inputStr)
+			}
+			if err == nil && got != tc.expected {
+				t.Errorf("Got %v for converting string to availablity class; expect %v", got, tc.expected)
+			}
+		})
+	}
+}
+
 func TestParseMachineType(t *testing.T) {
 	tests := []struct {
 		desc                string

--- a/test/e2e/tests/multi_zone_e2e_test.go
+++ b/test/e2e/tests/multi_zone_e2e_test.go
@@ -31,6 +31,14 @@ import (
 	remote "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/test/remote"
 )
 
+type verifyArgs struct {
+	publishDir, stageDir string
+}
+
+type verifyFunc func(*verifyArgs) error
+
+type detacherFunc func()
+
 var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 	BeforeEach(func() {
 		Expect(len(testContexts)).To(BeNumerically(">", 1))
@@ -77,7 +85,7 @@ var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 			}
 		}
 
-		Expect(len(zoneToContext)).To(Equal(2), "Must have instances in exactly 2 zones")
+		Expect(len(zoneToContext)).To(Equal(2), "Must have instances in 2 zones")
 
 		controllerContext := zoneToContext[zones[0]]
 		controllerClient := controllerContext.Client
@@ -90,7 +98,7 @@ var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 
 		// Create Disk
 		volName := testNamePrefix + string(uuid.NewUUID())
-		volID, err := controllerClient.CreateVolume(volName, map[string]string{
+		volume, err := controllerClient.CreateVolume(volName, map[string]string{
 			common.ParameterKeyReplicationType: "regional-pd",
 		}, defaultRepdSizeGb, &csi.TopologyRequirement{
 			Requisite: []*csi.Topology{
@@ -121,7 +129,7 @@ var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 
 		defer func() {
 			// Delete Disk
-			controllerClient.DeleteVolume(volID)
+			controllerClient.DeleteVolume(volume.VolumeId)
 			Expect(err).To(BeNil(), "DeleteVolume failed")
 
 			// Validate Disk Deleted
@@ -136,22 +144,121 @@ var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 			if i >= 1 {
 				readOnly = true
 			}
-			err = testAttachWriteReadDetach(volID, volName, testContext.Instance, testContext.Client, readOnly)
+			err = testAttachWriteReadDetach(volume.VolumeId, volName, testContext.Instance, testContext.Client, readOnly)
 			Expect(err).To(BeNil(), "failed volume lifecycle checks")
 			i = i + 1
 		}
 	})
+
+	It("Should create a RePD instance, write to it, force-attach it to another instance, and read the same data", func() {
+		Expect(testContexts).NotTo(BeEmpty())
+
+		zoneToContext := map[string]*remote.TestContext{}
+		zones := []string{}
+
+		for _, tc := range testContexts {
+			_, z, _ := tc.Instance.GetIdentity()
+			// Zone hasn't been seen before
+			if _, ok := zoneToContext[z]; !ok {
+				zoneToContext[z] = tc
+				zones = append(zones, z)
+			}
+			if len(zoneToContext) == 2 {
+				break
+			}
+		}
+
+		Expect(len(zoneToContext)).To(Equal(2), "Must have instances in 2 zones")
+
+		controllerContext := zoneToContext[zones[0]]
+		controllerClient := controllerContext.Client
+		controllerInstance := controllerContext.Instance
+
+		p, _, _ := controllerInstance.GetIdentity()
+
+		region, err := common.GetRegionFromZones(zones)
+		Expect(err).To(BeNil(), "Failed to get region from zones")
+
+		// Create Disk
+		volName := testNamePrefix + string(uuid.NewUUID())
+		volume, err := controllerClient.CreateVolume(volName, map[string]string{
+			common.ParameterKeyReplicationType: "regional-pd",
+			common.ParameterAvailabilityClass:  common.ParameterRegionalHardFailoverClass,
+		}, defaultRepdSizeGb, &csi.TopologyRequirement{
+			Requisite: []*csi.Topology{
+				{
+					Segments: map[string]string{common.TopologyKeyZone: zones[0]},
+				},
+				{
+					Segments: map[string]string{common.TopologyKeyZone: zones[1]},
+				},
+			},
+		}, nil)
+		Expect(err).To(BeNil(), "CreateVolume failed with error: %v", err)
+
+		// Validate Disk Created
+		cloudDisk, err := computeService.RegionDisks.Get(p, region, volName).Do()
+		Expect(err).To(BeNil(), "Could not get disk from cloud directly")
+		Expect(cloudDisk.Type).To(ContainSubstring(standardDiskType))
+		Expect(cloudDisk.Status).To(Equal(readyState))
+		Expect(cloudDisk.SizeGb).To(Equal(defaultRepdSizeGb))
+		Expect(cloudDisk.Name).To(Equal(volName))
+		Expect(len(cloudDisk.ReplicaZones)).To(Equal(2))
+		zonesSet := sets.NewString(zones...)
+		for _, replicaZone := range cloudDisk.ReplicaZones {
+			tokens := strings.Split(replicaZone, "/")
+			actualZone := tokens[len(tokens)-1]
+			Expect(zonesSet.Has(actualZone)).To(BeTrue(), "Expected zone %v to exist in zone set %v", actualZone, zones)
+		}
+		Expect(volume.VolumeContext).To(HaveKeyWithValue("force-attach", "true"))
+
+		detachers := []detacherFunc{}
+
+		defer func() {
+			// Perform any detaches
+			for _, fn := range detachers {
+				fn()
+			}
+
+			// Delete Disk
+			controllerClient.DeleteVolume(volume.VolumeId)
+			Expect(err).To(BeNil(), "DeleteVolume failed")
+
+			// Validate Disk Deleted
+			_, err = computeService.RegionDisks.Get(p, region, volName).Do()
+			Expect(gce.IsGCEError(err, "notFound")).To(BeTrue(), "Expected disk to not be found")
+		}()
+
+		// Attach disk to instance in the first zone.
+		tc0 := zoneToContext[zones[0]]
+		err, detacher, args := testAttachAndMount(volume.VolumeId, volName, tc0.Instance, tc0.Client, false /* useBlock */, false /* forceAttach */)
+		detachers = append(detachers, detacher)
+		Expect(err).To(BeNil(), "failed attach in zone 0")
+		testFileName := filepath.Join(args.publishDir, "force-attach-test")
+		testFileContents := "force attach test"
+		err = testutils.WriteFile(tc0.Instance, testFileName, testFileContents)
+		Expect(err).To(BeNil(), "failed write in zone 0")
+		_, err = tc0.Instance.SSH("sync") // Sync so force detach doesn't lose data.
+		Expect(err).To(BeNil(), "failed sync")
+
+		readContents, err := testutils.ReadFile(tc0.Instance, testFileName)
+		Expect(err).To(BeNil(), "failed read in zone 0")
+		Expect(strings.TrimSpace(string(readContents))).To(BeIdenticalTo(testFileContents), "content mismatch in zone 0")
+
+		// Now force attach to the second instance without detaching.
+		tc1 := zoneToContext[zones[1]]
+		err, detacher, args = testAttachAndMount(volume.VolumeId, volName, tc1.Instance, tc1.Client, false /* useBlock */, true /* forceAttach */)
+		detachers = append(detachers, detacher)
+		Expect(err).To(BeNil(), "failed force attach in zone 1")
+		readContents, err = testutils.ReadFile(tc1.Instance, testFileName)
+		Expect(err).To(BeNil(), "failed read in zone 1")
+		Expect(strings.TrimSpace(string(readContents))).To(BeIdenticalTo(testFileContents), "content mismatch in zone 1")
+	})
 })
-
-type verifyArgs struct {
-	publishDir string
-}
-
-type verifyFunc func(verifyArgs) error
 
 func testAttachWriteReadDetach(volID string, volName string, instance *remote.InstanceInfo, client *remote.CsiClient, readOnly bool) error {
 	var testFileContents = "test"
-	writeFile := func(a verifyArgs) error {
+	writeFile := func(a *verifyArgs) error {
 		if !readOnly {
 			// Write a file
 			testFile := filepath.Join(a.publishDir, "testfile")
@@ -163,7 +270,7 @@ func testAttachWriteReadDetach(volID string, volName string, instance *remote.In
 		return nil
 	}
 
-	verifyReadFile := func(a verifyArgs) error {
+	verifyReadFile := func(a *verifyArgs) error {
 		// Read File
 		secondTestFile := filepath.Join(a.publishDir, "testfile")
 		readContents, err := testutils.ReadFile(instance, secondTestFile)
@@ -178,23 +285,20 @@ func testAttachWriteReadDetach(volID string, volName string, instance *remote.In
 	return testLifecycleWithVerify(volID, volName, instance, client, readOnly, false /* fs */, writeFile, verifyReadFile)
 }
 
-func testLifecycleWithVerify(volID string, volName string, instance *remote.InstanceInfo, client *remote.CsiClient, readOnly, useBlock bool, firstMountVerify, secondMountVerify verifyFunc) error {
-	var err error
-	klog.Infof("Starting testAttachWriteReadDetach with volume %v node %v with readonly %v\n", volID, instance.GetNodeID(), readOnly)
+func testAttachAndMount(volID string, volName string, instance *remote.InstanceInfo, client *remote.CsiClient, useBlock, forceAttach bool) (error, func(), *verifyArgs) {
 	// Attach Disk
-	err = client.ControllerPublishVolume(volID, instance.GetNodeID())
+	err := client.ControllerPublishVolume(volID, instance.GetNodeID(), forceAttach)
 	if err != nil {
-		return fmt.Errorf("ControllerPublishVolume failed with error for disk %v on node %v: %v", volID, instance.GetNodeID(), err.Error())
+		return fmt.Errorf("ControllerPublishVolume failed with error for disk %v on node %v: %v", volID, instance.GetNodeID(), err.Error()), nil, nil
 	}
 
-	defer func() {
+	detach := func() {
 		// Detach Disk
 		err = client.ControllerUnpublishVolume(volID, instance.GetNodeID())
 		if err != nil {
 			klog.Errorf("Failed to detach disk: %w", err)
 		}
-
-	}()
+	}
 
 	// Stage Disk
 	stageDir := filepath.Join("/tmp/", volName, "stage")
@@ -204,12 +308,12 @@ func testLifecycleWithVerify(volID string, volName string, instance *remote.Inst
 		err = client.NodeStageExt4Volume(volID, stageDir)
 	}
 
-	//err = client.NodeStageExt4Volume(volID, stageDir)
 	if err != nil {
-		return fmt.Errorf("NodeStageExt4Volume failed with error: %w", err)
+		detach()
+		return fmt.Errorf("NodeStageExt4Volume failed with error: %w", err), nil, nil
 	}
 
-	defer func() {
+	unstageAndDetach := func() {
 		// Unstage Disk
 		err = client.NodeUnstageVolume(volID, stageDir)
 		if err != nil {
@@ -220,7 +324,9 @@ func testLifecycleWithVerify(volID string, volName string, instance *remote.Inst
 		if err != nil {
 			klog.Errorf("Failed to rm file path %s: %w", fp, err)
 		}
-	}()
+
+		detach()
+	}
 
 	// Mount Disk
 	publishDir := filepath.Join("/tmp/", volName, "mount")
@@ -232,24 +338,38 @@ func testLifecycleWithVerify(volID string, volName string, instance *remote.Inst
 	}
 
 	if err != nil {
-		return fmt.Errorf("NodePublishVolume failed with error: %v", err.Error())
+		unstageAndDetach()
+		return fmt.Errorf("NodePublishVolume failed with error: %v", err.Error()), nil, nil
 	}
 	err = testutils.ForceChmod(instance, filepath.Join("/tmp/", volName), "777")
 	if err != nil {
-		return fmt.Errorf("Chmod failed with error: %v", err.Error())
+		unstageAndDetach()
+		return fmt.Errorf("Chmod failed with error: %v", err.Error()), nil, nil
 	}
 
-	a := verifyArgs{
+	args := &verifyArgs{
 		publishDir: publishDir,
+		stageDir:   stageDir,
 	}
 
-	err = firstMountVerify(a)
+	return nil, unstageAndDetach, args
+}
+
+func testLifecycleWithVerify(volID string, volName string, instance *remote.InstanceInfo, client *remote.CsiClient, readOnly, useBlock bool, firstMountVerify, secondMountVerify verifyFunc) error {
+	klog.Infof("Starting testAttachWriteReadDetach with volume %v node %v with readonly %v\n", volID, instance.GetNodeID(), readOnly)
+	err, detacher, args := testAttachAndMount(volID, volName, instance, client, useBlock, false /* forceAttach */)
 	if err != nil {
-		return fmt.Errorf("failed to verify after first mount to %s: %v", publishDir, err)
+		return fmt.Errorf("failed to attach and mount: %w", err)
+	}
+	defer detacher()
+
+	err = firstMountVerify(args)
+	if err != nil {
+		return fmt.Errorf("failed to verify after first mount to %s: %w", args.publishDir, err)
 	}
 
 	// Unmount Disk
-	err = client.NodeUnpublishVolume(volID, publishDir)
+	err = client.NodeUnpublishVolume(volID, args.publishDir)
 	if err != nil {
 		return fmt.Errorf("NodeUnpublishVolume failed with error: %v", err.Error())
 	}
@@ -258,9 +378,9 @@ func testLifecycleWithVerify(volID string, volName string, instance *remote.Inst
 		// Mount disk somewhere else
 		secondPublishDir := filepath.Join("/tmp/", volName, "secondmount")
 		if useBlock {
-			err = client.NodePublishBlockVolume(volID, stageDir, secondPublishDir)
+			err = client.NodePublishBlockVolume(volID, args.stageDir, secondPublishDir)
 		} else {
-			err = client.NodePublishVolume(volID, stageDir, secondPublishDir)
+			err = client.NodePublishVolume(volID, args.stageDir, secondPublishDir)
 		}
 		if err != nil {
 			return fmt.Errorf("NodePublishVolume failed with error: %v", err.Error())
@@ -273,9 +393,9 @@ func testLifecycleWithVerify(volID string, volName string, instance *remote.Inst
 		b := verifyArgs{
 			publishDir: secondPublishDir,
 		}
-		err = secondMountVerify(b)
+		err = secondMountVerify(&b)
 		if err != nil {
-			return fmt.Errorf("failed to verify after second mount to %s: %v", publishDir, err.Error())
+			return fmt.Errorf("failed to verify after second mount to %s: %v", args.publishDir, err.Error())
 		}
 
 		// Unmount Disk

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -59,7 +59,9 @@ func GCEClientAndDriverSetup(instance *remote.InstanceInfo, computeEndpoint stri
 	}
 
 	workspace := remote.NewWorkspaceDir("gce-pd-e2e-")
-	driverRunCmd := fmt.Sprintf("sh -c '/usr/bin/nohup %s/gce-pd-csi-driver -v=4 --endpoint=%s %s --extra-labels=%s=%s 2> %s/prog.out < /dev/null > /dev/null &'",
+	// Log at V(6) as the compute API calls are emitted at that level and it's
+	// useful to see what's happening when debugging tests.
+	driverRunCmd := fmt.Sprintf("sh -c '/usr/bin/nohup %s/gce-pd-csi-driver -v=6 --endpoint=%s %s --extra-labels=%s=%s 2> %s/prog.out < /dev/null > /dev/null &'",
 		workspace, endpoint, computeFlag, DiskLabelKey, DiskLabelValue, workspace)
 
 	config := &remote.ClientConfig{

--- a/test/run-e2e-local.sh
+++ b/test/run-e2e-local.sh
@@ -2,7 +2,13 @@
 
 set -o nounset
 set -o errexit
+set -x
+
+echo Using GOPATH $GOPATH
 
 readonly PKGDIR=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 
-ginkgo --v "test/e2e/tests" -- --project "${PROJECT}" --service-account "${IAM_NAME}" --v=4 --logtostderr
+# This requires application default credentials to be set up, eg by
+# `gcloud auth application-default login`
+
+ginkgo --v "test/e2e/tests" -- --project "${PROJECT}" --service-account "${IAM_NAME}" --v=6 --logtostderr


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This adds an alpha-level storage class parameter to always perform a force attach. This is only valid for RePD disks (although this is not validated --- using this parameter with zonal disks will cause attaches to fail).

This parameter is not guaranteed to have continued support or to be stable in any way. In addition, using this can cause data loss.

```release-note
Add alpha-level force attach storage class parameter.
```
