### PR TITLE
Fix zone specification in HdT tests

### DIFF
--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -276,10 +276,6 @@ var _ = Describe("GCE PD CSI Driver", func() {
 			client := testContext.Client
 			instance := testContext.Instance
 
-			if diskType == hdtDiskType {
-				z = "us-east4-a"
-			}
-
 			volName, _ := createAndValidateUniqueZonalDisk(client, p, z, diskType)
 
 			underSpecifiedID := common.GenerateUnderspecifiedVolumeID(volName, true /* isZonal */)


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:
The zone specification was mistakenly added, HdT is available in both the two test zones:

```
➜  ~ gcloud compute disk-types list --filter="zone:( us-east4-a)" --project xxxxxxx
NAME                  ZONE        VALID_DISK_SIZES
hyperdisk-extreme     us-east4-a  64GB-65536GB
hyperdisk-throughput  us-east4-a  2048GB-32768GB
local-ssd             us-east4-a  375GB-375GB
pd-balanced           us-east4-a  10GB-65536GB
pd-extreme            us-east4-a  500GB-65536GB
pd-ssd                us-east4-a  10GB-65536GB
pd-standard           us-east4-a  10GB-65536GB
➜  ~ gcloud compute disk-types list --filter="zone:( us-east4-c)" --project xxxxxxx
NAME                  ZONE        VALID_DISK_SIZES
hyperdisk-extreme     us-east4-c  64GB-65536GB
hyperdisk-throughput  us-east4-c  2048GB-32768GB
local-ssd             us-east4-c  375GB-375GB
pd-balanced           us-east4-c  10GB-65536GB
pd-extreme            us-east4-c  500GB-65536GB
pd-ssd                us-east4-c  10GB-65536GB
pd-standard           us-east4-c  10GB-65536GB
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Fix zone specification in HdT tests
```
