### PR TITLE
Add Groups in Dependabot for the Rest Dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,17 @@ updates:
         - "k8s.io*"
         - "sigs.k8s.io*"
         - "github.com/kubernetes-csi*"
+    github-dependencies:
+      patterns:
+        - "*"
+      exclude-patterns:
+        - "golang.org/x*"
+        - "cloud.google.com/go*"
+        - "google.golang.org*"
+        - "github.com/onsi*"
+        - "k8s.io*"
+        - "sigs.k8s.io*"
+        - "github.com/kubernetes-csi*"
   labels:
     - "area/dependency"
     - "release-note-none"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Add groups and we can use [dependabot command like ignore](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates#managing-dependabot-pull-requests-for-grouped-version-updates-with-comment-commands) to exclude packages.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```