### PR TITLE
Update test/run-e2e.sh to match PROW configuration

### DIFF
--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -5,4 +5,4 @@ set -x
 
 readonly PKGDIR=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 
-go test --timeout 20m --v "${PKGDIR}/test/e2e/tests" --run-in-prow=true --delete-instances=true --logtostderr
+go test --timeout 30m --v "${PKGDIR}/test/e2e/tests" --run-in-prow=true --delete-instances=true --logtostderr


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
The Prow job test timeout was updated in https://github.com/kubernetes/test-infra/pull/30158. This updates the corresponding script to use a go test timeout of 30 minutes.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
