### PR TITLE
Fix Kubernetes Integration test status icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Latest stable image: `registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-
 | Driver Version | Kubernetes Version | Test Status |
 |----------------|--------------------|-------------|
 | HEAD Latest | HEAD | [<img alt="Test Status" src="https://testgrid.k8s.io/q/summary/provider-gcp-compute-persistent-disk-csi-driver/Kubernetes%20Master%20Driver%20Latest/tests_status" />](https://testgrid.k8s.io/provider-gcp-compute-persistent-disk-csi-driver#Kubernetes%20Master%20Driver%20Latest) |
-| HEAD stable-master | HEAD (Migration ON) | [<img alt="Test Status" src="https://testgrid.k8s.io/q/summary/provider-gcp-compute-persistent-disk-csi-driver/Kubernetes%20Master%20Driver%20Latest%20Release/tests_status" />](https://testgrid.k8s.io/provider-gcp-compute-persistent-disk-csi-driver#Kubernetes%20Master%20Driver%20Latest%20Release%20Candidate) |
+| HEAD stable-master | HEAD (Migration ON) | [<img alt="Test Status" src="https://testgrid.k8s.io/q/summary/provider-gcp-compute-persistent-disk-csi-driver/Kubernetes%20Master%20Driver%20Latest%20Release%20Candidate/tests_status" />](https://testgrid.k8s.io/provider-gcp-compute-persistent-disk-csi-driver#Kubernetes%20Master%20Driver%20Latest%20Release%20Candidate) |
 
 ### CSI Compatibility
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Icon URL is not correct, resulting in a broken image icon.

![Image](https://gist.githubusercontent.com/pwschuurman/4b315f60b4e6293d7fec5b9a842706b7/raw/96185d457e553c960614bb7cef52050ed956650a/image1.png)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
