### PR TITLE
fix: volumeID is incorrent when project name contains alpha/beta/v1

### DIFF
--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -1745,7 +1745,7 @@ func generateCreateVolumeResponse(disk *gce.CloudDisk, zones []string, params co
 }
 
 func cleanSelfLink(selfLink string) string {
-	r, _ := regexp.Compile("https:\\/\\/www.*apis.com\\/.*(v1|beta|alpha)\\/")
+	r, _ := regexp.Compile(`https://www.*apis.com/[^/]+/(v1|beta|alpha)/`)
 	return r.ReplaceAllString(selfLink, "")
 }
 

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -3304,6 +3304,16 @@ func TestCleanSelfLink(t *testing.T) {
 			in:   "https://www.partnerapis.com/compute/alpha/projects/project/zones/zone/disks/disk",
 			want: "projects/project/zones/zone/disks/disk",
 		},
+		{
+			name: "project name contains keyword",
+			in:   "https://www.partnerapis.com/compute/alpha/projects/proj-alpha/zones/zone/disks/disk",
+			want: "projects/proj-alpha/zones/zone/disks/disk",
+		},
+		{
+			name: "project name contains keyword 2",
+			in:   "https://www.partnerapis.com/compute/v1/projects/proj-alpha/zones/zone/disks/disk",
+			want: "projects/proj-alpha/zones/zone/disks/disk",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1302 

**Does this PR introduce a user-facing change**:
```release-note
Fix: AttachVolume.Attach failed when name of gcp project ends with beta
```
