### PR TITLE
Make CloudDisk methods compatible with alphaDisk

### DIFF
--- a/pkg/gce-cloud-provider/compute/cloud-disk.go
+++ b/pkg/gce-cloud-provider/compute/cloud-disk.go
@@ -58,6 +58,9 @@ func (d *CloudDisk) LocationType() meta.KeyType {
 	case d.betaDisk != nil:
 		zone = d.betaDisk.Zone
 		region = d.betaDisk.Region
+	case d.alphaDisk != nil:
+		zone = d.alphaDisk.Zone
+		region = d.alphaDisk.Region
 	}
 	switch {
 	case zone != "":
@@ -75,6 +78,8 @@ func (d *CloudDisk) GetUsers() []string {
 		return d.disk.Users
 	case d.betaDisk != nil:
 		return d.betaDisk.Users
+	case d.alphaDisk != nil:
+		return d.alphaDisk.Users
 	default:
 		return nil
 	}
@@ -86,6 +91,8 @@ func (d *CloudDisk) GetName() string {
 		return d.disk.Name
 	case d.betaDisk != nil:
 		return d.betaDisk.Name
+	case d.alphaDisk != nil:
+		return d.alphaDisk.Name
 	default:
 		return ""
 	}
@@ -97,6 +104,8 @@ func (d *CloudDisk) GetKind() string {
 		return d.disk.Kind
 	case d.betaDisk != nil:
 		return d.betaDisk.Kind
+	case d.alphaDisk != nil:
+		return d.alphaDisk.Kind
 	default:
 		return ""
 	}
@@ -108,6 +117,8 @@ func (d *CloudDisk) GetStatus() string {
 		return d.disk.Status
 	case d.betaDisk != nil:
 		return d.betaDisk.Status
+	case d.alphaDisk != nil:
+		return d.alphaDisk.Status
 	default:
 		return "Unknown"
 	}
@@ -123,6 +134,8 @@ func (d *CloudDisk) GetPDType() string {
 		pdType = d.disk.Type
 	case d.betaDisk != nil:
 		pdType = d.betaDisk.Type
+	case d.alphaDisk != nil:
+		pdType = d.alphaDisk.Type
 	default:
 		return ""
 	}
@@ -136,6 +149,8 @@ func (d *CloudDisk) GetSelfLink() string {
 		return d.disk.SelfLink
 	case d.betaDisk != nil:
 		return d.betaDisk.SelfLink
+	case d.alphaDisk != nil:
+		return d.alphaDisk.SelfLink
 	default:
 		return ""
 	}
@@ -147,6 +162,8 @@ func (d *CloudDisk) GetSizeGb() int64 {
 		return d.disk.SizeGb
 	case d.betaDisk != nil:
 		return d.betaDisk.SizeGb
+	case d.alphaDisk != nil:
+		return d.alphaDisk.SizeGb
 	default:
 		return -1
 	}
@@ -160,6 +177,8 @@ func (d *CloudDisk) setSizeGb(size int64) {
 		d.disk.SizeGb = size
 	case d.betaDisk != nil:
 		d.betaDisk.SizeGb = size
+	case d.alphaDisk != nil:
+		d.alphaDisk.SizeGb = size
 	}
 }
 
@@ -169,6 +188,8 @@ func (d *CloudDisk) GetZone() string {
 		return d.disk.Zone
 	case d.betaDisk != nil:
 		return d.betaDisk.Zone
+	case d.alphaDisk != nil:
+		return d.alphaDisk.Zone
 	default:
 		return ""
 	}
@@ -180,6 +201,8 @@ func (d *CloudDisk) GetSnapshotId() string {
 		return d.disk.SourceSnapshotId
 	case d.betaDisk != nil:
 		return d.betaDisk.SourceSnapshotId
+	case d.alphaDisk != nil:
+		return d.alphaDisk.SourceSnapshotId
 	default:
 		return ""
 	}
@@ -191,6 +214,8 @@ func (d *CloudDisk) GetSourceDiskId() string {
 		return d.disk.SourceDiskId
 	case d.betaDisk != nil:
 		return d.betaDisk.SourceDiskId
+	case d.alphaDisk != nil:
+		return d.alphaDisk.SourceDiskId
 	default:
 		return ""
 	}
@@ -202,6 +227,8 @@ func (d *CloudDisk) GetImageId() string {
 		return d.disk.SourceImageId
 	case d.betaDisk != nil:
 		return d.betaDisk.SourceImageId
+	case d.alphaDisk != nil:
+		return d.alphaDisk.SourceImageId
 	default:
 		return ""
 	}
@@ -217,6 +244,10 @@ func (d *CloudDisk) GetKMSKeyName() string {
 		if dek := d.betaDisk.DiskEncryptionKey; dek != nil {
 			return dek.KmsKeyName
 		}
+	case d.alphaDisk != nil:
+		if dek := d.alphaDisk.DiskEncryptionKey; dek != nil {
+			return dek.KmsKeyName
+		}
 	}
 	return ""
 }
@@ -227,6 +258,8 @@ func (d *CloudDisk) GetMultiWriter() bool {
 		return false
 	case d.betaDisk != nil:
 		return d.betaDisk.MultiWriter
+	case d.alphaDisk != nil:
+		return d.alphaDisk.MultiWriter
 	default:
 		return false
 	}
@@ -238,6 +271,21 @@ func (d *CloudDisk) GetEnableConfidentialCompute() bool {
 		return false
 	case d.betaDisk != nil:
 		return d.betaDisk.EnableConfidentialCompute
+	case d.alphaDisk != nil:
+		return d.alphaDisk.EnableConfidentialCompute
+	default:
+		return false
+	}
+}
+
+func (d *CloudDisk) GetEnableStoragePools() bool {
+	switch {
+	case d.disk != nil:
+		return false
+	case d.betaDisk != nil:
+		return false
+	case d.alphaDisk != nil:
+		return d.alphaDisk.StoragePool != ""
 	default:
 		return false
 	}

--- a/pkg/gce-cloud-provider/compute/cloud-disk_test.go
+++ b/pkg/gce-cloud-provider/compute/cloud-disk_test.go
@@ -20,6 +20,7 @@ package gcecloudprovider
 import (
 	"testing"
 
+	computealpha "google.golang.org/api/compute/v0.alpha"
 	computebeta "google.golang.org/api/compute/v0.beta"
 	computev1 "google.golang.org/api/compute/v1"
 )
@@ -55,12 +56,12 @@ func TestGetEnableConfidentialCompute(t *testing.T) {
 			expectedEnableConfidentialCompute: true,
 		},
 		{
-			name:                              "test disk withpit enableConfidentialCompute",
+			name:                              "test disk without enableConfidentialCompute",
 			diskVersion:                       CreateDiskWithConfidentialCompute(false, false, "hyperdisk-balanced"),
 			expectedEnableConfidentialCompute: false,
 		},
 		{
-			name:                              "test disk withpit enableConfidentialCompute",
+			name:                              "test disk without enableConfidentialCompute",
 			diskVersion:                       CreateDiskWithConfidentialCompute(false, false, "pd-standard"),
 			expectedEnableConfidentialCompute: false,
 		},
@@ -74,6 +75,57 @@ func TestGetEnableConfidentialCompute(t *testing.T) {
 		}
 		if confidentialCompute != tc.expectedEnableConfidentialCompute {
 			t.Fatalf("Got confidentialCompute value %t expected %t", confidentialCompute, tc.expectedEnableConfidentialCompute)
+		}
+	}
+}
+
+func TestGetEnableStoragePools(t *testing.T) {
+	testCases := []struct {
+		name                       string
+		cloudDisk                  *CloudDisk
+		expectedEnableStoragePools bool
+	}{
+		{
+			name: "v1 disk returns false",
+			cloudDisk: &CloudDisk{
+				disk: &computev1.Disk{},
+			},
+			expectedEnableStoragePools: false,
+		},
+		{
+			name: "beta disk returns false",
+			cloudDisk: &CloudDisk{
+				betaDisk: &computebeta.Disk{},
+			},
+			expectedEnableStoragePools: false,
+		},
+		{
+			name: "alpha disk without storage pool returns false",
+			cloudDisk: &CloudDisk{
+				alphaDisk: &computealpha.Disk{},
+			},
+			expectedEnableStoragePools: false,
+		},
+		{
+			name: "alpha disk with storage pool returns true",
+			cloudDisk: &CloudDisk{
+				alphaDisk: &computealpha.Disk{
+					StoragePool: "projects/my-project/zones/us-central1-a/storagePools/storagePool-1",
+				},
+			},
+			expectedEnableStoragePools: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Logf("Running test: %v", tc.name)
+		input := "GetEnableStoragePools()"
+		enableStoragePools := tc.cloudDisk.GetEnableStoragePools()
+		if enableStoragePools != tc.expectedEnableStoragePools {
+			t.Fatalf("%s got confidentialCompute value %t expected %t", input, enableStoragePools, tc.expectedEnableStoragePools)
+		}
+		if enableStoragePools != tc.expectedEnableStoragePools {
+			t.Fatalf("%s got confidentialCompute value %t expected %t", input, enableStoragePools, tc.expectedEnableStoragePools)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This PR makes CloudDisk methods compatible with alphaDisk. This is a follow up PR #1524, which added the capability to use the GCE Alpha API to create zonal disks when Storage Pools is enabled. 

This PR also adds the CloudDisk method `GetEnableStoragePools()`, which will be used in a follow up PR in metrics.GetMetricParameters() to add another dimension `enable_storage_pool` to the already existing `csidriver_operation_errors` metric to track the Storage Pool error rate. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
