### PR TITLE
Increase strictness of fully qualified GCP link cleaning in e2e test parsing code

### DIFF
--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -1407,7 +1407,7 @@ func createAndValidateUniqueZonalMultiWriterDisk(client *remote.CsiClient, proje
 }
 
 func cleanSelfLink(selfLink string) string {
-	r, _ := regexp.Compile("https:\\/\\/www.*apis.com\\/.*(v1|beta|alpha)\\/")
+	r, _ := regexp.Compile("https:\\/\\/www.*apis.com\\/[a-z]+\\/(v1|beta|alpha)\\/")
 	return r.ReplaceAllString(selfLink, "")
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Fixes GCP selfLink cleaning code, allowing for projects that end in "v1", "alpha" or "beta" to have their fully qualified links parsed correctly.

**Which issue(s) this PR fixes**:
Fixes #1543

**Special notes for your reviewer**:
The production link cleaning code was fixed in #1302. This just improves the parsing logic for the test. In the production code, this functionality is a private method, and not exported to the test.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
