### PR TITLE
Automated cherry pick of #1406: Change Unavailable error codes that signal a problem with the

### DIFF
--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -886,7 +886,8 @@ func wrapOpErr(name string, opErr *computev1.OperationErrorErrors) error {
 }
 
 // codeForGCEOpError return the grpc error code for the passed in
-// gce operation error.
+// gce operation error. All of these error codes are filtered out from our SLO,
+// but will be monitored by the stockout reporting dashboard.
 func codeForGCEOpError(err computev1.OperationErrorErrors) codes.Code {
 	userErrors := map[string]codes.Code{
 		"RESOURCE_NOT_FOUND":                        codes.NotFound,

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -1902,7 +1902,7 @@ func (b *csiErrorBackoff) code(id csiErrorBackoffId) codes.Code {
 	// If we haven't recorded a code, return unavailable, which signals a problem with the driver
 	// (ie, next() wasn't called correctly).
 	klog.Errorf("using default code for %s", id)
-	return codes.Unavailable
+	return codes.Internal
 }
 
 func (b *csiErrorBackoff) next(id csiErrorBackoffId, code codes.Code) {

--- a/pkg/gce-pd-csi-driver/identity.go
+++ b/pkg/gce-pd-csi-driver/identity.go
@@ -29,7 +29,7 @@ type GCEIdentityServer struct {
 // GetPluginInfo(context.Context, *GetPluginInfoRequest) (*GetPluginInfoResponse, error)
 func (gceIdentity *GCEIdentityServer) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 	if gceIdentity.Driver.name == "" {
-		return nil, status.Error(codes.Unavailable, "Driver name not configured")
+		return nil, status.Error(codes.Internal, "Driver name not configured")
 	}
 
 	return &csi.GetPluginInfoResponse{


### PR DESCRIPTION
Cherry pick of #1406 on release-1.11.

#1406: Change Unavailable error codes that signal a problem with the

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```