### PR TITLE
[release-1.8] Fix provisioned-iops-on-create passing logic

### DIFF
--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -598,6 +598,12 @@ func TestConvertStringToInt64(t *testing.T) {
 			expectError: false,
 		},
 		{
+			desc:        "test higher number",
+			inputStr:    "15000",
+			expInt64:    15000,
+			expectError: false,
+		},
+		{
 			desc:        "round M to number",
 			inputStr:    "1M",
 			expInt64:    1000000,

--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -419,6 +419,9 @@ func convertV1DiskToBetaDisk(v1Disk *computev1.Disk, provisionedThroughputOnCrea
 		ReplicaZones:      v1Disk.ReplicaZones,
 		DiskEncryptionKey: dek,
 	}
+	if v1Disk.ProvisionedIops > 0 {
+		betaDisk.ProvisionedIops = v1Disk.ProvisionedIops
+	}
 	if provisionedThroughputOnCreate > 0 {
 		betaDisk.ProvisionedThroughput = provisionedThroughputOnCreate
 	}
@@ -449,12 +452,11 @@ func (cloud *CloudProvider) insertRegionalDisk(
 	}
 
 	diskToCreate := &computev1.Disk{
-		Name:            volKey.Name,
-		SizeGb:          common.BytesToGbRoundUp(capBytes),
-		Description:     description,
-		Type:            cloud.GetDiskTypeURI(cloud.project, volKey, params.DiskType),
-		Labels:          params.Labels,
-		ProvisionedIops: params.ProvisionedIOPSOnCreate,
+		Name:        volKey.Name,
+		SizeGb:      common.BytesToGbRoundUp(capBytes),
+		Description: description,
+		Type:        cloud.GetDiskTypeURI(cloud.project, volKey, params.DiskType),
+		Labels:      params.Labels,
 	}
 	if snapshotID != "" {
 		_, snapshotType, _, err := common.SnapshotIDToProjectKey(snapshotID)
@@ -562,11 +564,12 @@ func (cloud *CloudProvider) insertZonalDisk(
 	}
 
 	diskToCreate := &computev1.Disk{
-		Name:        volKey.Name,
-		SizeGb:      common.BytesToGbRoundUp(capBytes),
-		Description: description,
-		Type:        cloud.GetDiskTypeURI(project, volKey, params.DiskType),
-		Labels:      params.Labels,
+		Name:            volKey.Name,
+		SizeGb:          common.BytesToGbRoundUp(capBytes),
+		Description:     description,
+		Type:            cloud.GetDiskTypeURI(project, volKey, params.DiskType),
+		Labels:          params.Labels,
+		ProvisionedIops: params.ProvisionedIOPSOnCreate,
 	}
 
 	if snapshotID != "" {

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -1175,7 +1175,12 @@ func createAndValidateUniqueZonalDisk(client *remote.CsiClient, project, zone st
 	Expect(err).To(BeNil(), "Could not get disk from cloud directly")
 	Expect(cloudDisk.Type).To(ContainSubstring(diskType))
 	Expect(cloudDisk.Status).To(Equal(readyState))
-	Expect(cloudDisk.SizeGb).To(Equal(defaultSizeGb))
+	if diskType == "pd-extreme" {
+		Expect(cloudDisk.SizeGb).To(Equal(defaultExtremeSizeGb))
+	} else {
+		Expect(cloudDisk.SizeGb).To(Equal(defaultSizeGb))
+	}
+
 	Expect(cloudDisk.Name).To(Equal(volName))
 	return
 }

--- a/test/e2e/tests/single_zone_pd_extreme_e2e_test.go
+++ b/test/e2e/tests/single_zone_pd_extreme_e2e_test.go
@@ -33,9 +33,10 @@ import (
 )
 
 const (
-	extremeDiskType            = "pd-extreme"
-	provisionedIOPSOnCreate    = "100000Gi"
-	provisionedIOPSOnCreateInt = int64(100000)
+	extremeDiskType                  = "pd-extreme"
+	defaultExtremeSizeGb       int64 = 500
+	provisionedIOPSOnCreate          = "12345"
+	provisionedIOPSOnCreateInt       = int64(12345)
 )
 
 var _ = Describe("GCE PD CSI Driver pd-extreme", func() {
@@ -53,7 +54,7 @@ var _ = Describe("GCE PD CSI Driver pd-extreme", func() {
 			common.ParameterKeyType:                    extremeDiskType,
 			common.ParameterKeyProvisionedIOPSOnCreate: provisionedIOPSOnCreate,
 		}
-		volID, err := client.CreateVolume(volName, params, defaultSizeGb, nil, nil)
+		volID, err := client.CreateVolume(volName, params, defaultExtremeSizeGb, nil, nil)
 		Expect(err).To(BeNil(), "CreateVolume failed with error: %v", err)
 
 		// Validate Disk Created
@@ -62,7 +63,7 @@ var _ = Describe("GCE PD CSI Driver pd-extreme", func() {
 		Expect(cloudDisk.Type).To(ContainSubstring(extremeDiskType))
 		Expect(cloudDisk.ProvisionedIops).To(Equal(provisionedIOPSOnCreateInt))
 		Expect(cloudDisk.Status).To(Equal(readyState))
-		Expect(cloudDisk.SizeGb).To(Equal(defaultSizeGb))
+		Expect(cloudDisk.SizeGb).To(Equal(defaultExtremeSizeGb))
 		Expect(cloudDisk.Name).To(Equal(volName))
 
 		defer func() {
@@ -90,7 +91,7 @@ var _ = Describe("GCE PD CSI Driver pd-extreme", func() {
 			common.ParameterKeyType:                    extremeDiskType,
 			common.ParameterKeyProvisionedIOPSOnCreate: provisionedIOPSOnCreate,
 		}
-		volID, err := client.CreateVolume(volName, params, defaultSizeGb, nil, nil)
+		volID, err := client.CreateVolume(volName, params, defaultExtremeSizeGb, nil, nil)
 		Expect(err).To(BeNil(), "CreateVolume failed with error: %v", err)
 
 		// Validate Disk Created
@@ -99,7 +100,7 @@ var _ = Describe("GCE PD CSI Driver pd-extreme", func() {
 		Expect(cloudDisk.Type).To(ContainSubstring(extremeDiskType))
 		Expect(cloudDisk.ProvisionedIops).To(Equal(provisionedIOPSOnCreateInt))
 		Expect(cloudDisk.Status).To(Equal(readyState))
-		Expect(cloudDisk.SizeGb).To(Equal(defaultSizeGb))
+		Expect(cloudDisk.SizeGb).To(Equal(defaultExtremeSizeGb))
 		Expect(cloudDisk.Labels).To(Equal(map[string]string{
 			"key1": "value1",
 			"key2": "value2",
@@ -157,7 +158,7 @@ var _ = Describe("GCE PD CSI Driver pd-extreme", func() {
 			common.ParameterKeyDiskEncryptionKmsKey:    key.Name,
 			common.ParameterKeyType:                    extremeDiskType,
 			common.ParameterKeyProvisionedIOPSOnCreate: provisionedIOPSOnCreate,
-		}, defaultSizeGb,
+		}, defaultExtremeSizeGb,
 			&csi.TopologyRequirement{
 				Requisite: []*csi.Topology{
 					{
@@ -173,7 +174,7 @@ var _ = Describe("GCE PD CSI Driver pd-extreme", func() {
 		Expect(cloudDisk.Type).To(ContainSubstring(extremeDiskType))
 		Expect(cloudDisk.ProvisionedIops).To(Equal(provisionedIOPSOnCreateInt))
 		Expect(cloudDisk.Status).To(Equal(readyState))
-		Expect(cloudDisk.SizeGb).To(Equal(defaultSizeGb))
+		Expect(cloudDisk.SizeGb).To(Equal(defaultExtremeSizeGb))
 		Expect(cloudDisk.Name).To(Equal(volName))
 
 		defer func() {
@@ -250,7 +251,7 @@ var _ = Describe("GCE PD CSI Driver pd-extreme", func() {
 			common.ParameterKeyPVName:                  "test-pv-name",
 			common.ParameterKeyType:                    extremeDiskType,
 			common.ParameterKeyProvisionedIOPSOnCreate: provisionedIOPSOnCreate,
-		}, defaultSizeGb, nil /* topReq */, nil)
+		}, defaultExtremeSizeGb, nil /* topReq */, nil)
 		Expect(err).To(BeNil(), "CreateVolume failed with error: %v", err)
 
 		// Validate Disk Created
@@ -259,7 +260,7 @@ var _ = Describe("GCE PD CSI Driver pd-extreme", func() {
 		Expect(cloudDisk.Type).To(ContainSubstring(extremeDiskType))
 		Expect(cloudDisk.ProvisionedIops).To(Equal(provisionedIOPSOnCreateInt))
 		Expect(cloudDisk.Status).To(Equal(readyState))
-		Expect(cloudDisk.SizeGb).To(Equal(defaultSizeGb))
+		Expect(cloudDisk.SizeGb).To(Equal(defaultExtremeSizeGb))
 		Expect(cloudDisk.Name).To(Equal(volName))
 		Expect(cloudDisk.Description).To(Equal("{\"kubernetes.io/created-for/pv/name\":\"test-pv-name\",\"kubernetes.io/created-for/pvc/name\":\"test-pvc\",\"kubernetes.io/created-for/pvc/namespace\":\"test-pvc-namespace\",\"storage.gke.io/created-by\":\"pd.csi.storage.gke.io\"}"))
 		defer func() {


### PR DESCRIPTION
This is a cherry-pick of #1278

```release-note
Fix provisioned-iops-on-create passing logic
```