### PR TITLE
Use volKey.Zone instead of diskToCreate.Zone when finding StoragePoolInZone

### DIFF
--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -676,9 +676,9 @@ func (cloud *CloudProvider) insertZonalDisk(
 		var insertOp *computealpha.Operation
 		var storagePool *common.StoragePool
 		if storagePoolsEnabled {
-			storagePool = common.StoragePoolInZone(params.StoragePools, diskToCreate.Zone)
+			storagePool = common.StoragePoolInZone(params.StoragePools, volKey.Zone)
 			if storagePool == nil {
-				return status.Errorf(codes.InvalidArgument, "cannot create disk in zone %q: no Storage Pools exist in zone", diskToCreate.Zone)
+				return status.Errorf(codes.InvalidArgument, "cannot create disk in zone %q: no Storage Pools exist in zone", volKey.Zone)
 			}
 		}
 		alphaDiskToCreate := convertV1DiskToAlphaDisk(diskToCreate, params.ProvisionedThroughputOnCreate, storagePool)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Use volKey.Zone instead of diskToCreate.Zone when finding StoragePoolInZone. diskToCreate.Zone is not set. 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
