### PR TITLE
 [release-1.9] Automated cherry pick of #1330: Update go version to 1.20.6 to fix CVE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG BUILDPLATFORM
 
-FROM --platform=$BUILDPLATFORM golang:1.20.5 as builder
+FROM --platform=$BUILDPLATFORM golang:1.20.6 as builder
 
 ARG STAGINGVERSION
 ARG TARGETPLATFORM

--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG BASE_IMAGE
-FROM --platform=$BUILDPLATFORM golang:1.20.5 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.20.6 AS builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19.6 as builder
+FROM golang:1.20.6 as builder
 WORKDIR /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 ADD . .
 


### PR DESCRIPTION
Cherry pick of #1330 on release-1.9.

#1330: Update go version to 1.20.6 to fix CVE

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Update go version to 1.20.6 to fix CVE-2023-29406
```