### PR TITLE
Use GCE Alpha API to create zonal disks when Storage Pools is enabled

### DIFF
--- a/pkg/common/parameters.go
+++ b/pkg/common/parameters.go
@@ -31,6 +31,7 @@ const (
 	ParameterKeyProvisionedThroughputOnCreate = "provisioned-throughput-on-create"
 	ParameterAvailabilityClass                = "availability-class"
 	ParameterKeyEnableConfidentialCompute     = "enable-confidential-storage"
+	ParameterKeyStoragePools                  = "storage-pools"
 
 	// Parameters for VolumeSnapshotClass
 	ParameterKeyStorageLocations = "storage-locations"
@@ -94,6 +95,9 @@ type DiskParameters struct {
 	EnableConfidentialCompute bool
 	// Default: false
 	ForceAttach bool
+	// Values: {[]string}
+	// Default: ""
+	StoragePools []string
 }
 
 // SnapshotParameters contains normalized and defaulted parameters for snapshots
@@ -183,12 +187,17 @@ func ExtractAndDefaultParameters(parameters map[string]string, driverName string
 			if paramEnableConfidentialCompute {
 				// DiskEncryptionKmsKey is needed to enable confidentialStorage
 				if val, ok := parameters[ParameterKeyDiskEncryptionKmsKey]; !ok || !isValidDiskEncryptionKmsKey(val) {
-					return p, fmt.Errorf("Valid %v is required to enbale ConfidentialStorage", ParameterKeyDiskEncryptionKmsKey)
+					return p, fmt.Errorf("Valid %v is required to enable ConfidentialStorage", ParameterKeyDiskEncryptionKmsKey)
 				}
 			}
 
 			p.EnableConfidentialCompute = paramEnableConfidentialCompute
-
+		case ParameterKeyStoragePools:
+			storagePools, err := ParseStoragePools(v)
+			if err != nil {
+				return p, fmt.Errorf("parameters contain invalid value for %s parameter: %w", ParameterKeyStoragePools, err)
+			}
+			p.StoragePools = storagePools
 		default:
 			return p, fmt.Errorf("parameters contains invalid option %q", k)
 		}

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -392,3 +392,16 @@ func isValidDiskEncryptionKmsKey(DiskEncryptionKmsKey string) bool {
 	kmsKeyPattern := regexp.MustCompile("projects/[^/]+/locations/([^/]+)/keyRings/[^/]+/cryptoKeys/[^/]+")
 	return kmsKeyPattern.MatchString(DiskEncryptionKmsKey)
 }
+
+// TODO(amacaskill): Implement this function.
+// ParseStoragePools returns an error if none of the given storagePools
+// (delimited by a comma) are in the format
+// projects/project/zones/zone/storagePools/storagePool.
+func ParseStoragePools(storagePools string) ([]string, error) {
+	return nil, status.Errorf(codes.Unimplemented, "")
+}
+
+// TODO(amacaskill): Implement this function.
+func StoragePoolInZone(storagePools []string, zone string) string {
+	return ""
+}

--- a/pkg/gce-cloud-provider/compute/cloud-disk.go
+++ b/pkg/gce-cloud-provider/compute/cloud-disk.go
@@ -18,13 +18,15 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
+	computealpha "google.golang.org/api/compute/v0.alpha"
 	computebeta "google.golang.org/api/compute/v0.beta"
 	computev1 "google.golang.org/api/compute/v1"
 )
 
 type CloudDisk struct {
-	disk     *computev1.Disk
-	betaDisk *computebeta.Disk
+	disk      *computev1.Disk
+	betaDisk  *computebeta.Disk
+	alphaDisk *computealpha.Disk
 }
 
 type CloudDiskType string
@@ -38,6 +40,12 @@ func CloudDiskFromV1(disk *computev1.Disk) *CloudDisk {
 func CloudDiskFromBeta(disk *computebeta.Disk) *CloudDisk {
 	return &CloudDisk{
 		betaDisk: disk,
+	}
+}
+
+func CloudDiskFromAlpha(disk *computealpha.Disk) *CloudDisk {
+	return &CloudDisk{
+		alphaDisk: disk,
 	}
 }
 

--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	computealpha "google.golang.org/api/compute/v0.alpha"
 	computebeta "google.golang.org/api/compute/v0.beta"
 	computev1 "google.golang.org/api/compute/v1"
 	"google.golang.org/grpc/codes"
@@ -51,8 +52,10 @@ type GCEAPIVersion string
 const (
 	// V1 key type
 	GCEAPIVersionV1 GCEAPIVersion = "v1"
-	// Alpha key type
+	// Beta key type
 	GCEAPIVersionBeta GCEAPIVersion = "beta"
+	// Alpha key type
+	GCEAPIVersionAlpha GCEAPIVersion = "alpha"
 )
 
 // AttachDiskBackoff is backoff used to wait for AttachDisk to complete.
@@ -266,13 +269,16 @@ func (cloud *CloudProvider) GetDisk(ctx context.Context, project string, key *me
 		if gceAPIVersion == GCEAPIVersionBeta {
 			disk, err := cloud.getZonalBetaDiskOrError(ctx, project, key.Zone, key.Name)
 			return CloudDiskFromBeta(disk), err
+		} else if gceAPIVersion == GCEAPIVersionAlpha {
+			disk, err := cloud.getZonalAlphaDiskOrError(ctx, project, key.Zone, key.Name)
+			return CloudDiskFromAlpha(disk), err
 		} else {
 			disk, err := cloud.getZonalDiskOrError(ctx, project, key.Zone, key.Name)
 			return CloudDiskFromV1(disk), err
 		}
 	case meta.Regional:
 		if gceAPIVersion == GCEAPIVersionBeta {
-			disk, err := cloud.getRegionalAlphaDiskOrError(ctx, project, key.Region, key.Name)
+			disk, err := cloud.getRegionalBetaDiskOrError(ctx, project, key.Region, key.Name)
 			return CloudDiskFromBeta(disk), err
 		} else {
 			disk, err := cloud.getRegionalDiskOrError(ctx, project, key.Region, key.Name)
@@ -299,6 +305,14 @@ func (cloud *CloudProvider) getRegionalDiskOrError(ctx context.Context, project,
 	return disk, nil
 }
 
+func (cloud *CloudProvider) getZonalAlphaDiskOrError(ctx context.Context, project, volumeZone, volumeName string) (*computealpha.Disk, error) {
+	disk, err := cloud.alphaService.Disks.Get(project, volumeZone, volumeName).Context(ctx).Do()
+	if err != nil {
+		return nil, err
+	}
+	return disk, nil
+}
+
 func (cloud *CloudProvider) getZonalBetaDiskOrError(ctx context.Context, project, volumeZone, volumeName string) (*computebeta.Disk, error) {
 	disk, err := cloud.betaService.Disks.Get(project, volumeZone, volumeName).Context(ctx).Do()
 	if err != nil {
@@ -307,7 +321,7 @@ func (cloud *CloudProvider) getZonalBetaDiskOrError(ctx context.Context, project
 	return disk, nil
 }
 
-func (cloud *CloudProvider) getRegionalAlphaDiskOrError(ctx context.Context, project, volumeRegion, volumeName string) (*computebeta.Disk, error) {
+func (cloud *CloudProvider) getRegionalBetaDiskOrError(ctx context.Context, project, volumeRegion, volumeName string) (*computebeta.Disk, error) {
 	disk, err := cloud.betaService.RegionDisks.Get(project, volumeRegion, volumeName).Context(ctx).Do()
 	if err != nil {
 		return nil, err
@@ -438,6 +452,37 @@ func convertV1DiskToBetaDisk(v1Disk *computev1.Disk, provisionedThroughputOnCrea
 	}
 
 	return betaDisk
+}
+
+func convertV1DiskToAlphaDisk(v1Disk *computev1.Disk, provisionedThroughputOnCreate int64, storagePool string) *computealpha.Disk {
+	// Note: this is an incomplete list. It only includes the fields we use for disk creation.
+	alphaDisk := &computealpha.Disk{
+		Name:             v1Disk.Name,
+		SizeGb:           v1Disk.SizeGb,
+		Description:      v1Disk.Description,
+		Type:             v1Disk.Type,
+		SourceSnapshot:   v1Disk.SourceSnapshot,
+		SourceImage:      v1Disk.SourceImage,
+		SourceImageId:    v1Disk.SourceImageId,
+		SourceSnapshotId: v1Disk.SourceSnapshotId,
+		SourceDisk:       v1Disk.SourceDisk,
+		ReplicaZones:     v1Disk.ReplicaZones,
+		Zone:             v1Disk.Zone,
+		Region:           v1Disk.Region,
+		Status:           v1Disk.Status,
+		SelfLink:         v1Disk.SelfLink,
+	}
+	if v1Disk.ProvisionedIops > 0 {
+		alphaDisk.ProvisionedIops = v1Disk.ProvisionedIops
+	}
+	if provisionedThroughputOnCreate > 0 {
+		alphaDisk.ProvisionedThroughput = provisionedThroughputOnCreate
+	}
+	if storagePool != "" {
+		alphaDisk.StoragePool = storagePool
+	}
+
+	return alphaDisk
 }
 
 func (cloud *CloudProvider) insertRegionalDisk(
@@ -572,6 +617,10 @@ func (cloud *CloudProvider) insertZonalDisk(
 	if multiWriter || containsBetaDiskType(hyperdiskTypes, params.DiskType) {
 		gceAPIVersion = GCEAPIVersionBeta
 	}
+	storagePoolsEnabled := params.StoragePools != nil
+	if storagePoolsEnabled {
+		gceAPIVersion = GCEAPIVersionAlpha
+	}
 
 	diskToCreate := &computev1.Disk{
 		Name:        volKey.Name,
@@ -615,6 +664,22 @@ func (cloud *CloudProvider) insertZonalDisk(
 		betaDiskToCreate.MultiWriter = multiWriter
 		betaDiskToCreate.EnableConfidentialCompute = params.EnableConfidentialCompute
 		insertOp, err = cloud.betaService.Disks.Insert(project, volKey.Zone, betaDiskToCreate).Context(ctx).Do()
+		if insertOp != nil {
+			opName = insertOp.Name
+		}
+	} else if gceAPIVersion == GCEAPIVersionAlpha {
+		var insertOp *computealpha.Operation
+		var storagePool string
+		if storagePoolsEnabled {
+			storagePool = common.StoragePoolInZone(params.StoragePools, diskToCreate.Zone)
+			if storagePool == "" {
+				return status.Errorf(codes.InvalidArgument, "cannot create disk in zone %q: no Storage Pools exist in zone", diskToCreate.Zone)
+			}
+		}
+		alphaDiskToCreate := convertV1DiskToAlphaDisk(diskToCreate, params.ProvisionedThroughputOnCreate, storagePool)
+		alphaDiskToCreate.MultiWriter = multiWriter
+		alphaDiskToCreate.EnableConfidentialCompute = params.EnableConfidentialCompute
+		insertOp, err = cloud.alphaService.Disks.Insert(project, volKey.Zone, alphaDiskToCreate).Context(ctx).Do()
 		if insertOp != nil {
 			opName = insertOp.Name
 		}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
The StoragePool field is only supported in the [GCE Alpha Disk API](https://pkg.go.dev/google.golang.org/api@v0.134.0/compute/v0.alpha#disk). This code can be removed once Storage  Pools is supported on v1/beta.  StoragePools only support zonal disks, so only insertZonalDisk has support for the alphaAPI. Only zonal disks are supported in Storage Pools. CreateVolume implementation for Storage Pools will come in a follow up PR.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
