### PR TITLE
Automated cherry pick of #1354: Add pwschuurman as reviewer/approver to

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,7 @@ reviewers:
   - msau42
   - saad-ali
   - saikat-royc
+  - pwschuurman
 approvers:
   - davidz627
   - jingxu97
@@ -12,3 +13,4 @@ approvers:
   - msau42
   - saad-ali
   - saikat-royc
+  - pwschuurman


### PR DESCRIPTION
Cherry pick of #1354 on release-1.8.

#1354: Add pwschuurman@ as reviewer/approver to OWNERS

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```