### PR TITLE
Increase parallelism in e2e test

### DIFF
--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -55,7 +55,7 @@ func GCEClientAndDriverSetup(instance *remote.InstanceInfo, computeEndpoint stri
 	endpoint := fmt.Sprintf("tcp://localhost:%s", port)
 	extra_flags := []string{
 		fmt.Sprintf("--extra-labels=%s=%s", DiskLabelKey, DiskLabelValue),
-		"--max-concurrent-format-and-mount=10", // otherwise the serialization times out.
+		"--max-concurrent-format-and-mount=20", // otherwise the serialization times out the e2e test.
 	}
 	if computeEndpoint != "" {
 		extra_flags = append(extra_flags, fmt.Sprintf("--compute-endpoint %s", computeEndpoint))


### PR DESCRIPTION
/kind failing-test

**What this PR does / why we need it**:
The e2e tests seems to have gotten a bit more flakey, and the serialization of fsck is the only recent change that seems plausibly a cause.

See also https://github.com/kubernetes/test-infra/pull/30158

/assign @msau42 

-->
```release-note
None
```
