### PR TITLE
Change e2e test machine type to n2-standard-2 to include more Hyperdisk cases

### DIFF
--- a/test/e2e/tests/setup_e2e_test.go
+++ b/test/e2e/tests/setup_e2e_test.go
@@ -39,7 +39,7 @@ var (
 	serviceAccount  = flag.String("service-account", "", "Service account to bring up instance with")
 	architecture    = flag.String("arch", "amd64", "Architecture pd csi driver build on")
 	zones           = flag.String("zones", "us-central1-c,us-central1-b", "Zones to run tests in. If there are multiple zones, separate each by comma")
-	machineType     = flag.String("machine-type", "n1-standard-1", "Type of machine to provision instance on")
+	machineType     = flag.String("machine-type", "n2-standard-2", "Type of machine to provision instance on")
 	imageURL        = flag.String("image-url", "projects/debian-cloud/global/images/family/debian-11", "OS image url to get image from")
 	runInProw       = flag.Bool("run-in-prow", false, "If true, use a Boskos loaned project and special CI service accounts and ssh keys")
 	deleteInstances = flag.Bool("delete-instances", false, "Delete the instances after tests run")


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Hyperdisk disk types do not work with n1 machine and a more general working machine is n2.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Change e2e test machine type to n2-standard-2 to include more Hyperdisk cases
```
