### PR TITLE
Classify QUOTA_EXCEEDED errors as ResourceExhausted rather than Internal errors

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -72,7 +72,7 @@ const (
 	machineTypePattern = "zones/[^/]+/machineTypes/([^/]+)$"
 
 	// User-caused quota exceeded messages
-	stockoutError1 = "QUOTA_EXCEEDED"
+	stockoutError = "QUOTA_EXCEEDED"
 )
 
 var (
@@ -374,7 +374,7 @@ func isStockoutError(err error) *codes.Code {
 		return nil
 	}
 
-	if strings.Contains(err.Error(), stockoutError1){
+	if strings.Contains(err.Error(), stockoutError) {
 		return errCodePtr(codes.ResourceExhausted)
 	}
 	return nil

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -71,8 +71,8 @@ const (
 	//   zones/zone/machineTypes/machine-type
 	machineTypePattern = "zones/[^/]+/machineTypes/([^/]+)$"
 
-	// Will catch ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS also
-	stockoutError = "ZONE_RESOURCE_POOL_EXHAUSTED"
+	// User-caused quota exceeded messages
+	stockoutError1 = "QUOTA_EXCEEDED"
 )
 
 var (
@@ -374,8 +374,8 @@ func isStockoutError(err error) *codes.Code {
 		return nil
 	}
 
-	if strings.Contains(err.Error(), stockoutError) {
-		return errCodePtr(codes.DeadlineExceeded)
+	if strings.Contains(err.Error(), stockoutError1){
+		return errCodePtr(codes.ResourceExhausted)
 	}
 	return nil
 }

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -1002,6 +1002,11 @@ func TestCodeForError(t *testing.T) {
 			expCode:  errCodePtr(codes.DeadlineExceeded),
 		},
 		{
+			name:     "stockout error",
+			inputErr: fmt.Errorf("(ZONE_RESOURCE_POOL_EXHAUSTED): The zone 'us-central1-c' does not have enough resources available to fulfill the request. Try a different zone, or try again later."),
+			expCode:  errCodePtr(codes.ResourceExhausted),
+		},
+		{
 			name:     "status error with Aborted error code",
 			inputErr: status.Error(codes.Aborted, "aborted error"),
 			expCode:  errCodePtr(codes.Aborted),

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -1002,8 +1002,8 @@ func TestCodeForError(t *testing.T) {
 			expCode:  errCodePtr(codes.DeadlineExceeded),
 		},
 		{
-			name:     "stockout error",
-			inputErr: fmt.Errorf("(ZONE_RESOURCE_POOL_EXHAUSTED): The zone 'us-central1-c' does not have enough resources available to fulfill the request. Try a different zone, or try again later."),
+			name:     "user-caused stockout error",
+			inputErr: fmt.Errorf("csi.v1.Controller/CreateVolume returned with error: rpc error: code = Internal desc = CreateVolume failed to create single zonal disk test-pvc: failed to insert zonal disk: unknown Insert disk operation error: operation CreateDisk failed (QUOTA_EXCEEDED): Quota 'SSD_TOTAL_GB' exceeded. Limit: 100.00 in region us-central1."),
 			expCode:  errCodePtr(codes.ResourceExhausted),
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Classifies user-caused stockouts (QUOTA_EXCEEDED) as ResourceExhausted rather than Internal errors. This helps exclude user-caused issues from our SLOs and monitoring.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Classifies QUOTA_EXCEEDED errors as ResourceExhausted rather than Internal errors.
```
