### PR TITLE
Update changelog for release v1.11.1, v1.10.7, v1.9.9, v1.8.10, v1.7.12

### DIFF
--- a/CHANGELOG/CHANGELOG-1.10.md
+++ b/CHANGELOG/CHANGELOG-1.10.md
@@ -1,3 +1,11 @@
+# v1.10.7 - Changelog since v1.10.6
+
+## Changes by Kind
+
+### Uncategorized
+
+- Update go version to 1.20.7 to fix CVE-2023-29409 CVE-2023-39533 ([#1348](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1348), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
+
 # v1.10.6 - Changelog since v1.10.5
 
 ## Changes by Kind

--- a/CHANGELOG/CHANGELOG-1.11.md
+++ b/CHANGELOG/CHANGELOG-1.11.md
@@ -1,3 +1,15 @@
+# v1.11.1 - Changelog since v1.11.0
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Update go version to 1.20.7 to fix CVE-2023-29409 CVE-2023-39533 ([#1347](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1347), [@Sneha-at](https://github.com/Sneha-at))
+
+### Uncategorized
+
+- Fix zone specification in HdT tests ([#1341](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1341), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
+
 # v1.11.0 - Changelog since v1.10.5
 
 ## Changes by Kind

--- a/CHANGELOG/CHANGELOG-1.7.md
+++ b/CHANGELOG/CHANGELOG-1.7.md
@@ -1,3 +1,11 @@
+# v1.7.12 - Changelog since v1.7.11
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Update go version to 1.19.12 to fix CVE-2023-29409 CVE-2023-39533 ([#1351](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1351), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
+
 # v1.7.11 - Changelog since v1.7.10
 
 ## Changes by Kind
@@ -8,6 +16,9 @@
 
 ### Uncategorized
 
+- #1101: Add provisionedThroughput for hyperdisk
+  #1227: Adding new metric pdcsi_operation_errors to fetch error
+  #1296: emit metrics even for success scenarios ([#1305](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1305), [@sunnylovestiramisu](https://github.com/sunnylovestiramisu))
 - Use errors.As so we can detect wrapped errors, and check for existing error codes in CodesForError ([#1326](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1326), [@judemars](https://github.com/judemars))
 
 # v1.7.10 - Changelog since v1.7.9

--- a/CHANGELOG/CHANGELOG-1.7.md
+++ b/CHANGELOG/CHANGELOG-1.7.md
@@ -8,9 +8,6 @@
 
 ### Uncategorized
 
-- #1101: Add provisionedThroughput for hyperdisk
-  #1227: Adding new metric pdcsi_operation_errors to fetch error
-  #1296: emit metrics even for success scenarios ([#1305](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1305), [@sunnylovestiramisu](https://github.com/sunnylovestiramisu))
 - Use errors.As so we can detect wrapped errors, and check for existing error codes in CodesForError ([#1326](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1326), [@judemars](https://github.com/judemars))
 
 # v1.7.10 - Changelog since v1.7.9

--- a/CHANGELOG/CHANGELOG-1.8.md
+++ b/CHANGELOG/CHANGELOG-1.8.md
@@ -7,10 +7,6 @@
 - Update go version to 1.19.11 to fix CVE-2023-29406 ([#1336](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1336), [@Sneha-at](https://github.com/Sneha-at))
 - Updated dependencies to fix CVE-2022-27664, CVE-2022-32149, CVE-2022-41723, CVE-2022-41721 ([#1334](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1334), [@Sneha-at](https://github.com/Sneha-at))
 
-### Uncategorized
-
-- Add disk type for all operations metrics. ([#1297](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1297), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
-
 ## Dependencies
 
 ### Added

--- a/CHANGELOG/CHANGELOG-1.8.md
+++ b/CHANGELOG/CHANGELOG-1.8.md
@@ -1,3 +1,11 @@
+# v1.8.10 - Changelog since v1.8.9
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Update go version to 1.19.12 to fix CVE-2023-29409 CVE-2023-39533 ([#1350](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1350), [@Sneha-at](https://github.com/Sneha-at))
+
 # v1.8.9 - Changelog since v1.8.8
 
 ## Changes by Kind
@@ -6,6 +14,10 @@
 
 - Update go version to 1.19.11 to fix CVE-2023-29406 ([#1336](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1336), [@Sneha-at](https://github.com/Sneha-at))
 - Updated dependencies to fix CVE-2022-27664, CVE-2022-32149, CVE-2022-41723, CVE-2022-41721 ([#1334](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1334), [@Sneha-at](https://github.com/Sneha-at))
+
+### Uncategorized
+
+- Add disk type for all operations metrics. ([#1297](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1297), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
 
 ## Dependencies
 

--- a/CHANGELOG/CHANGELOG-1.9.md
+++ b/CHANGELOG/CHANGELOG-1.9.md
@@ -1,3 +1,15 @@
+# v1.9.9 - Changelog since v1.9.8
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Add option for serializing formatAndMount, including fsck as well as mkfs. ([#1352](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1352), [@mattcary](https://github.com/mattcary))
+
+### Uncategorized
+
+- Update go version to 1.20.7 to fix CVE-2023-29409 CVE-2023-39533 ([#1349](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1349), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
+
 # v1.9.8 - Changelog since v1.9.7
 
 ## Changes by Kind


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Update release specific changelog for recent gcp-compute-persistent-disk-csi-driver releases

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
