### PR TITLE
Add error logging when error is encountered fetching a VolumeSnapshotContent source image

### DIFF
--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -1391,6 +1391,7 @@ func (gceCS *GCEControllerServer) getSnapshotByID(ctx context.Context, snapshotI
 				// return empty list if no snapshot is found
 				return &csi.ListSnapshotsResponse{}, nil
 			}
+			return nil, common.LoggedError("Failed to get image snapshot: ", err)
 		}
 		e, err := generateDiskImageEntry(image)
 		if err != nil {

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -294,11 +294,43 @@ func TestListSnapshotsArguments(t *testing.T) {
 			expectedCount: 1,
 		},
 		{
+			name: "valid image",
+			req: &csi.ListSnapshotsRequest{
+				SnapshotId: testImageID + "0",
+			},
+			numSnapshots:  3,
+			numImages:     2,
+			expectedCount: 1,
+		},
+		{
 			name: "invalid id",
 			req: &csi.ListSnapshotsRequest{
 				SnapshotId: testSnapshotID + "/foo",
 			},
 			expectedCount: 0,
+		},
+		{
+			name: "invalid image id",
+			req: &csi.ListSnapshotsRequest{
+				SnapshotId: testImageID + "/foo",
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "invalid snapshot name",
+			req: &csi.ListSnapshotsRequest{
+				SnapshotId: testSnapshotID + "-invalid-snapshot-",
+			},
+			expectedCount: 0,
+			expErrCode:    codes.InvalidArgument,
+		},
+		{
+			name: "invalid image name",
+			req: &csi.ListSnapshotsRequest{
+				SnapshotId: testImageID + "-invalid-image-",
+			},
+			expectedCount: 0,
+			expErrCode:    codes.InvalidArgument,
 		},
 		{
 			name: "no id",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Errors from the GCE images.get API call are not properly wrapped. This prevents error messages from being transparently displayed on a VolumeSnapshotContent, results in driver nil-ptr dereference and can result in Kubernetes sidecars to also restart.

**Which issue(s) this PR fixes**:
Fixes #1513

**Does this PR introduce a user-facing change?**:
```release-note
Properly wrap error from GCE Images.Get() API call, to fix a potential nil-ptr dereference
```
