### PR TITLE
Update mentions of testgrid dashboard link

### DIFF
--- a/docs/release/overlays.md
+++ b/docs/release/overlays.md
@@ -10,7 +10,7 @@ When it comes to creation of overlays there are no strict rules on how overlays 
    * Consider a scenario where the existing `stable-master` overlay needs to be changed for a new kubernetes version.
    * Update the `deploy/kubernetes/images/prow-stable-sidecar-rc-master` directory with appropriate image versions.
    * Update the `deploy/kubernetes/images/prow-stable-sidecar-rc-master` directory. If there are no additional kustomize diff patches to add, no updates are necessary.
-   * At this stage, validate the changes made to the `prow-stable-sidecar-rc-master` overlay. Ensure the upstream testgrids like [this](https://k8s-testgrid.appspot.com/provider-gcp-compute-persistent-disk-csi-driver) are green, and verify with repository maintainers that downstream test grids (e.g GKE internal prow test grids) are green. Care must be taken to avoid directly making changes to `deploy/kubernetes/base` manifests at this stage, as they may impact existing overlays.
+   * At this stage, validate the changes made to the `prow-stable-sidecar-rc-master` overlay. Ensure the upstream testgrids like [this](https://testgrid.k8s.io/provider-gcp-compute-persistent-disk-csi-driver) are green, and verify with repository maintainers that downstream test grids (e.g GKE internal prow test grids) are green. Care must be taken to avoid directly making changes to `deploy/kubernetes/base` manifests at this stage, as they may impact existing overlays.
 
    A sample kustomize patch file would look like this:
 

--- a/release-tools/SIDECAR_RELEASE_PROCESS.md
+++ b/release-tools/SIDECAR_RELEASE_PROCESS.md
@@ -17,7 +17,7 @@ The release manager must:
 Whenever a new Kubernetes minor version is released, our kubernetes-csi CI jobs
 must be updated.
 
-[Our CI jobs](https://k8s-testgrid.appspot.com/sig-storage-csi-ci) have the
+[Our CI jobs](https://testgrid.k8s.io/sig-storage-csi-ci) have the
 naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 
 1. Jobs should be actively monitored to find and fix failures in sidecars and
@@ -90,7 +90,7 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 1. Submit a PR for README changes, in particular, Compatibility, Feature status,
    and any other sections that may need updating.
 1. Check that all [canary CI
-  jobs](https://k8s-testgrid.appspot.com/sig-storage-csi-ci) are passing,
+  jobs](https://testgrid.k8s.io/sig-storage-csi-ci) are passing,
   and that test coverage is adequate for the changes that are going into the release.
 1. Make sure that no new PRs have merged in the meantime, and no PRs are in
    flight and soon to be merged.
@@ -99,7 +99,7 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
    [external-provisioner example](https://github.com/kubernetes-csi/external-provisioner/releases/new)
 1. If release was a new major/minor version, create a new `release-<minor>`
    branch at that commit.
-1. Check [image build status](https://k8s-testgrid.appspot.com/sig-storage-image-build).
+1. Check [image build status](https://testgrid.k8s.io/sig-storage-image-build).
 1. Promote images from k8s-staging-sig-storage to registry.k8s.io/sig-storage. From
    the [k8s image
    repo](https://github.com/kubernetes/k8s.io/tree/HEAD/registry.k8s.io/images/k8s-staging-sig-storage),
@@ -118,7 +118,7 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 
 The following jobs are triggered after tagging to produce the corresponding
 image(s):
-https://k8s-testgrid.appspot.com/sig-storage-image-build
+https://testgrid.k8s.io/sig-storage-image-build
 
 Clicking on a failed build job opens that job in https://prow.k8s.io. Next to
 the job title is a rerun icon (circle with arrow). Clicking it opens a popup


### PR DESCRIPTION
Testgrid dashboard link changed to testgrid.k8s.io

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design

/kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Changes the old testgrid dashboard links (appspot) to the new one (testgrid.k8s.io)

**Which issue(s) this PR fixes**:

Please see https://github.com/kubernetes/test-infra/issues/30370
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**: N/A

**Does this PR introduce a user-facing change?**: 
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
