### PR TITLE
Map UNSUPPORTED_OPERATION GCE operation error codes to InvalidArgument

### DIFF
--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -978,6 +978,7 @@ func codeForGCEOpError(err computev1.OperationErrorErrors) codes.Code {
 		"REGION_QUOTA_EXCEEDED":                     codes.ResourceExhausted,
 		"RATE_LIMIT_EXCEEDED":                       codes.ResourceExhausted,
 		"INVALID_USAGE":                             codes.InvalidArgument,
+		"UNSUPPORTED_OPERATION":                     codes.InvalidArgument,
 	}
 	if code, ok := userErrors[err.Code]; ok {
 		return code

--- a/pkg/gce-cloud-provider/compute/gce-compute_test.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute_test.go
@@ -162,7 +162,7 @@ func TestCodeForGCEOpError(t *testing.T) {
 		{
 			name:     "UNSUPPORTED_OPERATION error",
 			inputErr: computev1.OperationErrorErrors{Code: "UNSUPPORTED_OPERATION"},
-			expCode:  codes.Internal,
+			expCode:  codes.InvalidArgument,
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR maps UNSUPPORTED_OPERATION GCE operation error codes to InvalidArgument. Right now, UNSUPPORTED_OPERATION return Internal error codes, which counts against our SLO, but this should not count. 

UNSUPPORTED_OPERATION would be returned with several different user errors. For example: 
- The requested PD disk type (READ_WRITE_ONLY)  is not supported for the requested machine type
- The requested Hyperdisk disk type (READ_WRITE_ONLY)  is not supported for the requested machine type


 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
