### PR TITLE
Added support for confidential storage to disk parametrs and metric

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -397,3 +397,9 @@ func LoggedError(msg string, err error) error {
 	klog.Errorf(msg+"%v", err.Error())
 	return status.Errorf(*CodeForError(err), msg+"%v", err.Error())
 }
+
+func isValidDiskEncryptionKmsKey(DiskEncryptionKmsKey string) bool {
+	// Validate key against default kmskey pattern
+	kmsKeyPattern := regexp.MustCompile("projects/[^/]+/locations/([^/]+)/keyRings/[^/]+/cryptoKeys/[^/]+")
+	return kmsKeyPattern.MatchString(DiskEncryptionKmsKey)
+}

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -1079,3 +1079,29 @@ func TestIsContextError(t *testing.T) {
 		}
 	}
 }
+
+func TestIsValidDiskEncryptionKmsKey(t *testing.T) {
+	cases := []struct {
+		diskEncryptionKmsKey string
+		expectedIsValid      bool
+	}{
+		{
+			diskEncryptionKmsKey: "projects/my-project/locations/us-central1/keyRings/TestKeyRing/cryptoKeys/test-key",
+			expectedIsValid:      true,
+		},
+		{
+			diskEncryptionKmsKey: "projects/my-project/locations/global/keyRings/TestKeyRing/cryptoKeys/test-key",
+			expectedIsValid:      true,
+		},
+		{
+			diskEncryptionKmsKey: "projects/my-project/locations/keyRings/TestKeyRing/cryptoKeys/test-key",
+			expectedIsValid:      false,
+		},
+	}
+	for _, tc := range cases {
+		isValid := isValidDiskEncryptionKmsKey(tc.diskEncryptionKmsKey)
+		if tc.expectedIsValid != isValid {
+			t.Errorf("test failed: the provided key %s expected to be %v bu tgot %v", tc.diskEncryptionKmsKey, tc.expectedIsValid, isValid)
+		}
+	}
+}

--- a/pkg/gce-cloud-provider/compute/cloud-disk.go
+++ b/pkg/gce-cloud-provider/compute/cloud-disk.go
@@ -223,3 +223,14 @@ func (d *CloudDisk) GetMultiWriter() bool {
 		return false
 	}
 }
+
+func (d *CloudDisk) GetEnableConfidentialCompute() bool {
+	switch {
+	case d.disk != nil:
+		return false
+	case d.betaDisk != nil:
+		return d.betaDisk.EnableConfidentialCompute
+	default:
+		return false
+	}
+}

--- a/pkg/gce-cloud-provider/compute/cloud-disk_test.go
+++ b/pkg/gce-cloud-provider/compute/cloud-disk_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcecloudprovider
+
+import (
+	"testing"
+
+	computebeta "google.golang.org/api/compute/v0.beta"
+	computev1 "google.golang.org/api/compute/v1"
+)
+
+func CreateDiskWithConfidentialCompute(betaDisk bool, confidentialCompute bool, diskType string) *CloudDisk {
+	if betaDisk {
+		return &CloudDisk{
+			betaDisk: &computebeta.Disk{
+				EnableConfidentialCompute: confidentialCompute,
+				Type:                      diskType,
+			},
+		}
+	}
+	return &CloudDisk{
+		disk: &computev1.Disk{},
+	}
+}
+
+func TestGetEnableConfidentialCompute(t *testing.T) {
+	testCases := []struct {
+		name                              string
+		diskVersion                       *CloudDisk
+		expectedEnableConfidentialCompute bool
+	}{
+		{
+			name:                              "test betaDisk with enableConfidentialCompute=false",
+			diskVersion:                       CreateDiskWithConfidentialCompute(true, false, "hyperdisk-balanced"),
+			expectedEnableConfidentialCompute: false,
+		},
+		{
+			name:                              "test betaDisk with enableConfidentialCompute=true",
+			diskVersion:                       CreateDiskWithConfidentialCompute(true, true, "hyperdisk-balanced"),
+			expectedEnableConfidentialCompute: true,
+		},
+		{
+			name:                              "test disk withpit enableConfidentialCompute",
+			diskVersion:                       CreateDiskWithConfidentialCompute(false, false, "hyperdisk-balanced"),
+			expectedEnableConfidentialCompute: false,
+		},
+		{
+			name:                              "test disk withpit enableConfidentialCompute",
+			diskVersion:                       CreateDiskWithConfidentialCompute(false, false, "pd-standard"),
+			expectedEnableConfidentialCompute: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Logf("Running test: %v", tc.name)
+		confidentialCompute := tc.diskVersion.GetEnableConfidentialCompute()
+		if confidentialCompute != tc.expectedEnableConfidentialCompute {
+			t.Fatalf("Got confidentialCompute value %t expected %t", confidentialCompute, tc.expectedEnableConfidentialCompute)
+		}
+		if confidentialCompute != tc.expectedEnableConfidentialCompute {
+			t.Fatalf("Got confidentialCompute value %t expected %t", confidentialCompute, tc.expectedEnableConfidentialCompute)
+		}
+	}
+}

--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -237,7 +237,13 @@ func (cloud *FakeCloudProvider) InsertDisk(ctx context.Context, project string, 
 		return fmt.Errorf("could not create disk, key was neither zonal nor regional, instead got: %v", volKey.String())
 	}
 
-	cloud.disks[volKey.Name] = CloudDiskFromV1(computeDisk)
+	if containsBetaDiskType(hyperdiskTypes, params.DiskType) {
+		betaDisk := convertV1DiskToBetaDisk(computeDisk, params.ProvisionedThroughputOnCreate)
+		betaDisk.EnableConfidentialCompute = params.EnableConfidentialCompute
+		cloud.disks[volKey.Name] = CloudDiskFromBeta(betaDisk)
+	} else {
+		cloud.disks[volKey.Name] = CloudDiskFromV1(computeDisk)
+	}
 	return nil
 }
 

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -21,6 +21,7 @@ import (
 	"math/rand"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -128,7 +129,6 @@ const (
 
 	replicationTypeNone       = "none"
 	replicationTypeRegionalPD = "regional-pd"
-	diskNotFound              = ""
 	// The maximum number of entries that we can include in the
 	// ListVolumesResposne
 	// In reality, the limit here is 4MB (based on gRPC client response limits),
@@ -203,9 +203,10 @@ func useVolumeCloning(req *csi.CreateVolumeRequest) bool {
 
 func (gceCS *GCEControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	var err error
-	diskTypeForMetric := ""
+	diskTypeForMetric := metrics.DefaultDiskTypeForMetric
+	enableConfidentialCompute := metrics.DefaultEnableConfidentialCompute
 	defer func() {
-		gceCS.Metrics.RecordOperationErrorMetrics("CreateVolume", err, diskTypeForMetric)
+		gceCS.Metrics.RecordOperationErrorMetrics("CreateVolume", err, diskTypeForMetric, enableConfidentialCompute)
 	}()
 	// Validate arguments
 	volumeCapabilities := req.GetVolumeCapabilities()
@@ -232,6 +233,7 @@ func (gceCS *GCEControllerServer) CreateVolume(ctx context.Context, req *csi.Cre
 	// the values to the cloud provider.
 	params, err := common.ExtractAndDefaultParameters(req.GetParameters(), gceCS.Driver.name, gceCS.Driver.extraVolumeLabels)
 	diskTypeForMetric = params.DiskType
+	enableConfidentialCompute = strconv.FormatBool(params.EnableConfidentialCompute)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to extract parameters: %v", err.Error())
 	}
@@ -355,7 +357,6 @@ func (gceCS *GCEControllerServer) CreateVolume(ctx context.Context, req *csi.Cre
 					return nil, common.LoggedError("CreateVolume, getDisk error when validating: ", err)
 				}
 			}
-
 			// Verify the disk type and encryption key of the clone are the same as that of the source disk.
 			if diskFromSourceVolume.GetPDType() != params.DiskType || !gce.KmsKeyEqual(diskFromSourceVolume.GetKMSKeyName(), params.DiskEncryptionKMSKey) {
 				return nil, status.Errorf(codes.InvalidArgument, "CreateVolume Parameters %v do not match source volume Parameters", params)
@@ -440,9 +441,10 @@ func (gceCS *GCEControllerServer) CreateVolume(ctx context.Context, req *csi.Cre
 
 func (gceCS *GCEControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
 	var err error
-	diskTypeForMetric := ""
+	diskTypeForMetric := metrics.DefaultDiskTypeForMetric
+	enableConfidentialCompute := metrics.DefaultEnableConfidentialCompute
 	defer func() {
-		gceCS.Metrics.RecordOperationErrorMetrics("DeleteVolume", err, diskTypeForMetric)
+		gceCS.Metrics.RecordOperationErrorMetrics("DeleteVolume", err, diskTypeForMetric, enableConfidentialCompute)
 	}()
 	// Validate arguments
 	volumeID := req.GetVolumeId()
@@ -472,7 +474,7 @@ func (gceCS *GCEControllerServer) DeleteVolume(ctx context.Context, req *csi.Del
 	}
 	defer gceCS.volumeLocks.Release(volumeID)
 	disk, _ := gceCS.CloudProvider.GetDisk(ctx, project, volKey, gce.GCEAPIVersionV1)
-	diskTypeForMetric = metrics.GetDiskType(disk)
+	diskTypeForMetric, enableConfidentialCompute = metrics.GetMetricParameters(disk)
 	err = gceCS.CloudProvider.DeleteDisk(ctx, project, volKey)
 	if err != nil {
 		return nil, common.LoggedError("Failed to delete disk: ", err)
@@ -484,9 +486,10 @@ func (gceCS *GCEControllerServer) DeleteVolume(ctx context.Context, req *csi.Del
 
 func (gceCS *GCEControllerServer) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
 	var err error
-	diskTypeForMetric := ""
+	diskTypeForMetric := metrics.DefaultDiskTypeForMetric
+	enableConfidentialCompute := metrics.DefaultEnableConfidentialCompute
 	defer func() {
-		gceCS.Metrics.RecordOperationErrorMetrics("ControllerPublishVolume", err, diskTypeForMetric)
+		gceCS.Metrics.RecordOperationErrorMetrics("ControllerPublishVolume", err, diskTypeForMetric, enableConfidentialCompute)
 	}()
 	// Only valid requests will be accepted
 	_, _, _, err = gceCS.validateControllerPublishVolumeRequest(ctx, req)
@@ -499,7 +502,8 @@ func (gceCS *GCEControllerServer) ControllerPublishVolume(ctx context.Context, r
 		return nil, status.Errorf(codes.Unavailable, "ControllerPublish not permitted on node %q due to backoff condition", req.NodeId)
 	}
 
-	resp, err, diskTypeForMetric := gceCS.executeControllerPublishVolume(ctx, req)
+	resp, err, disk := gceCS.executeControllerPublishVolume(ctx, req)
+	diskTypeForMetric, enableConfidentialCompute = metrics.GetMetricParameters(disk)
 	if err != nil {
 		klog.Infof("For node %s adding backoff due to error for volume %s: %v", req.NodeId, req.VolumeId, err.Error())
 		gceCS.errorBackoff.next(backoffId)
@@ -552,11 +556,10 @@ func parseMachineType(machineTypeUrl string) string {
 	return machineType
 }
 
-func (gceCS *GCEControllerServer) executeControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error, string) {
-	diskType := ""
+func (gceCS *GCEControllerServer) executeControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error, *gce.CloudDisk) {
 	project, volKey, pdcsiContext, err := gceCS.validateControllerPublishVolumeRequest(ctx, req)
 	if err != nil {
-		return nil, err, diskType
+		return nil, err, nil
 	}
 
 	volumeID := req.GetVolumeId()
@@ -571,36 +574,35 @@ func (gceCS *GCEControllerServer) executeControllerPublishVolume(ctx context.Con
 	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey)
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
-			return nil, status.Errorf(codes.NotFound, "ControllerPublishVolume could not find volume with ID %v: %v", volumeID, err.Error()), diskType
+			return nil, status.Errorf(codes.NotFound, "ControllerPublishVolume could not find volume with ID %v: %v", volumeID, err.Error()), nil
 		}
-		return nil, common.LoggedError("ControllerPublishVolume error repairing underspecified volume key: ", err), diskType
+		return nil, common.LoggedError("ControllerPublishVolume error repairing underspecified volume key: ", err), nil
 	}
 
 	// Acquires the lock for the volume on that node only, because we need to support the ability
 	// to publish the same volume onto different nodes concurrently
 	lockingVolumeID := fmt.Sprintf("%s/%s", nodeID, volumeID)
 	if acquired := gceCS.volumeLocks.TryAcquire(lockingVolumeID); !acquired {
-		return nil, status.Errorf(codes.Aborted, common.VolumeOperationAlreadyExistsFmt, lockingVolumeID), diskType
+		return nil, status.Errorf(codes.Aborted, common.VolumeOperationAlreadyExistsFmt, lockingVolumeID), nil
 	}
 	defer gceCS.volumeLocks.Release(lockingVolumeID)
 	disk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey, gce.GCEAPIVersionV1)
-	diskType = metrics.GetDiskType(disk)
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
-			return nil, status.Errorf(codes.NotFound, "Could not find disk %v: %v", volKey.String(), err.Error()), diskType
+			return nil, status.Errorf(codes.NotFound, "Could not find disk %v: %v", volKey.String(), err.Error()), disk
 		}
-		return nil, common.LoggedError("Failed to getDisk: ", err), diskType
+		return nil, common.LoggedError("Failed to getDisk: ", err), disk
 	}
 	instanceZone, instanceName, err := common.NodeIDToZoneAndName(nodeID)
 	if err != nil {
-		return nil, status.Errorf(codes.NotFound, "could not split nodeID: %v", err.Error()), diskType
+		return nil, status.Errorf(codes.NotFound, "could not split nodeID: %v", err.Error()), disk
 	}
 	instance, err := gceCS.CloudProvider.GetInstanceOrError(ctx, instanceZone, instanceName)
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
-			return nil, status.Errorf(codes.NotFound, "Could not find instance %v: %v", nodeID, err.Error()), diskType
+			return nil, status.Errorf(codes.NotFound, "Could not find instance %v: %v", nodeID, err.Error()), disk
 		}
-		return nil, status.Errorf(codes.Internal, "Failed to get instance: %v", err.Error()), diskType
+		return nil, status.Errorf(codes.Internal, "Failed to get instance: %v", err.Error()), disk
 	}
 
 	readWrite := "READ_WRITE"
@@ -610,21 +612,21 @@ func (gceCS *GCEControllerServer) executeControllerPublishVolume(ctx context.Con
 
 	deviceName, err := common.GetDeviceName(volKey)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "error getting device name: %v", err.Error()), diskType
+		return nil, status.Errorf(codes.Internal, "error getting device name: %v", err.Error()), disk
 	}
 
 	attached, err := diskIsAttachedAndCompatible(deviceName, instance, volumeCapability, readWrite)
 	if err != nil {
-		return nil, status.Errorf(codes.AlreadyExists, "Disk %v already published to node %v but incompatible: %v", volKey.Name, nodeID, err.Error()), diskType
+		return nil, status.Errorf(codes.AlreadyExists, "Disk %v already published to node %v but incompatible: %v", volKey.Name, nodeID, err.Error()), disk
 	}
 	if attached {
 		// Volume is attached to node. Success!
 		klog.V(4).Infof("ControllerPublishVolume succeeded for disk %v to instance %v, already attached.", volKey, nodeID)
-		return pubVolResp, nil, diskType
+		return pubVolResp, nil, disk
 	}
 	instanceZone, instanceName, err = common.NodeIDToZoneAndName(nodeID)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "could not split nodeID: %v", err.Error()), diskType
+		return nil, status.Errorf(codes.InvalidArgument, "could not split nodeID: %v", err.Error()), disk
 	}
 	err = gceCS.CloudProvider.AttachDisk(ctx, project, volKey, readWrite, attachableDiskTypePersistent, instanceZone, instanceName, pdcsiContext.ForceAttach)
 	if err != nil {
@@ -633,25 +635,26 @@ func (gceCS *GCEControllerServer) executeControllerPublishVolume(ctx context.Con
 			// If we encountered an UnsupportedDiskError, rewrite the error message to be more user friendly.
 			// The error message from GCE is phrased around disk create on VM creation, not runtime attach.
 			machineType := parseMachineType(instance.MachineType)
-			return nil, status.Errorf(codes.InvalidArgument, "'%s' is not a compatible disk type with the machine type %s, please review the GCP online documentation for available persistent disk options", udErr.DiskType, machineType), diskType
+			return nil, status.Errorf(codes.InvalidArgument, "'%s' is not a compatible disk type with the machine type %s, please review the GCP online documentation for available persistent disk options", udErr.DiskType, machineType), disk
 		}
-		return nil, status.Errorf(codes.Internal, "Failed to Attach: %v", err.Error()), diskType
+		return nil, status.Errorf(codes.Internal, "Failed to Attach: %v", err.Error()), disk
 	}
 
 	err = gceCS.CloudProvider.WaitForAttach(ctx, project, volKey, instanceZone, instanceName)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Errored during WaitForAttach: %v", err.Error()), diskType
+		return nil, status.Errorf(codes.Internal, "Errored during WaitForAttach: %v", err.Error()), disk
 	}
 
 	klog.V(4).Infof("ControllerPublishVolume succeeded for disk %v to instance %v", volKey, nodeID)
-	return pubVolResp, nil, diskType
+	return pubVolResp, nil, disk
 }
 
 func (gceCS *GCEControllerServer) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
 	var err error
-	diskTypeForMetric := ""
+	diskTypeForMetric := metrics.DefaultDiskTypeForMetric
+	enableConfidentialCompute := metrics.DefaultEnableConfidentialCompute
 	defer func() {
-		gceCS.Metrics.RecordOperationErrorMetrics("ControllerUnpublishVolume", err, diskTypeForMetric)
+		gceCS.Metrics.RecordOperationErrorMetrics("ControllerUnpublishVolume", err, diskTypeForMetric, enableConfidentialCompute)
 	}()
 	_, _, err = gceCS.validateControllerUnpublishVolumeRequest(ctx, req)
 	if err != nil {
@@ -663,7 +666,8 @@ func (gceCS *GCEControllerServer) ControllerUnpublishVolume(ctx context.Context,
 	if gceCS.errorBackoff.blocking(backoffId) {
 		return nil, status.Errorf(codes.Unavailable, "ControllerUnpublish not permitted on node %q due to backoff condition", req.NodeId)
 	}
-	resp, err, diskTypeForMetric := gceCS.executeControllerUnpublishVolume(ctx, req)
+	resp, err, disk := gceCS.executeControllerUnpublishVolume(ctx, req)
+	diskTypeForMetric, enableConfidentialCompute = metrics.GetMetricParameters(disk)
 	if err != nil {
 		klog.Infof("For node %s adding backoff due to error for volume %s", req.NodeId, req.VolumeId)
 		gceCS.errorBackoff.next(backoffId)
@@ -693,12 +697,11 @@ func (gceCS *GCEControllerServer) validateControllerUnpublishVolumeRequest(ctx c
 	return project, volKey, nil
 }
 
-func (gceCS *GCEControllerServer) executeControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error, string) {
-	var diskType string
+func (gceCS *GCEControllerServer) executeControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error, *gce.CloudDisk) {
 	project, volKey, err := gceCS.validateControllerUnpublishVolumeRequest(ctx, req)
 
 	if err != nil {
-		return nil, err, diskType
+		return nil, err, nil
 	}
 
 	volumeID := req.GetVolumeId()
@@ -707,37 +710,36 @@ func (gceCS *GCEControllerServer) executeControllerUnpublishVolume(ctx context.C
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
 			klog.Warningf("Treating volume %v as unpublished because it could not be found", volumeID)
-			return &csi.ControllerUnpublishVolumeResponse{}, nil, diskType
+			return &csi.ControllerUnpublishVolumeResponse{}, nil, nil
 		}
-		return nil, common.LoggedError("ControllerUnpublishVolume error repairing underspecified volume key: ", err), diskType
+		return nil, common.LoggedError("ControllerUnpublishVolume error repairing underspecified volume key: ", err), nil
 	}
 
 	// Acquires the lock for the volume on that node only, because we need to support the ability
 	// to unpublish the same volume from different nodes concurrently
 	lockingVolumeID := fmt.Sprintf("%s/%s", nodeID, volumeID)
 	if acquired := gceCS.volumeLocks.TryAcquire(lockingVolumeID); !acquired {
-		return nil, status.Errorf(codes.Aborted, common.VolumeOperationAlreadyExistsFmt, lockingVolumeID), diskType
+		return nil, status.Errorf(codes.Aborted, common.VolumeOperationAlreadyExistsFmt, lockingVolumeID), nil
 	}
 	defer gceCS.volumeLocks.Release(lockingVolumeID)
 	diskToUnpublish, _ := gceCS.CloudProvider.GetDisk(ctx, project, volKey, gce.GCEAPIVersionV1)
-	diskType = metrics.GetDiskType(diskToUnpublish)
 	instanceZone, instanceName, err := common.NodeIDToZoneAndName(nodeID)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "could not split nodeID: %v", err.Error()), diskType
+		return nil, status.Errorf(codes.InvalidArgument, "could not split nodeID: %v", err.Error()), diskToUnpublish
 	}
 	instance, err := gceCS.CloudProvider.GetInstanceOrError(ctx, instanceZone, instanceName)
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
 			// Node not existing on GCE means that disk has been detached
 			klog.Warningf("Treating volume %v as unpublished because node %v could not be found", volKey.String(), instanceName)
-			return &csi.ControllerUnpublishVolumeResponse{}, nil, diskType
+			return &csi.ControllerUnpublishVolumeResponse{}, nil, diskToUnpublish
 		}
-		return nil, status.Errorf(codes.Internal, "error getting instance: %v", err.Error()), diskType
+		return nil, status.Errorf(codes.Internal, "error getting instance: %v", err.Error()), diskToUnpublish
 	}
 
 	deviceName, err := common.GetDeviceName(volKey)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "error getting device name: %v", err.Error()), diskType
+		return nil, status.Errorf(codes.Internal, "error getting device name: %v", err.Error()), diskToUnpublish
 	}
 
 	attached := diskIsAttached(deviceName, instance)
@@ -745,22 +747,23 @@ func (gceCS *GCEControllerServer) executeControllerUnpublishVolume(ctx context.C
 	if !attached {
 		// Volume is not attached to node. Success!
 		klog.V(4).Infof("ControllerUnpublishVolume succeeded for disk %v from node %v. Already not attached.", volKey, nodeID)
-		return &csi.ControllerUnpublishVolumeResponse{}, nil, diskType
+		return &csi.ControllerUnpublishVolumeResponse{}, nil, diskToUnpublish
 	}
 	err = gceCS.CloudProvider.DetachDisk(ctx, project, deviceName, instanceZone, instanceName)
 	if err != nil {
-		return nil, common.LoggedError("Failed to detach: ", err), diskType
+		return nil, common.LoggedError("Failed to detach: ", err), diskToUnpublish
 	}
 
 	klog.V(4).Infof("ControllerUnpublishVolume succeeded for disk %v from node %v", volKey, nodeID)
-	return &csi.ControllerUnpublishVolumeResponse{}, nil, diskType
+	return &csi.ControllerUnpublishVolumeResponse{}, nil, diskToUnpublish
 }
 
 func (gceCS *GCEControllerServer) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
 	var err error
-	diskTypeForMetric := ""
+	diskTypeForMetric := metrics.DefaultDiskTypeForMetric
+	enableConfidentialCompute := metrics.DefaultEnableConfidentialCompute
 	defer func() {
-		gceCS.Metrics.RecordOperationErrorMetrics("ValidateVolumeCapabilities", err, diskTypeForMetric)
+		gceCS.Metrics.RecordOperationErrorMetrics("ValidateVolumeCapabilities", err, diskTypeForMetric, enableConfidentialCompute)
 	}()
 	if req.GetVolumeCapabilities() == nil || len(req.GetVolumeCapabilities()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume Capabilities must be provided")
@@ -787,7 +790,7 @@ func (gceCS *GCEControllerServer) ValidateVolumeCapabilities(ctx context.Context
 	defer gceCS.volumeLocks.Release(volumeID)
 
 	disk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey, gce.GCEAPIVersionV1)
-	diskTypeForMetric = metrics.GetDiskType(disk)
+	diskTypeForMetric, enableConfidentialCompute = metrics.GetMetricParameters(disk)
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
 			return nil, status.Errorf(codes.NotFound, "Could not find disk %v: %v", volKey.Name, err.Error())
@@ -910,9 +913,10 @@ func (gceCS *GCEControllerServer) ControllerGetCapabilities(ctx context.Context,
 
 func (gceCS *GCEControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
 	var err error
-	diskTypeForMetric := ""
+	diskTypeForMetric := metrics.DefaultDiskTypeForMetric
+	enableConfidentialCompute := metrics.DefaultEnableConfidentialCompute
 	defer func() {
-		gceCS.Metrics.RecordOperationErrorMetrics("CreateSnapshot", err, diskTypeForMetric)
+		gceCS.Metrics.RecordOperationErrorMetrics("CreateSnapshot", err, diskTypeForMetric, enableConfidentialCompute)
 	}()
 	// Validate arguments
 	volumeID := req.GetSourceVolumeId()
@@ -934,7 +938,7 @@ func (gceCS *GCEControllerServer) CreateSnapshot(ctx context.Context, req *csi.C
 
 	// Check if volume exists
 	disk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey, gce.GCEAPIVersionV1)
-	diskTypeForMetric = metrics.GetDiskType(disk)
+	diskTypeForMetric, enableConfidentialCompute = metrics.GetMetricParameters(disk)
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
 			return nil, status.Errorf(codes.NotFound, "CreateSnapshot could not find disk %v: %v", volKey.String(), err.Error())
@@ -1145,9 +1149,10 @@ func isCSISnapshotReady(status string) (bool, error) {
 
 func (gceCS *GCEControllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
 	var err error
-	diskTypeForMetric := ""
+	diskTypeForMetric := metrics.DefaultDiskTypeForMetric
+	enableConfidentialCompute := metrics.DefaultEnableConfidentialCompute
 	defer func() {
-		gceCS.Metrics.RecordOperationErrorMetrics("DeleteSnapshot", err, diskTypeForMetric)
+		gceCS.Metrics.RecordOperationErrorMetrics("DeleteSnapshot", err, diskTypeForMetric, enableConfidentialCompute)
 	}()
 	// Validate arguments
 	snapshotID := req.GetSnapshotId()
@@ -1234,9 +1239,10 @@ func (gceCS *GCEControllerServer) ListSnapshots(ctx context.Context, req *csi.Li
 
 func (gceCS *GCEControllerServer) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
 	var err error
-	diskTypeForMetric := ""
+	diskTypeForMetric := metrics.DefaultDiskTypeForMetric
+	enableConfidentialCompute := metrics.DefaultEnableConfidentialCompute
 	defer func() {
-		gceCS.Metrics.RecordOperationErrorMetrics("ControllerExpandVolume", err, diskTypeForMetric)
+		gceCS.Metrics.RecordOperationErrorMetrics("ControllerExpandVolume", err, diskTypeForMetric, enableConfidentialCompute)
 	}()
 	volumeID := req.GetVolumeId()
 	if len(volumeID) == 0 {
@@ -1260,7 +1266,7 @@ func (gceCS *GCEControllerServer) ControllerExpandVolume(ctx context.Context, re
 		return nil, common.LoggedError("ControllerExpandVolume error repairing underspecified volume key: ", err)
 	}
 	sourceDisk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey, gce.GCEAPIVersionV1)
-	diskTypeForMetric = metrics.GetDiskType(sourceDisk)
+	diskTypeForMetric, enableConfidentialCompute = metrics.GetMetricParameters(sourceDisk)
 	resizedGb, err := gceCS.CloudProvider.ResizeDisk(ctx, project, volKey, reqBytes)
 	if err != nil {
 		return nil, common.LoggedError("ControllerExpandVolume failed to resize disk: ", err)
@@ -1771,7 +1777,6 @@ func createRegionalDisk(ctx context.Context, cloudProvider gce.GCECompute, name 
 	if multiWriter {
 		gceAPIVersion = gce.GCEAPIVersionBeta
 	}
-
 	disk, err := cloudProvider.GetDisk(ctx, project, meta.RegionalKey(name, region), gceAPIVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get disk after creating regional disk: %w", err)

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -20,6 +20,7 @@ import (
 	"math/rand"
 	"reflect"
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -39,12 +40,14 @@ import (
 )
 
 const (
-	project    = "test-project"
-	zone       = "country-region-zone"
-	secondZone = "country-region-fakesecondzone"
-	node       = "test-node"
-	driver     = "test-driver"
-	name       = "test-name"
+	project                      = "test-project"
+	zone                         = "country-region-zone"
+	secondZone                   = "country-region-fakesecondzone"
+	node                         = "test-node"
+	driver                       = "test-driver"
+	name                         = "test-name"
+	parameterConfidentialCompute = "EnableConfidentialCompute"
+	testDiskEncryptionKmsKey     = "projects/KMS_PROJECT_ID/locations/REGION/keyRings/KEY_RING/cryptoKeys/KEY"
 )
 
 var (
@@ -72,6 +75,7 @@ var (
 
 	errorBackoffInitialDuration = 200 * time.Millisecond
 	errorBackoffMaxDuration     = 5 * time.Minute
+	defaultConfidentialStorage  = "false"
 )
 
 func TestCreateSnapshotArguments(t *testing.T) {
@@ -3312,6 +3316,106 @@ func TestCleanSelfLink(t *testing.T) {
 			if got != tc.want {
 				t.Errorf("Expected cleaned self link: %v, got: %v", tc.want, got)
 			}
+		})
+	}
+}
+
+func TestCreateConfidentialVolume(t *testing.T) {
+	// Define test cases
+	testCases := []struct {
+		name       string
+		volKey     *meta.Key
+		req        *csi.CreateVolumeRequest
+		diskStatus string
+		expErrCode codes.Code
+	}{
+		{
+			name:       "create confidential volume from snapshot",
+			volKey:     meta.ZonalKey("my-disk", zone),
+			diskStatus: "READY",
+			req: &csi.CreateVolumeRequest{
+				Name:               "test-volume",
+				CapacityRange:      stdCapRange,
+				VolumeCapabilities: stdVolCaps,
+				Parameters: map[string]string{
+					common.ParameterKeyEnableConfidentialCompute: "true",
+					common.ParameterKeyDiskEncryptionKmsKey:      testDiskEncryptionKmsKey,
+					common.ParameterKeyType:                      "hyperdisk-balanced",
+				},
+				VolumeContentSource: &csi.VolumeContentSource{
+					Type: &csi.VolumeContentSource_Snapshot{
+						Snapshot: &csi.VolumeContentSource_SnapshotSource{
+							SnapshotId: testSnapshotID,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "create volume from snapshot with confidential-compute disabled",
+			volKey:     meta.ZonalKey("my-disk", zone),
+			diskStatus: "READY",
+			req: &csi.CreateVolumeRequest{
+				Name:               "test-volume",
+				CapacityRange:      stdCapRange,
+				VolumeCapabilities: stdVolCaps,
+				Parameters: map[string]string{
+					common.ParameterKeyEnableConfidentialCompute: "false",
+					common.ParameterKeyType:                      "hyperdisk-balanced",
+				},
+				VolumeContentSource: &csi.VolumeContentSource{
+					Type: &csi.VolumeContentSource_Snapshot{
+						Snapshot: &csi.VolumeContentSource_SnapshotSource{
+							SnapshotId: testSnapshotID,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Logf("test case: %s", tc.name)
+		t.Run(tc.name, func(t *testing.T) {
+			fcp, err := gce.CreateFakeCloudProvider(project, zone, nil)
+			if err != nil {
+				t.Fatalf("Failed to create fake cloud provider: %v", err)
+			}
+			// Setup new driver each time so no interference
+			gceDriver := initGCEDriverWithCloudProvider(t, fcp)
+
+			if tc.req.VolumeContentSource.GetType() != nil {
+				snapshotParams, err := common.ExtractAndDefaultSnapshotParameters(nil, gceDriver.name)
+				if err != nil {
+					t.Errorf("Got error extracting snapshot parameters: %v", err)
+				}
+				if snapshotParams.SnapshotType == common.DiskSnapshotType {
+					fcp.CreateSnapshot(context.Background(), project, tc.volKey, name, snapshotParams)
+				} else {
+					t.Fatalf("No volume source mentioned in snapshot parameters %v", snapshotParams)
+				}
+			}
+
+			// Start Test
+			resp, err := gceDriver.cs.CreateVolume(context.Background(), tc.req)
+			if err != nil {
+				serverError, ok := status.FromError(err)
+				if !ok {
+					t.Fatalf("Could not get error status code from err: %v", serverError)
+				}
+				t.Errorf("Recieved error %v", serverError)
+			}
+
+			volumeId := resp.GetVolume().VolumeId
+			project, volumeKey, err := common.VolumeIDToKey(volumeId)
+			createdDisk, err := fcp.GetDisk(context.Background(), project, volumeKey, gce.GCEAPIVersionBeta)
+			if err != nil {
+				t.Fatalf("Get Disk failed for created disk with error: %v", err)
+			}
+			val, ok := tc.req.Parameters[common.ParameterKeyEnableConfidentialCompute]
+			if ok && val != strconv.FormatBool(createdDisk.GetEnableConfidentialCompute()) {
+				t.Fatalf("Confidential disk parameter does not match with created disk: %v Got error %v", createdDisk.GetEnableConfidentialCompute(), err)
+			}
+			t.Logf("Created disk for confidentialCompute %v with parametrs, %v", createdDisk.GetEnableConfidentialCompute(), tc.req.Parameters)
 		})
 	}
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	computebeta "google.golang.org/api/compute/v0.beta"
+	"google.golang.org/api/compute/v1"
+	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute"
+)
+
+const (
+	hyperdiskBalanced = "hyperdisk-balanced"
+)
+
+func CreateDiskWithConfidentialCompute(betaVersion bool, confidentialCompute bool, diskType string) *gce.CloudDisk {
+	if betaVersion {
+		return gce.CloudDiskFromBeta(&computebeta.Disk{
+			EnableConfidentialCompute: confidentialCompute,
+			Type:                      diskType,
+		})
+	}
+	return gce.CloudDiskFromV1(&compute.Disk{
+		Type: diskType,
+	})
+}
+
+func TestGetEnableConfidentialCompute(t *testing.T) {
+	testCases := []struct {
+		name                              string
+		disk                              *gce.CloudDisk
+		expectedEnableConfidentialCompute string
+		expectedDiskType                  string
+	}{
+		{
+			name:                              "test betaDisk with enableConfidentialCompute=false",
+			disk:                              CreateDiskWithConfidentialCompute(true, false, hyperdiskBalanced),
+			expectedEnableConfidentialCompute: "false",
+			expectedDiskType:                  hyperdiskBalanced,
+		},
+		{
+			name:                              "test betaDisk with enableConfidentialCompute=true",
+			disk:                              CreateDiskWithConfidentialCompute(true, true, hyperdiskBalanced),
+			expectedEnableConfidentialCompute: "true",
+			expectedDiskType:                  hyperdiskBalanced,
+		},
+		{
+			name:                              "test disk withpit enableConfidentialCompute",
+			disk:                              CreateDiskWithConfidentialCompute(false, false, hyperdiskBalanced),
+			expectedEnableConfidentialCompute: "false",
+			expectedDiskType:                  hyperdiskBalanced,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Logf("Running test: %v", tc.name)
+		diskType, confidentialCompute := GetMetricParameters(tc.disk)
+		if confidentialCompute != tc.expectedEnableConfidentialCompute {
+			t.Fatalf("Got confidentialCompute value %v expected %v", confidentialCompute, tc.expectedEnableConfidentialCompute)
+		}
+		if diskType != tc.expectedDiskType {
+			t.Fatalf("Got confidentialCompute value %v expected %v", diskType, tc.expectedDiskType)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adds support in PDCSI driver to create confidential hyperdisk storage on GCE.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This change has been tested manually as we cannot add e2e tests yet.
Scenarios tested:
1. Create a hyperdisk-balanced confidential disk with PDCSI driver.
2. Created a confidential disk from a non-confidential snapshot (Snapshot source disk type: pd-standard)
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added support in PDCSI driver to create confidential hyperdisk storage on GCE.
```
