### PR TITLE
Automated cherry pick of #1338: Always call LoggedError for errors returned from

### DIFF
--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -590,7 +590,7 @@ func (gceCS *GCEControllerServer) executeControllerPublishVolume(ctx context.Con
 		if gce.IsGCENotFoundError(err) {
 			return nil, status.Errorf(codes.NotFound, "Could not find instance %v: %v", nodeID, err.Error()), diskType
 		}
-		return nil, status.Errorf(codes.Internal, "Failed to get instance: %v", err.Error()), diskType
+		return nil, common.LoggedError("Failed to get instance: ", err), diskType
 	}
 
 	readWrite := "READ_WRITE"
@@ -625,12 +625,12 @@ func (gceCS *GCEControllerServer) executeControllerPublishVolume(ctx context.Con
 			machineType := parseMachineType(instance.MachineType)
 			return nil, status.Errorf(codes.InvalidArgument, "'%s' is not a compatible disk type with the machine type %s, please review the GCP online documentation for available persistent disk options", udErr.DiskType, machineType), diskType
 		}
-		return nil, status.Errorf(codes.Internal, "Failed to Attach: %v", err.Error()), diskType
+		return nil, common.LoggedError("Failed to Attach: ", err), diskType
 	}
 
 	err = gceCS.CloudProvider.WaitForAttach(ctx, project, volKey, instanceZone, instanceName)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Errored during WaitForAttach: %v", err.Error()), diskType
+		return nil, common.LoggedError("Errored during WaitForAttach: ", err), diskType
 	}
 
 	klog.V(4).Infof("ControllerPublishVolume succeeded for disk %v to instance %v", volKey, nodeID)
@@ -722,7 +722,7 @@ func (gceCS *GCEControllerServer) executeControllerUnpublishVolume(ctx context.C
 			klog.Warningf("Treating volume %v as unpublished because node %v could not be found", volKey.String(), instanceName)
 			return &csi.ControllerUnpublishVolumeResponse{}, nil, diskType
 		}
-		return nil, status.Errorf(codes.Internal, "error getting instance: %v", err.Error()), diskType
+		return nil, common.LoggedError("error getting instance: ", err), diskType
 	}
 
 	deviceName, err := common.GetDeviceName(volKey)
@@ -972,7 +972,7 @@ func (gceCS *GCEControllerServer) createPDSnapshot(ctx context.Context, project 
 	snapshot, err = gceCS.CloudProvider.GetSnapshot(ctx, project, snapshotName)
 	if err != nil {
 		if !gce.IsGCEError(err, "notFound") {
-			return nil, status.Errorf(codes.Internal, "Failed to get snapshot: %v", err.Error())
+			return nil, common.LoggedError("Failed to get snapshot: ", err)
 		}
 		// If we could not find the snapshot, we create a new one
 		snapshot, err = gceCS.CloudProvider.CreateSnapshot(ctx, project, volKey, snapshotName, snapshotParams)


### PR DESCRIPTION
Cherry pick of #1338 on release-1.7.

#1338: Always call LoggedError for errors returned from

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
None
```