### PR TITLE
Fix provisioned-iops-on-create passing logic

### DIFF
--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -598,6 +598,12 @@ func TestConvertStringToInt64(t *testing.T) {
 			expectError: false,
 		},
 		{
+			desc:        "test higher number",
+			inputStr:    "15000",
+			expInt64:    15000,
+			expectError: false,
+		},
+		{
 			desc:        "round M to number",
 			inputStr:    "1M",
 			expInt64:    1000000,

--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -419,6 +419,9 @@ func convertV1DiskToBetaDisk(v1Disk *computev1.Disk, provisionedThroughputOnCrea
 		ReplicaZones:      v1Disk.ReplicaZones,
 		DiskEncryptionKey: dek,
 	}
+	if v1Disk.ProvisionedIops > 0 {
+		betaDisk.ProvisionedIops = v1Disk.ProvisionedIops
+	}
 	if provisionedThroughputOnCreate > 0 {
 		betaDisk.ProvisionedThroughput = provisionedThroughputOnCreate
 	}
@@ -449,12 +452,11 @@ func (cloud *CloudProvider) insertRegionalDisk(
 	}
 
 	diskToCreate := &computev1.Disk{
-		Name:            volKey.Name,
-		SizeGb:          common.BytesToGbRoundUp(capBytes),
-		Description:     description,
-		Type:            cloud.GetDiskTypeURI(cloud.project, volKey, params.DiskType),
-		Labels:          params.Labels,
-		ProvisionedIops: params.ProvisionedIOPSOnCreate,
+		Name:        volKey.Name,
+		SizeGb:      common.BytesToGbRoundUp(capBytes),
+		Description: description,
+		Type:        cloud.GetDiskTypeURI(cloud.project, volKey, params.DiskType),
+		Labels:      params.Labels,
 	}
 	if snapshotID != "" {
 		_, snapshotType, _, err := common.SnapshotIDToProjectKey(snapshotID)
@@ -562,11 +564,12 @@ func (cloud *CloudProvider) insertZonalDisk(
 	}
 
 	diskToCreate := &computev1.Disk{
-		Name:        volKey.Name,
-		SizeGb:      common.BytesToGbRoundUp(capBytes),
-		Description: description,
-		Type:        cloud.GetDiskTypeURI(project, volKey, params.DiskType),
-		Labels:      params.Labels,
+		Name:            volKey.Name,
+		SizeGb:          common.BytesToGbRoundUp(capBytes),
+		Description:     description,
+		Type:            cloud.GetDiskTypeURI(project, volKey, params.DiskType),
+		Labels:          params.Labels,
+		ProvisionedIops: params.ProvisionedIOPSOnCreate,
 	}
 
 	if snapshotID != "" {

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -45,14 +45,15 @@ const (
 	testNamePrefix = "gcepd-csi-e2e-"
 
 	defaultSizeGb              int64 = 5
+	defaultExtremeSizeGb       int64 = 500
 	defaultRepdSizeGb          int64 = 200
 	defaultMwSizeGb            int64 = 200
 	defaultVolumeLimit         int64 = 127
 	readyState                       = "READY"
 	standardDiskType                 = "pd-standard"
 	extremeDiskType                  = "pd-extreme"
-	provisionedIOPSOnCreate          = "100000"
-	provisionedIOPSOnCreateInt       = int64(100000)
+	provisionedIOPSOnCreate          = "12345"
+	provisionedIOPSOnCreateInt       = int64(12345)
 
 	defaultEpsilon = 500000000 // 500M
 )
@@ -386,14 +387,21 @@ var _ = Describe("GCE PD CSI Driver", func() {
 			// Create Disk
 			disk := typeToDisk[diskType]
 			volName := testNamePrefix + string(uuid.NewUUID())
-			volume, err := client.CreateVolume(volName, disk.params, defaultSizeGb, nil, nil)
+
+			diskSize := defaultSizeGb
+			if diskType == extremeDiskType {
+				diskSize = defaultExtremeSizeGb
+			}
+
+			volume, err := client.CreateVolume(volName, disk.params, diskSize, nil, nil)
+
 			Expect(err).To(BeNil(), "CreateVolume failed with error: %v", err)
 
 			// Validate Disk Created
 			cloudDisk, err := computeService.Disks.Get(p, z, volName).Do()
 			Expect(err).To(BeNil(), "Could not get disk from cloud directly")
 			Expect(cloudDisk.Status).To(Equal(readyState))
-			Expect(cloudDisk.SizeGb).To(Equal(defaultSizeGb))
+			Expect(cloudDisk.SizeGb).To(Equal(diskSize))
 			Expect(cloudDisk.Name).To(Equal(volName))
 			disk.validate(cloudDisk)
 
@@ -425,14 +433,19 @@ var _ = Describe("GCE PD CSI Driver", func() {
 			params := merge(disk.params, map[string]string{
 				common.ParameterKeyLabels: "key1=value1,key2=value2",
 			})
-			volume, err := client.CreateVolume(volName, params, defaultSizeGb, nil, nil)
+
+			diskSize := defaultSizeGb
+			if diskType == extremeDiskType {
+				diskSize = defaultExtremeSizeGb
+			}
+			volume, err := client.CreateVolume(volName, params, diskSize, nil, nil)
 			Expect(err).To(BeNil(), "CreateVolume failed with error: %v", err)
 
 			// Validate Disk Created
 			cloudDisk, err := computeService.Disks.Get(p, z, volName).Do()
 			Expect(err).To(BeNil(), "Could not get disk from cloud directly")
 			Expect(cloudDisk.Status).To(Equal(readyState))
-			Expect(cloudDisk.SizeGb).To(Equal(defaultSizeGb))
+			Expect(cloudDisk.SizeGb).To(Equal(diskSize))
 			Expect(cloudDisk.Labels).To(Equal(map[string]string{
 				"key1": "value1",
 				"key2": "value2",
@@ -547,14 +560,19 @@ var _ = Describe("GCE PD CSI Driver", func() {
 					},
 				},
 			}
-			volume, err := controllerClient.CreateVolume(volName, params, defaultSizeGb, topology, nil)
+
+			diskSize := defaultSizeGb
+			if diskType == extremeDiskType {
+				diskSize = defaultExtremeSizeGb
+			}
+			volume, err := controllerClient.CreateVolume(volName, params, diskSize, topology, nil)
 			Expect(err).To(BeNil(), "CreateVolume failed with error: %v", err)
 
 			// Validate Disk Created
 			cloudDisk, err := computeService.Disks.Get(p, z, volName).Do()
 			Expect(err).To(BeNil(), "Could not get disk from cloud directly")
 			Expect(cloudDisk.Status).To(Equal(readyState))
-			Expect(cloudDisk.SizeGb).To(Equal(defaultSizeGb))
+			Expect(cloudDisk.SizeGb).To(Equal(diskSize))
 			Expect(cloudDisk.Name).To(Equal(volName))
 			disk.validate(cloudDisk)
 
@@ -872,6 +890,11 @@ var _ = Describe("GCE PD CSI Driver", func() {
 			controllerInstance := testContext.Instance
 			controllerClient := testContext.Client
 
+			diskSize := defaultSizeGb
+			if diskType == extremeDiskType {
+				diskSize = defaultExtremeSizeGb
+			}
+
 			p, z, _ := controllerInstance.GetIdentity()
 
 			// Create Disk
@@ -882,14 +905,14 @@ var _ = Describe("GCE PD CSI Driver", func() {
 				common.ParameterKeyPVCNamespace: "test-pvc-namespace",
 				common.ParameterKeyPVName:       "test-pv-name",
 			})
-			volume, err := controllerClient.CreateVolume(volName, params, defaultSizeGb, nil /* topReq */, nil)
+			volume, err := controllerClient.CreateVolume(volName, params, diskSize, nil /* topReq */, nil)
 			Expect(err).To(BeNil(), "CreateVolume failed with error: %v", err)
 
 			// Validate Disk Created
 			cloudDisk, err := computeService.Disks.Get(p, z, volName).Do()
 			Expect(err).To(BeNil(), "Could not get disk from cloud directly")
 			Expect(cloudDisk.Status).To(Equal(readyState))
-			Expect(cloudDisk.SizeGb).To(Equal(defaultSizeGb))
+			Expect(cloudDisk.SizeGb).To(Equal(diskSize))
 			Expect(cloudDisk.Name).To(Equal(volName))
 			Expect(cloudDisk.Description).To(Equal("{\"kubernetes.io/created-for/pv/name\":\"test-pv-name\",\"kubernetes.io/created-for/pvc/name\":\"test-pvc\",\"kubernetes.io/created-for/pvc/namespace\":\"test-pvc-namespace\",\"storage.gke.io/created-by\":\"pd.csi.storage.gke.io\"}"))
 			disk.validate(cloudDisk)
@@ -1256,7 +1279,12 @@ func createAndValidateUniqueZonalDisk(client *remote.CsiClient, project, zone st
 	// Create Disk
 	disk := typeToDisk[diskType]
 	volName := testNamePrefix + string(uuid.NewUUID())
-	volume, err := client.CreateVolume(volName, disk.params, defaultSizeGb,
+
+	diskSize := defaultSizeGb
+	if diskType == extremeDiskType {
+		diskSize = defaultExtremeSizeGb
+	}
+	volume, err := client.CreateVolume(volName, disk.params, diskSize,
 		&csi.TopologyRequirement{
 			Requisite: []*csi.Topology{
 				{
@@ -1270,7 +1298,7 @@ func createAndValidateUniqueZonalDisk(client *remote.CsiClient, project, zone st
 	cloudDisk, err := computeService.Disks.Get(project, zone, volName).Do()
 	Expect(err).To(BeNil(), "Could not get disk from cloud directly")
 	Expect(cloudDisk.Status).To(Equal(readyState))
-	Expect(cloudDisk.SizeGb).To(Equal(defaultSizeGb))
+	Expect(cloudDisk.SizeGb).To(Equal(diskSize))
 	Expect(cloudDisk.Name).To(Equal(volName))
 	disk.validate(cloudDisk)
 


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
The logic of passing in provisioned-iops-on-create is not at the right func. The tests picked the default value and the verification is passing.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
```release-note
Fix provisioned-iops-on-create passing logic
```
