### PR TITLE
Updating changelog for release v1.11.0, v1.10.6, v1.9.8, v1.8.9 v1.7.11

### DIFF
--- a/CHANGELOG/CHANGELOG-1.10.md
+++ b/CHANGELOG/CHANGELOG-1.10.md
@@ -1,3 +1,11 @@
+# v1.10.6 - Changelog since v1.10.5
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Update go version to 1.20.6 to fix CVE-2023-29406 ([#1331](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1331), [@pwschuurman](https://github.com/pwschuurman))
+
 # v1.10.5 - Changelog since v1.10.4
 
 ## Changes by Kind
@@ -9,7 +17,6 @@
 ### Uncategorized
 
 - Add disk type for all operations metrics. ([#1295](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1295), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
-- Fix provisioned-iops-on-create passing logic ([#1282](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1282), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
 - Fix resource parsing when the gcp project name ends with alpha, beta or v1 ([#1307](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1307), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
 - Use original error code when responding with a backoff error on publish or unpublish. ([#1311](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1311), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
 - Added support in PDCSI driver to create confidential hyperdisk storage on GCE. ([#1315](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1315), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))

--- a/CHANGELOG/CHANGELOG-1.11.md
+++ b/CHANGELOG/CHANGELOG-1.11.md
@@ -1,0 +1,172 @@
+# v1.11.0 - Changelog since v1.10.5
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Update go version to 1.20.6 to fix CVE-2023-29406 ([#1330](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1330), [@Sneha-at](https://github.com/Sneha-at))
+
+### Other (Cleanup or Flake)
+
+- Change e2e test machine type to n2-standard-2 to include more Hyperdisk cases ([#1320](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1320), [@sunnylovestiramisu](https://github.com/sunnylovestiramisu))
+- Update k8s-cloud-provider to v1.24.0 and add HdT e2e tests ([#1325](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1325), [@sunnylovestiramisu](https://github.com/sunnylovestiramisu))
+
+## Dependencies
+
+### Added
+- github.com/google/go-pkcs11: [v0.2.0](https://github.com/google/go-pkcs11/tree/v0.2.0)
+- github.com/google/s2a-go: [v0.1.4](https://github.com/google/s2a-go/tree/v0.1.4)
+- google.golang.org/genproto/googleapis/api: ccb25ca
+- google.golang.org/genproto/googleapis/bytestream: 659f7aa
+- google.golang.org/genproto/googleapis/rpc: 659f7aa
+
+### Changed
+- cloud.google.com/go/accessapproval: v1.5.0 → v1.7.1
+- cloud.google.com/go/accesscontextmanager: v1.4.0 → v1.8.1
+- cloud.google.com/go/aiplatform: v1.27.0 → v1.45.0
+- cloud.google.com/go/analytics: v0.12.0 → v0.21.2
+- cloud.google.com/go/apigateway: v1.4.0 → v1.6.1
+- cloud.google.com/go/apigeeconnect: v1.4.0 → v1.6.1
+- cloud.google.com/go/apigeeregistry: v0.4.0 → v0.7.1
+- cloud.google.com/go/appengine: v1.5.0 → v1.8.1
+- cloud.google.com/go/area120: v0.6.0 → v0.8.1
+- cloud.google.com/go/artifactregistry: v1.9.0 → v1.14.1
+- cloud.google.com/go/asset: v1.10.0 → v1.14.1
+- cloud.google.com/go/assuredworkloads: v1.9.0 → v1.11.1
+- cloud.google.com/go/automl: v1.8.0 → v1.13.1
+- cloud.google.com/go/baremetalsolution: v0.4.0 → v0.5.0
+- cloud.google.com/go/batch: v0.4.0 → v0.7.0
+- cloud.google.com/go/beyondcorp: v0.3.0 → v0.6.1
+- cloud.google.com/go/bigquery: v1.44.0 → v1.52.0
+- cloud.google.com/go/billing: v1.7.0 → v1.16.0
+- cloud.google.com/go/binaryauthorization: v1.4.0 → v1.6.1
+- cloud.google.com/go/certificatemanager: v1.4.0 → v1.7.1
+- cloud.google.com/go/channel: v1.9.0 → v1.16.0
+- cloud.google.com/go/cloudbuild: v1.4.0 → v1.10.1
+- cloud.google.com/go/clouddms: v1.4.0 → v1.6.1
+- cloud.google.com/go/cloudtasks: v1.8.0 → v1.11.1
+- cloud.google.com/go/compute: v1.18.0 → v1.20.1
+- cloud.google.com/go/contactcenterinsights: v1.4.0 → v1.9.1
+- cloud.google.com/go/container: v1.7.0 → v1.22.1
+- cloud.google.com/go/containeranalysis: v0.6.0 → v0.10.1
+- cloud.google.com/go/datacatalog: v1.8.0 → v1.14.1
+- cloud.google.com/go/dataflow: v0.7.0 → v0.9.1
+- cloud.google.com/go/dataform: v0.5.0 → v0.8.1
+- cloud.google.com/go/datafusion: v1.5.0 → v1.7.1
+- cloud.google.com/go/datalabeling: v0.6.0 → v0.8.1
+- cloud.google.com/go/dataplex: v1.4.0 → v1.8.1
+- cloud.google.com/go/dataproc: v1.8.0 → v1.12.0
+- cloud.google.com/go/dataqna: v0.6.0 → v0.8.1
+- cloud.google.com/go/datastore: v1.10.0 → v1.12.0
+- cloud.google.com/go/datastream: v1.5.0 → v1.9.1
+- cloud.google.com/go/deploy: v1.5.0 → v1.11.0
+- cloud.google.com/go/dialogflow: v1.29.0 → v1.38.0
+- cloud.google.com/go/dlp: v1.7.0 → v1.10.1
+- cloud.google.com/go/documentai: v1.10.0 → v1.20.0
+- cloud.google.com/go/domains: v0.7.0 → v0.9.1
+- cloud.google.com/go/edgecontainer: v0.2.0 → v1.1.1
+- cloud.google.com/go/essentialcontacts: v1.4.0 → v1.6.2
+- cloud.google.com/go/eventarc: v1.8.0 → v1.12.1
+- cloud.google.com/go/filestore: v1.4.0 → v1.7.1
+- cloud.google.com/go/firestore: v1.9.0 → v1.11.0
+- cloud.google.com/go/functions: v1.9.0 → v1.15.1
+- cloud.google.com/go/gaming: v1.8.0 → v1.10.1
+- cloud.google.com/go/gkebackup: v0.3.0 → v0.4.0
+- cloud.google.com/go/gkeconnect: v0.6.0 → v0.8.1
+- cloud.google.com/go/gkehub: v0.10.0 → v0.14.1
+- cloud.google.com/go/gkemulticloud: v0.4.0 → v0.6.1
+- cloud.google.com/go/gsuiteaddons: v1.4.0 → v1.6.1
+- cloud.google.com/go/iam: v0.11.0 → v1.1.0
+- cloud.google.com/go/iap: v1.5.0 → v1.8.1
+- cloud.google.com/go/ids: v1.2.0 → v1.4.1
+- cloud.google.com/go/iot: v1.4.0 → v1.7.1
+- cloud.google.com/go/kms: v1.6.0 → v1.12.1
+- cloud.google.com/go/language: v1.8.0 → v1.10.1
+- cloud.google.com/go/lifesciences: v0.6.0 → v0.9.1
+- cloud.google.com/go/logging: v1.6.1 → v1.7.0
+- cloud.google.com/go/longrunning: v0.3.0 → v0.5.1
+- cloud.google.com/go/managedidentities: v1.4.0 → v1.6.1
+- cloud.google.com/go/maps: v0.1.0 → v0.7.0
+- cloud.google.com/go/mediatranslation: v0.6.0 → v0.8.1
+- cloud.google.com/go/memcache: v1.7.0 → v1.10.1
+- cloud.google.com/go/metastore: v1.8.0 → v1.11.1
+- cloud.google.com/go/monitoring: v1.8.0 → v1.15.1
+- cloud.google.com/go/networkconnectivity: v1.7.0 → v1.12.1
+- cloud.google.com/go/networkmanagement: v1.5.0 → v1.8.0
+- cloud.google.com/go/networksecurity: v0.6.0 → v0.9.1
+- cloud.google.com/go/notebooks: v1.5.0 → v1.9.1
+- cloud.google.com/go/optimization: v1.2.0 → v1.4.1
+- cloud.google.com/go/orchestration: v1.4.0 → v1.8.1
+- cloud.google.com/go/orgpolicy: v1.5.0 → v1.11.1
+- cloud.google.com/go/osconfig: v1.10.0 → v1.12.1
+- cloud.google.com/go/oslogin: v1.7.0 → v1.10.1
+- cloud.google.com/go/phishingprotection: v0.6.0 → v0.8.1
+- cloud.google.com/go/policytroubleshooter: v1.4.0 → v1.7.1
+- cloud.google.com/go/privatecatalog: v0.6.0 → v0.9.1
+- cloud.google.com/go/pubsub: v1.27.1 → v1.32.0
+- cloud.google.com/go/pubsublite: v1.5.0 → v1.8.1
+- cloud.google.com/go/recaptchaenterprise/v2: v2.5.0 → v2.7.2
+- cloud.google.com/go/recommendationengine: v0.6.0 → v0.8.1
+- cloud.google.com/go/recommender: v1.8.0 → v1.10.1
+- cloud.google.com/go/redis: v1.10.0 → v1.13.1
+- cloud.google.com/go/resourcemanager: v1.4.0 → v1.9.1
+- cloud.google.com/go/resourcesettings: v1.4.0 → v1.6.1
+- cloud.google.com/go/retail: v1.11.0 → v1.14.1
+- cloud.google.com/go/run: v0.3.0 → v0.9.0
+- cloud.google.com/go/scheduler: v1.7.0 → v1.10.1
+- cloud.google.com/go/secretmanager: v1.9.0 → v1.11.1
+- cloud.google.com/go/security: v1.10.0 → v1.15.1
+- cloud.google.com/go/securitycenter: v1.16.0 → v1.23.0
+- cloud.google.com/go/servicedirectory: v1.7.0 → v1.10.1
+- cloud.google.com/go/shell: v1.4.0 → v1.7.1
+- cloud.google.com/go/spanner: v1.41.0 → v1.47.0
+- cloud.google.com/go/speech: v1.9.0 → v1.17.1
+- cloud.google.com/go/storagetransfer: v1.6.0 → v1.10.0
+- cloud.google.com/go/talent: v1.4.0 → v1.6.2
+- cloud.google.com/go/texttospeech: v1.5.0 → v1.7.1
+- cloud.google.com/go/tpu: v1.4.0 → v1.6.1
+- cloud.google.com/go/trace: v1.4.0 → v1.10.1
+- cloud.google.com/go/translate: v1.4.0 → v1.8.1
+- cloud.google.com/go/video: v1.9.0 → v1.17.1
+- cloud.google.com/go/videointelligence: v1.9.0 → v1.11.1
+- cloud.google.com/go/vision/v2: v2.5.0 → v2.7.2
+- cloud.google.com/go/vmmigration: v1.3.0 → v1.7.1
+- cloud.google.com/go/vmwareengine: v0.1.0 → v0.4.1
+- cloud.google.com/go/vpcaccess: v1.5.0 → v1.7.1
+- cloud.google.com/go/webrisk: v1.7.0 → v1.9.1
+- cloud.google.com/go/websecurityscanner: v1.4.0 → v1.6.1
+- cloud.google.com/go/workflows: v1.9.0 → v1.11.1
+- cloud.google.com/go: v0.107.0 → v0.110.4
+- github.com/GoogleCloudPlatform/k8s-cloud-provider: [v1.18.0 → v1.24.0](https://github.com/GoogleCloudPlatform/k8s-cloud-provider/compare/v1.18.0...v1.24.0)
+- github.com/cncf/xds/go: [06c439d → e9ce688](https://github.com/cncf/xds/go/compare/06c439d...e9ce688)
+- github.com/envoyproxy/go-control-plane: [v0.10.3 → 9239064](https://github.com/envoyproxy/go-control-plane/compare/v0.10.3...9239064)
+- github.com/envoyproxy/protoc-gen-validate: [v0.9.1 → v0.10.1](https://github.com/envoyproxy/protoc-gen-validate/compare/v0.9.1...v0.10.1)
+- github.com/golang/glog: [v1.0.0 → v1.1.0](https://github.com/golang/glog/compare/v1.0.0...v1.1.0)
+- github.com/golang/protobuf: [v1.5.2 → v1.5.3](https://github.com/golang/protobuf/compare/v1.5.2...v1.5.3)
+- github.com/golang/snappy: [v0.0.3 → v0.0.1](https://github.com/golang/snappy/compare/v0.0.3...v0.0.1)
+- github.com/google/martian/v3: [v3.2.1 → v3.1.0](https://github.com/google/martian/v3/compare/v3.2.1...v3.1.0)
+- github.com/google/pprof: [4bb14d4 → 94a9f03](https://github.com/google/pprof/compare/4bb14d4...94a9f03)
+- github.com/googleapis/enterprise-certificate-proxy: [v0.2.3 → v0.2.5](https://github.com/googleapis/enterprise-certificate-proxy/compare/v0.2.3...v0.2.5)
+- github.com/googleapis/gax-go/v2: [v2.7.0 → v2.12.0](https://github.com/googleapis/gax-go/v2/compare/v2.7.0...v2.12.0)
+- github.com/rogpeppe/go-internal: [v1.5.2 → v1.9.0](https://github.com/rogpeppe/go-internal/compare/v1.5.2...v1.9.0)
+- github.com/yuin/goldmark: [v1.4.1 → v1.4.13](https://github.com/yuin/goldmark/compare/v1.4.1...v1.4.13)
+- golang.org/x/crypto: 8634188 → v0.11.0
+- golang.org/x/mod: 86c51ed → v0.8.0
+- golang.org/x/net: v0.7.0 → v0.12.0
+- golang.org/x/oauth2: v0.5.0 → v0.10.0
+- golang.org/x/sync: v0.1.0 → v0.3.0
+- golang.org/x/sys: v0.5.0 → v0.10.0
+- golang.org/x/term: v0.5.0 → v0.10.0
+- golang.org/x/text: v0.7.0 → v0.11.0
+- golang.org/x/tools: v0.5.0 → v0.6.0
+- google.golang.org/api: v0.111.0 → v0.134.0
+- google.golang.org/genproto: 637eb22 → ccb25ca
+- google.golang.org/grpc: v1.53.0 → v1.56.2
+- google.golang.org/protobuf: v1.28.1 → v1.31.0
+
+### Removed
+- cloud.google.com/go/apikeys: v0.4.0
+- cloud.google.com/go/servicecontrol: v1.5.0
+- cloud.google.com/go/servicemanagement: v1.5.0
+- cloud.google.com/go/serviceusage: v1.4.0
+- google.golang.org/grpc/cmd/protoc-gen-go-grpc: v1.1.0

--- a/CHANGELOG/CHANGELOG-1.7.md
+++ b/CHANGELOG/CHANGELOG-1.7.md
@@ -1,3 +1,18 @@
+# v1.7.11 - Changelog since v1.7.10
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Update go version to 1.19.11 to fix CVE-2023-29406 ([#1335](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1335), [@Sneha-at](https://github.com/Sneha-at))
+
+### Uncategorized
+
+- #1101: Add provisionedThroughput for hyperdisk
+  #1227: Adding new metric pdcsi_operation_errors to fetch error
+  #1296: emit metrics even for success scenarios ([#1305](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1305), [@sunnylovestiramisu](https://github.com/sunnylovestiramisu))
+- Use errors.As so we can detect wrapped errors, and check for existing error codes in CodesForError ([#1326](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1326), [@judemars](https://github.com/judemars))
+
 # v1.7.10 - Changelog since v1.7.9
 
 ## Changes by Kind

--- a/CHANGELOG/CHANGELOG-1.8.md
+++ b/CHANGELOG/CHANGELOG-1.8.md
@@ -1,3 +1,175 @@
+# v1.8.9 - Changelog since v1.8.8
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Update go version to 1.19.11 to fix CVE-2023-29406 ([#1336](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1336), [@Sneha-at](https://github.com/Sneha-at))
+- Updated dependencies to fix CVE-2022-27664, CVE-2022-32149, CVE-2022-41723, CVE-2022-41721 ([#1334](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1334), [@Sneha-at](https://github.com/Sneha-at))
+
+### Uncategorized
+
+- Add disk type for all operations metrics. ([#1297](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1297), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
+
+## Dependencies
+
+### Added
+- cloud.google.com/go/accessapproval: v1.6.0
+- cloud.google.com/go/accesscontextmanager: v1.6.0
+- cloud.google.com/go/aiplatform: v1.35.0
+- cloud.google.com/go/analytics: v0.18.0
+- cloud.google.com/go/apigateway: v1.5.0
+- cloud.google.com/go/apigeeconnect: v1.5.0
+- cloud.google.com/go/apigeeregistry: v0.5.0
+- cloud.google.com/go/apikeys: v0.5.0
+- cloud.google.com/go/appengine: v1.6.0
+- cloud.google.com/go/area120: v0.7.1
+- cloud.google.com/go/artifactregistry: v1.11.2
+- cloud.google.com/go/asset: v1.11.1
+- cloud.google.com/go/assuredworkloads: v1.10.0
+- cloud.google.com/go/automl: v1.12.0
+- cloud.google.com/go/baremetalsolution: v0.5.0
+- cloud.google.com/go/batch: v0.7.0
+- cloud.google.com/go/beyondcorp: v0.4.0
+- cloud.google.com/go/billing: v1.12.0
+- cloud.google.com/go/binaryauthorization: v1.5.0
+- cloud.google.com/go/certificatemanager: v1.6.0
+- cloud.google.com/go/channel: v1.11.0
+- cloud.google.com/go/cloudbuild: v1.7.0
+- cloud.google.com/go/clouddms: v1.5.0
+- cloud.google.com/go/cloudtasks: v1.9.0
+- cloud.google.com/go/compute/metadata: v0.2.3
+- cloud.google.com/go/contactcenterinsights: v1.6.0
+- cloud.google.com/go/container: v1.13.1
+- cloud.google.com/go/containeranalysis: v0.7.0
+- cloud.google.com/go/datacatalog: v1.12.0
+- cloud.google.com/go/dataflow: v0.8.0
+- cloud.google.com/go/dataform: v0.6.0
+- cloud.google.com/go/datafusion: v1.6.0
+- cloud.google.com/go/datalabeling: v0.7.0
+- cloud.google.com/go/dataplex: v1.5.2
+- cloud.google.com/go/dataproc: v1.12.0
+- cloud.google.com/go/dataqna: v0.7.0
+- cloud.google.com/go/datastream: v1.6.0
+- cloud.google.com/go/deploy: v1.6.0
+- cloud.google.com/go/dialogflow: v1.31.0
+- cloud.google.com/go/dlp: v1.9.0
+- cloud.google.com/go/documentai: v1.16.0
+- cloud.google.com/go/domains: v0.8.0
+- cloud.google.com/go/edgecontainer: v0.3.0
+- cloud.google.com/go/errorreporting: v0.3.0
+- cloud.google.com/go/essentialcontacts: v1.5.0
+- cloud.google.com/go/eventarc: v1.10.0
+- cloud.google.com/go/filestore: v1.5.0
+- cloud.google.com/go/functions: v1.10.0
+- cloud.google.com/go/gaming: v1.9.0
+- cloud.google.com/go/gkebackup: v0.4.0
+- cloud.google.com/go/gkeconnect: v0.7.0
+- cloud.google.com/go/gkehub: v0.11.0
+- cloud.google.com/go/gkemulticloud: v0.5.0
+- cloud.google.com/go/gsuiteaddons: v1.5.0
+- cloud.google.com/go/iap: v1.6.0
+- cloud.google.com/go/ids: v1.3.0
+- cloud.google.com/go/iot: v1.5.0
+- cloud.google.com/go/language: v1.9.0
+- cloud.google.com/go/lifesciences: v0.8.0
+- cloud.google.com/go/longrunning: v0.4.1
+- cloud.google.com/go/managedidentities: v1.5.0
+- cloud.google.com/go/maps: v0.6.0
+- cloud.google.com/go/mediatranslation: v0.7.0
+- cloud.google.com/go/memcache: v1.9.0
+- cloud.google.com/go/metastore: v1.10.0
+- cloud.google.com/go/monitoring: v1.12.0
+- cloud.google.com/go/networkconnectivity: v1.10.0
+- cloud.google.com/go/networkmanagement: v1.6.0
+- cloud.google.com/go/networksecurity: v0.7.0
+- cloud.google.com/go/notebooks: v1.7.0
+- cloud.google.com/go/optimization: v1.3.1
+- cloud.google.com/go/orchestration: v1.6.0
+- cloud.google.com/go/orgpolicy: v1.10.0
+- cloud.google.com/go/osconfig: v1.11.0
+- cloud.google.com/go/oslogin: v1.9.0
+- cloud.google.com/go/phishingprotection: v0.7.0
+- cloud.google.com/go/policytroubleshooter: v1.5.0
+- cloud.google.com/go/privatecatalog: v0.7.0
+- cloud.google.com/go/pubsublite: v1.6.0
+- cloud.google.com/go/recaptchaenterprise/v2: v2.6.0
+- cloud.google.com/go/recommendationengine: v0.7.0
+- cloud.google.com/go/recommender: v1.9.0
+- cloud.google.com/go/redis: v1.11.0
+- cloud.google.com/go/resourcemanager: v1.5.0
+- cloud.google.com/go/resourcesettings: v1.5.0
+- cloud.google.com/go/retail: v1.12.0
+- cloud.google.com/go/run: v0.8.0
+- cloud.google.com/go/scheduler: v1.8.0
+- cloud.google.com/go/secretmanager: v1.10.0
+- cloud.google.com/go/security: v1.12.0
+- cloud.google.com/go/securitycenter: v1.18.1
+- cloud.google.com/go/servicecontrol: v1.11.0
+- cloud.google.com/go/servicedirectory: v1.8.0
+- cloud.google.com/go/servicemanagement: v1.6.0
+- cloud.google.com/go/serviceusage: v1.5.0
+- cloud.google.com/go/shell: v1.6.0
+- cloud.google.com/go/spanner: v1.44.0
+- cloud.google.com/go/speech: v1.14.1
+- cloud.google.com/go/storagetransfer: v1.7.0
+- cloud.google.com/go/talent: v1.5.0
+- cloud.google.com/go/texttospeech: v1.6.0
+- cloud.google.com/go/tpu: v1.5.0
+- cloud.google.com/go/trace: v1.8.0
+- cloud.google.com/go/translate: v1.6.0
+- cloud.google.com/go/video: v1.13.0
+- cloud.google.com/go/videointelligence: v1.10.0
+- cloud.google.com/go/vision/v2: v2.6.0
+- cloud.google.com/go/vmmigration: v1.5.0
+- cloud.google.com/go/vmwareengine: v0.2.2
+- cloud.google.com/go/vpcaccess: v1.6.0
+- cloud.google.com/go/webrisk: v1.8.0
+- cloud.google.com/go/websecurityscanner: v1.5.0
+- cloud.google.com/go/workflows: v1.10.0
+
+### Changed
+- cloud.google.com/go/bigquery: v1.8.0 → v1.48.0
+- cloud.google.com/go/compute: v1.7.0 → v1.18.0
+- cloud.google.com/go/datastore: v1.1.0 → v1.10.0
+- cloud.google.com/go/firestore: v1.1.0 → v1.9.0
+- cloud.google.com/go/iam: v0.3.0 → v0.12.0
+- cloud.google.com/go/kms: v1.4.0 → v1.9.0
+- cloud.google.com/go/logging: v1.0.0 → v1.7.0
+- cloud.google.com/go/pubsub: v1.4.0 → v1.28.0
+- cloud.google.com/go/storage: v1.23.0 → v1.12.0
+- cloud.google.com/go: v0.103.0 → v0.110.0
+- github.com/census-instrumentation/opencensus-proto: [v0.2.1 → v0.4.1](https://github.com/census-instrumentation/opencensus-proto/compare/v0.2.1...v0.4.1)
+- github.com/cespare/xxhash/v2: [v2.1.2 → v2.2.0](https://github.com/cespare/xxhash/v2/compare/v2.1.2...v2.2.0)
+- github.com/cncf/udpa/go: [04548b0 → c52dc94](https://github.com/cncf/udpa/go/compare/04548b0...c52dc94)
+- github.com/cncf/xds/go: [cb28da3 → 32f1caf](https://github.com/cncf/xds/go/compare/cb28da3...32f1caf)
+- github.com/envoyproxy/go-control-plane: [49ff273 → v0.11.0](https://github.com/envoyproxy/go-control-plane/compare/49ff273...v0.11.0)
+- github.com/envoyproxy/protoc-gen-validate: [v0.1.0 → v0.10.0](https://github.com/envoyproxy/protoc-gen-validate/compare/v0.1.0...v0.10.0)
+- github.com/golang/glog: [v1.0.0 → v1.1.0](https://github.com/golang/glog/compare/v1.0.0...v1.1.0)
+- github.com/golang/protobuf: [v1.5.2 → v1.5.3](https://github.com/golang/protobuf/compare/v1.5.2...v1.5.3)
+- github.com/google/go-cmp: [v0.5.8 → v0.5.9](https://github.com/google/go-cmp/compare/v0.5.8...v0.5.9)
+- github.com/googleapis/enterprise-certificate-proxy: [v0.1.0 → v0.2.3](https://github.com/googleapis/enterprise-certificate-proxy/compare/v0.1.0...v0.2.3)
+- github.com/googleapis/gax-go/v2: [v2.4.0 → v2.7.0](https://github.com/googleapis/gax-go/v2/compare/v2.4.0...v2.7.0)
+- github.com/stretchr/objx: [v0.2.0 → v0.5.0](https://github.com/stretchr/objx/compare/v0.2.0...v0.5.0)
+- github.com/stretchr/testify: [v1.7.0 → v1.8.1](https://github.com/stretchr/testify/compare/v1.7.0...v1.8.1)
+- go.opencensus.io: v0.23.0 → v0.24.0
+- golang.org/x/mod: 9b9b3d8 → v0.8.0
+- golang.org/x/net: a158d28 → v0.8.0
+- golang.org/x/oauth2: 128564f → v0.6.0
+- golang.org/x/sync: 0de741c → v0.1.0
+- golang.org/x/sys: 8c9f86f → v0.6.0
+- golang.org/x/term: 03fcf44 → v0.6.0
+- golang.org/x/text: v0.3.7 → v0.8.0
+- golang.org/x/tools: 897bd77 → v0.6.0
+- golang.org/x/xerrors: 65e6541 → 5ec99f8
+- google.golang.org/api: v0.86.0 → v0.110.0
+- google.golang.org/genproto: 176da50 → 7f2fa6f
+- google.golang.org/grpc: v1.48.0 → v1.55.0
+- google.golang.org/protobuf: v1.28.0 → v1.30.0
+
+### Removed
+- github.com/googleapis/go-type-adapters: [v1.0.0](https://github.com/googleapis/go-type-adapters/tree/v1.0.0)
+
 # v1.8.8 - Changelog since v1.8.7
 
 ## Changes by Kind

--- a/CHANGELOG/CHANGELOG-1.9.md
+++ b/CHANGELOG/CHANGELOG-1.9.md
@@ -1,3 +1,169 @@
+# v1.9.8 - Changelog since v1.9.7
+
+## Changes by Kind
+
+### Feature
+
+- Added support in PDCSI driver to create confidential hyperdisk storage on GCE. ([#1318](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1318), [@Sneha-at](https://github.com/Sneha-at))
+
+### Bug or Regression
+
+- Update go version to 1.20.6 to fix CVE-2023-29406 ([#1330](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1330), [@pwschuurman](https://github.com/pwschuurman))
+
+## Dependencies
+
+### Added
+- cloud.google.com/go/accessapproval: v1.5.0
+- cloud.google.com/go/accesscontextmanager: v1.4.0
+- cloud.google.com/go/aiplatform: v1.27.0
+- cloud.google.com/go/analytics: v0.12.0
+- cloud.google.com/go/apigateway: v1.4.0
+- cloud.google.com/go/apigeeconnect: v1.4.0
+- cloud.google.com/go/apigeeregistry: v0.4.0
+- cloud.google.com/go/apikeys: v0.4.0
+- cloud.google.com/go/appengine: v1.5.0
+- cloud.google.com/go/area120: v0.6.0
+- cloud.google.com/go/artifactregistry: v1.9.0
+- cloud.google.com/go/asset: v1.10.0
+- cloud.google.com/go/assuredworkloads: v1.9.0
+- cloud.google.com/go/automl: v1.8.0
+- cloud.google.com/go/baremetalsolution: v0.4.0
+- cloud.google.com/go/batch: v0.4.0
+- cloud.google.com/go/beyondcorp: v0.3.0
+- cloud.google.com/go/billing: v1.7.0
+- cloud.google.com/go/binaryauthorization: v1.4.0
+- cloud.google.com/go/certificatemanager: v1.4.0
+- cloud.google.com/go/channel: v1.9.0
+- cloud.google.com/go/cloudbuild: v1.4.0
+- cloud.google.com/go/clouddms: v1.4.0
+- cloud.google.com/go/cloudtasks: v1.8.0
+- cloud.google.com/go/compute/metadata: v0.2.3
+- cloud.google.com/go/contactcenterinsights: v1.4.0
+- cloud.google.com/go/container: v1.7.0
+- cloud.google.com/go/containeranalysis: v0.6.0
+- cloud.google.com/go/datacatalog: v1.8.0
+- cloud.google.com/go/dataflow: v0.7.0
+- cloud.google.com/go/dataform: v0.5.0
+- cloud.google.com/go/datafusion: v1.5.0
+- cloud.google.com/go/datalabeling: v0.6.0
+- cloud.google.com/go/dataplex: v1.4.0
+- cloud.google.com/go/dataproc: v1.8.0
+- cloud.google.com/go/dataqna: v0.6.0
+- cloud.google.com/go/datastream: v1.5.0
+- cloud.google.com/go/deploy: v1.5.0
+- cloud.google.com/go/dialogflow: v1.29.0
+- cloud.google.com/go/dlp: v1.7.0
+- cloud.google.com/go/documentai: v1.10.0
+- cloud.google.com/go/domains: v0.7.0
+- cloud.google.com/go/edgecontainer: v0.2.0
+- cloud.google.com/go/errorreporting: v0.3.0
+- cloud.google.com/go/essentialcontacts: v1.4.0
+- cloud.google.com/go/eventarc: v1.8.0
+- cloud.google.com/go/filestore: v1.4.0
+- cloud.google.com/go/functions: v1.9.0
+- cloud.google.com/go/gaming: v1.8.0
+- cloud.google.com/go/gkebackup: v0.3.0
+- cloud.google.com/go/gkeconnect: v0.6.0
+- cloud.google.com/go/gkehub: v0.10.0
+- cloud.google.com/go/gkemulticloud: v0.4.0
+- cloud.google.com/go/gsuiteaddons: v1.4.0
+- cloud.google.com/go/iap: v1.5.0
+- cloud.google.com/go/ids: v1.2.0
+- cloud.google.com/go/iot: v1.4.0
+- cloud.google.com/go/language: v1.8.0
+- cloud.google.com/go/lifesciences: v0.6.0
+- cloud.google.com/go/longrunning: v0.3.0
+- cloud.google.com/go/managedidentities: v1.4.0
+- cloud.google.com/go/maps: v0.1.0
+- cloud.google.com/go/mediatranslation: v0.6.0
+- cloud.google.com/go/memcache: v1.7.0
+- cloud.google.com/go/metastore: v1.8.0
+- cloud.google.com/go/monitoring: v1.8.0
+- cloud.google.com/go/networkconnectivity: v1.7.0
+- cloud.google.com/go/networkmanagement: v1.5.0
+- cloud.google.com/go/networksecurity: v0.6.0
+- cloud.google.com/go/notebooks: v1.5.0
+- cloud.google.com/go/optimization: v1.2.0
+- cloud.google.com/go/orchestration: v1.4.0
+- cloud.google.com/go/orgpolicy: v1.5.0
+- cloud.google.com/go/osconfig: v1.10.0
+- cloud.google.com/go/oslogin: v1.7.0
+- cloud.google.com/go/phishingprotection: v0.6.0
+- cloud.google.com/go/policytroubleshooter: v1.4.0
+- cloud.google.com/go/privatecatalog: v0.6.0
+- cloud.google.com/go/pubsublite: v1.5.0
+- cloud.google.com/go/recaptchaenterprise/v2: v2.5.0
+- cloud.google.com/go/recommendationengine: v0.6.0
+- cloud.google.com/go/recommender: v1.8.0
+- cloud.google.com/go/redis: v1.10.0
+- cloud.google.com/go/resourcemanager: v1.4.0
+- cloud.google.com/go/resourcesettings: v1.4.0
+- cloud.google.com/go/retail: v1.11.0
+- cloud.google.com/go/run: v0.3.0
+- cloud.google.com/go/scheduler: v1.7.0
+- cloud.google.com/go/secretmanager: v1.9.0
+- cloud.google.com/go/security: v1.10.0
+- cloud.google.com/go/securitycenter: v1.16.0
+- cloud.google.com/go/servicecontrol: v1.5.0
+- cloud.google.com/go/servicedirectory: v1.7.0
+- cloud.google.com/go/servicemanagement: v1.5.0
+- cloud.google.com/go/serviceusage: v1.4.0
+- cloud.google.com/go/shell: v1.4.0
+- cloud.google.com/go/spanner: v1.41.0
+- cloud.google.com/go/speech: v1.9.0
+- cloud.google.com/go/storagetransfer: v1.6.0
+- cloud.google.com/go/talent: v1.4.0
+- cloud.google.com/go/texttospeech: v1.5.0
+- cloud.google.com/go/tpu: v1.4.0
+- cloud.google.com/go/trace: v1.4.0
+- cloud.google.com/go/translate: v1.4.0
+- cloud.google.com/go/video: v1.9.0
+- cloud.google.com/go/videointelligence: v1.9.0
+- cloud.google.com/go/vision/v2: v2.5.0
+- cloud.google.com/go/vmmigration: v1.3.0
+- cloud.google.com/go/vmwareengine: v0.1.0
+- cloud.google.com/go/vpcaccess: v1.5.0
+- cloud.google.com/go/webrisk: v1.7.0
+- cloud.google.com/go/websecurityscanner: v1.4.0
+- cloud.google.com/go/workflows: v1.9.0
+
+### Changed
+- cloud.google.com/go/bigquery: v1.8.0 → v1.44.0
+- cloud.google.com/go/compute: v1.7.0 → v1.18.0
+- cloud.google.com/go/datastore: v1.1.0 → v1.10.0
+- cloud.google.com/go/firestore: v1.1.0 → v1.9.0
+- cloud.google.com/go/iam: v0.3.0 → v0.11.0
+- cloud.google.com/go/kms: v1.4.0 → v1.6.0
+- cloud.google.com/go/logging: v1.0.0 → v1.6.1
+- cloud.google.com/go/pubsub: v1.4.0 → v1.27.1
+- cloud.google.com/go/storage: v1.23.0 → v1.12.0
+- cloud.google.com/go: v0.103.0 → v0.107.0
+- github.com/census-instrumentation/opencensus-proto: [v0.2.1 → v0.4.1](https://github.com/census-instrumentation/opencensus-proto/compare/v0.2.1...v0.4.1)
+- github.com/cespare/xxhash/v2: [v2.1.2 → v2.2.0](https://github.com/cespare/xxhash/v2/compare/v2.1.2...v2.2.0)
+- github.com/cncf/udpa/go: [04548b0 → c52dc94](https://github.com/cncf/udpa/go/compare/04548b0...c52dc94)
+- github.com/cncf/xds/go: [cb28da3 → 06c439d](https://github.com/cncf/xds/go/compare/cb28da3...06c439d)
+- github.com/envoyproxy/go-control-plane: [49ff273 → v0.10.3](https://github.com/envoyproxy/go-control-plane/compare/49ff273...v0.10.3)
+- github.com/envoyproxy/protoc-gen-validate: [v0.1.0 → v0.9.1](https://github.com/envoyproxy/protoc-gen-validate/compare/v0.1.0...v0.9.1)
+- github.com/googleapis/enterprise-certificate-proxy: [v0.1.0 → v0.2.3](https://github.com/googleapis/enterprise-certificate-proxy/compare/v0.1.0...v0.2.3)
+- github.com/googleapis/gax-go/v2: [v2.4.0 → v2.7.0](https://github.com/googleapis/gax-go/v2/compare/v2.4.0...v2.7.0)
+- github.com/stretchr/objx: [v0.2.0 → v0.5.0](https://github.com/stretchr/objx/compare/v0.2.0...v0.5.0)
+- github.com/stretchr/testify: [v1.7.0 → v1.8.1](https://github.com/stretchr/testify/compare/v1.7.0...v1.8.1)
+- go.opencensus.io: v0.23.0 → v0.24.0
+- golang.org/x/net: v0.5.0 → v0.7.0
+- golang.org/x/oauth2: 128564f → v0.5.0
+- golang.org/x/sync: 0de741c → v0.1.0
+- golang.org/x/sys: v0.4.0 → v0.5.0
+- golang.org/x/term: v0.4.0 → v0.5.0
+- golang.org/x/text: v0.6.0 → v0.7.0
+- golang.org/x/xerrors: 65e6541 → 5ec99f8
+- google.golang.org/api: v0.86.0 → v0.111.0
+- google.golang.org/genproto: 176da50 → 637eb22
+- google.golang.org/grpc: v1.48.0 → v1.53.0
+- google.golang.org/protobuf: v1.28.0 → v1.28.1
+
+### Removed
+- github.com/googleapis/go-type-adapters: [v1.0.0](https://github.com/googleapis/go-type-adapters/tree/v1.0.0)
+
 # v1.9.7 - Changelog since v1.9.6
 
 ## Changes by Kind
@@ -9,9 +175,7 @@
 ### Uncategorized
 
 - Add disk type for all operations metrics. ([#1296](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1296), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
-- Fix provisioned-iops-on-create passing logic ([#1283](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1283), [@sunnylovestiramisu](https://github.com/sunnylovestiramisu))
 - Use original error code when responding with a backoff error on publish or unpublish. ([#1312](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1312), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
-
 
 # v1.9.6 - Changelog since v1.9.5
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Update release specific changelog for recent gcp-compute-persistent-disk-csi-driver releases

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
