### PR TITLE
chore: unnecessary use of fmt.Sprintf

### DIFF
--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -167,7 +167,7 @@ func (ns *GCENodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePub
 			return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to create block file at target path %v: %v", targetPath, err.Error()))
 		}
 	} else {
-		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("NodePublishVolume volume capability must specify either mount or block mode"))
+		return nil, status.Error(codes.InvalidArgument, "NodePublishVolume volume capability must specify either mount or block mode")
 	}
 
 	err = ns.Mounter.Interface.Mount(sourcePath, targetPath, fstype, options)

--- a/pkg/gce-pd-csi-driver/node_test.go
+++ b/pkg/gce-pd-csi-driver/node_test.go
@@ -490,7 +490,7 @@ func TestNodeStageVolume(t *testing.T) {
 				&testingexec.FakeCmd{
 					CombinedOutputScript: []testingexec.FakeAction{
 						func() ([]byte, []byte, error) {
-							return []byte(fmt.Sprintf("DEVNAME=/dev/sdb\nTYPE=ext4")), nil, nil
+							return []byte("DEVNAME=/dev/sdb\nTYPE=ext4"), nil, nil
 						},
 					},
 				},
@@ -534,7 +534,7 @@ func TestNodeStageVolume(t *testing.T) {
 				&testingexec.FakeCmd{
 					CombinedOutputScript: []testingexec.FakeAction{
 						func() ([]byte, []byte, error) {
-							return []byte(fmt.Sprintf("DEVNAME=/dev/sdb\nTYPE=ext4")), nil, nil
+							return []byte("DEVNAME=/dev/sdb\nTYPE=ext4"), nil, nil
 						},
 					},
 				},
@@ -560,7 +560,7 @@ func TestNodeStageVolume(t *testing.T) {
 					&testingexec.FakeCmd{
 						CombinedOutputScript: []testingexec.FakeAction{
 							func() ([]byte, []byte, error) {
-								return []byte(fmt.Sprintf("DEVNAME=/dev/sdb\nTYPE=ext4")), nil, nil
+								return []byte("DEVNAME=/dev/sdb\nTYPE=ext4"), nil, nil
 							},
 						},
 					},
@@ -572,7 +572,7 @@ func TestNodeStageVolume(t *testing.T) {
 						CombinedOutputScript: []testingexec.FakeAction{
 							func() ([]byte, []byte, error) {
 								resizeCalled = true
-								return []byte(fmt.Sprintf("DEVNAME=/dev/sdb\nTYPE=ext4")), nil, nil
+								return []byte("DEVNAME=/dev/sdb\nTYPE=ext4"), nil, nil
 							},
 						},
 					},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind cleanup


**What this PR does / why we need it**:
unnecessary use of fmt.Sprintf
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
