### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/pkg/gce-pd-csi-driver/node_test.go
+++ b/pkg/gce-pd-csi-driver/node_test.go
@@ -18,7 +18,6 @@ package gceGCEDriver
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -82,7 +81,7 @@ func TestNodeGetVolumeStats(t *testing.T) {
 	gceDriver := getTestGCEDriver(t)
 	ns := gceDriver.ns
 
-	tempDir, err := ioutil.TempDir("", "ngvs")
+	tempDir, err := os.MkdirTemp("", "ngvs")
 	if err != nil {
 		t.Fatalf("Failed to set up temp dir: %v", err)
 	}
@@ -213,7 +212,7 @@ func TestNodePublishVolume(t *testing.T) {
 	gceDriver := getTestGCEDriver(t)
 	ns := gceDriver.ns
 
-	tempDir, err := ioutil.TempDir("", "npv")
+	tempDir, err := os.MkdirTemp("", "npv")
 	if err != nil {
 		t.Fatalf("Failed to set up temp dir: %v", err)
 	}
@@ -312,7 +311,7 @@ func TestNodeUnpublishVolume(t *testing.T) {
 	gceDriver := getTestGCEDriver(t)
 	ns := gceDriver.ns
 
-	tempDir, err := ioutil.TempDir("", "nupv")
+	tempDir, err := os.MkdirTemp("", "nupv")
 	if err != nil {
 		t.Fatalf("Failed to set up temp dir: %v", err)
 	}
@@ -374,7 +373,7 @@ func TestNodeStageVolume(t *testing.T) {
 		AccessType: blockCap,
 	}
 
-	tempDir, err := ioutil.TempDir("", "nsv")
+	tempDir, err := os.MkdirTemp("", "nsv")
 	if err != nil {
 		t.Fatalf("Failed to set up temp dir: %v", err)
 	}
@@ -785,7 +784,7 @@ func makeFakeCmd(fakeCmd *testingexec.FakeCmd, cmd string, args ...string) testi
 func TestNodeUnstageVolume(t *testing.T) {
 	gceDriver := getTestGCEDriver(t)
 	ns := gceDriver.ns
-	tempDir, err := ioutil.TempDir("", "nusv")
+	tempDir, err := os.MkdirTemp("", "nusv")
 	if err != nil {
 		t.Fatalf("Failed to set up temp dir: %v", err)
 	}
@@ -853,7 +852,7 @@ func TestConcurrentNodeOperations(t *testing.T) {
 	readyToExecute := make(chan chan struct{}, 1)
 	gceDriver := getTestBlockingGCEDriver(t, readyToExecute)
 	ns := gceDriver.ns
-	tempDir, err := ioutil.TempDir("", "cno")
+	tempDir, err := os.MkdirTemp("", "cno")
 	if err != nil {
 		t.Fatalf("Failed to set up temp dir: %v", err)
 	}

--- a/release-tools/filter-junit.go
+++ b/release-tools/filter-junit.go
@@ -24,7 +24,6 @@ package main
 import (
 	"encoding/xml"
 	"flag"
-	"io/ioutil"
 	"os"
 	"regexp"
 )
@@ -95,7 +94,7 @@ func main() {
 			}
 		} else {
 			var err error
-			data, err = ioutil.ReadFile(input)
+			data, err = os.ReadFile(input)
 			if err != nil {
 				panic(err)
 			}
@@ -142,7 +141,7 @@ func main() {
 			panic(err)
 		}
 	} else {
-		if err := ioutil.WriteFile(*output, data, 0644); err != nil {
+		if err := os.WriteFile(*output, data, 0644); err != nil {
 			panic(err)
 		}
 	}

--- a/test/k8s-integration/filter-junit.go
+++ b/test/k8s-integration/filter-junit.go
@@ -19,7 +19,6 @@ package main
 import (
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -76,7 +75,7 @@ func MergeJUnit(testFilter string, sourceDirectories []string, destination strin
 	var mergeErrors []string
 	var filesToDelete []string
 	for _, dir := range sourceDirectories {
-		files, err := ioutil.ReadDir(dir)
+		files, err := os.ReadDir(dir)
 		if err != nil {
 			klog.Errorf("Failed to read juint directory %s: %w", dir, err)
 			mergeErrors = append(mergeErrors, err.Error())
@@ -88,7 +87,7 @@ func MergeJUnit(testFilter string, sourceDirectories []string, destination strin
 			}
 			fullFilename := filepath.Join(dir, file.Name())
 			filesToDelete = append(filesToDelete, fullFilename)
-			data, err := ioutil.ReadFile(fullFilename)
+			data, err := os.ReadFile(fullFilename)
 			if err != nil {
 				return err
 			}
@@ -121,7 +120,7 @@ func MergeJUnit(testFilter string, sourceDirectories []string, destination strin
 		return err
 	}
 
-	if err = ioutil.WriteFile(destination, data, 0644); err != nil {
+	if err = os.WriteFile(destination, data, 0644); err != nil {
 		return err
 	}
 

--- a/test/k8s-integration/utils.go
+++ b/test/k8s-integration/utils.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -30,7 +29,7 @@ func runCommand(action string, cmd *exec.Cmd) error {
 }
 
 func generateUniqueTmpDir() string {
-	dir, err := ioutil.TempDir("", "gcp-pd-driver-tmp")
+	dir, err := os.MkdirTemp("", "gcp-pd-driver-tmp")
 	if err != nil {
 		klog.Fatalf("Error creating temp dir: %w", err)
 	}

--- a/test/remote/archiver.go
+++ b/test/remote/archiver.go
@@ -18,7 +18,6 @@ package remote
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -28,7 +27,7 @@ import (
 
 func CreateDriverArchive(archiveName, architecture, pkgPath, binPath string) (string, error) {
 	klog.V(2).Infof("Building archive...")
-	tarDir, err := ioutil.TempDir("", "driver-temp-archive")
+	tarDir, err := os.MkdirTemp("", "driver-temp-archive")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temporary directory %v", err.Error())
 	}

--- a/test/remote/instance.go
+++ b/test/remote/instance.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -388,7 +387,7 @@ func GetComputeBetaClient() (*computebeta.Service, error) {
 }
 
 func generateMetadataWithPublicKey(pubKeyFile string) (*compute.Metadata, error) {
-	publicKeyByte, err := ioutil.ReadFile(pubKeyFile)
+	publicKeyByte, err := os.ReadFile(pubKeyFile)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
