### PR TITLE
Update changelog for release v1.8.11, v1.7.13

### DIFF
--- a/CHANGELOG/CHANGELOG-1.7.md
+++ b/CHANGELOG/CHANGELOG-1.7.md
@@ -1,3 +1,11 @@
+# v1.7.13 - Changelog since v1.7.12
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Upgrade google.golang.org/grpc from v1.55.0 -> v1.55.1 to address https://github.com/grpc/grpc-go/issues/6373 ([#1373](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1373), [@pwschuurman](https://github.com/pwschuurman))
+
 # v1.7.12 - Changelog since v1.7.11
 
 ## Changes by Kind

--- a/CHANGELOG/CHANGELOG-1.8.md
+++ b/CHANGELOG/CHANGELOG-1.8.md
@@ -1,3 +1,11 @@
+# v1.8.11 - Changelog since v1.8.10
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Upgrade google.golang.org/grpc from v1.55.0 -> v1.55.1 to address https://github.com/grpc/grpc-go/issues/6373 ([#1371](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1371), [@pwschuurman](https://github.com/pwschuurman))
+
 # v1.8.10 - Changelog since v1.8.9
 
 ## Changes by Kind


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Update release specific changelog for recent gcp-compute-persistent-disk-csi-driver releases

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
