### PR TITLE
Initialize flags prior to setting --logtostderr in test/k8s-integration/main.go

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -112,12 +112,11 @@ type testParameters struct {
 }
 
 func init() {
+	klog.InitFlags(nil)
 	flag.Set("logtostderr", "true")
 }
 
 func main() {
-	klog.InitFlags(nil)
-	flag.Set("logtostderr", "true")
 	flag.Parse()
 
 	if *useGKEManagedDriver {


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Fixes CI Integration test that is failing: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-gcp-compute-persistent-disk-csi-driver-latest-k8s-master-integration/1712953895405228032

Test is failing with:

```
panic: flag logtostderr set at /usr/local/google/home/$USER/github_workspaces/gcp-compute-persistent-disk-csi-driver/test/k8s-integration/main.go:115 before being defined
```

The integration test runner sets a flag prior to defining the flag. The test is failing now that latest `gcr.io/k8s-staging-test-infra/kubekins-e2e` image is using go1.21.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
