### PR TITLE
Add pd-extreme e2e test case of defaulting to default iops when iops not set

### DIFF
--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -574,12 +574,15 @@ func (cloud *CloudProvider) insertZonalDisk(
 	}
 
 	diskToCreate := &computev1.Disk{
-		Name:            volKey.Name,
-		SizeGb:          common.BytesToGbRoundUp(capBytes),
-		Description:     description,
-		Type:            cloud.GetDiskTypeURI(project, volKey, params.DiskType),
-		Labels:          params.Labels,
-		ProvisionedIops: params.ProvisionedIOPSOnCreate,
+		Name:        volKey.Name,
+		SizeGb:      common.BytesToGbRoundUp(capBytes),
+		Description: description,
+		Type:        cloud.GetDiskTypeURI(project, volKey, params.DiskType),
+		Labels:      params.Labels,
+	}
+
+	if params.ProvisionedIOPSOnCreate > 0 {
+		diskToCreate.ProvisionedIops = params.ProvisionedIOPSOnCreate
 	}
 
 	if snapshotID != "" {


### PR DESCRIPTION


**What type of PR is this?**
/kind cleanup
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Add pd-extreme e2e test case of defaulting to default iops when iops not set
```
