### PR TITLE
Revert "Automated cherry pick of #1586: update driver to support staging compute#1609: fix pointer issue for GCE staging support"

### DIFF
--- a/cmd/gce-pd-csi-driver/main.go
+++ b/cmd/gce-pd-csi-driver/main.go
@@ -17,11 +17,8 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
-	"fmt"
 	"math/rand"
-	"net/url"
 	"os"
 	"runtime"
 	"strings"
@@ -41,6 +38,7 @@ import (
 var (
 	cloudConfigFilePath  = flag.String("cloud-config", "", "Path to GCE cloud provider config")
 	endpoint             = flag.String("endpoint", "unix:/tmp/csi.sock", "CSI endpoint")
+	computeEndpoint      = flag.String("compute-endpoint", "", "If set, used as the endpoint for the GCE API.")
 	runControllerService = flag.Bool("run-controller-service", true, "If set to false then the CSI driver does not activate its controller service (default: true)")
 	runNodeService       = flag.Bool("run-node-service", true, "If set to false then the CSI driver does not activate its node service (default: true)")
 	httpEndpoint         = flag.String("http-endpoint", "", "The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled.")
@@ -69,13 +67,12 @@ var (
 
 	maxConcurrentFormatAndMount = flag.Int("max-concurrent-format-and-mount", 1, "If set then format and mount operations are serialized on each node. This is stronger than max-concurrent-format as it includes fsck and other mount operations")
 	formatAndMountTimeout       = flag.Duration("format-and-mount-timeout", 1*time.Minute, "The maximum duration of a format and mount operation before another such operation will be started. Used only if --serialize-format-and-mount")
-	fallbackRequisiteZonesFlag  = flag.String("fallback-requisite-zones", "", "Comma separated list of requisite zones that will be used if there are not sufficient zones present in requisite topologies when provisioning a disk")
 
-	enableStoragePoolsFlag                    = flag.Bool("enable-storage-pools", false, "If set to true, the CSI Driver will allow volumes to be provisioned in Storage Pools")
-	computeEnvironment        gce.Environment = gce.EnvironmentProduction
-	computeEndpoint           *url.URL
-	version                   string
-	allowedComputeEnvironment = []gce.Environment{gce.EnvironmentStaging, gce.EnvironmentProduction}
+	fallbackRequisiteZonesFlag = flag.String("fallback-requisite-zones", "", "Comma separated list of requisite zones that will be used if there are not sufficient zones present in requisite topologies when provisioning a disk")
+
+	enableStoragePoolsFlag = flag.Bool("enable-storage-pools", false, "If set to true, the CSI Driver will allow volumes to be provisioned in Storage Pools")
+
+	version string
 )
 
 const (
@@ -88,8 +85,6 @@ func init() {
 	// Use V(4) for general debug information logging
 	// Use V(5) for GCE Cloud Provider Call informational logging
 	// Use V(6) for extra repeated/polling information
-	enumFlag(&computeEnvironment, "compute-environment", allowedComputeEnvironment, "Operating compute environment")
-	urlFlag(&computeEndpoint, "compute-endpoint", "Compute endpoint")
 	klog.InitFlags(flag.CommandLine)
 	flag.Set("logtostderr", "true")
 }
@@ -97,7 +92,6 @@ func init() {
 func main() {
 	flag.Parse()
 	rand.Seed(time.Now().UnixNano())
-	klog.Infof("Operating compute environment set to: %s and computeEndpoint is set to: %v", computeEnvironment, computeEndpoint)
 	handle()
 	os.Exit(0)
 }
@@ -162,7 +156,7 @@ func handle() {
 	// Initialize requirements for the controller service
 	var controllerServer *driver.GCEControllerServer
 	if *runControllerService {
-		cloudProvider, err := gce.CreateCloudProvider(ctx, version, *cloudConfigFilePath, computeEndpoint, computeEnvironment)
+		cloudProvider, err := gce.CreateCloudProvider(ctx, version, *cloudConfigFilePath, *computeEndpoint)
 		if err != nil {
 			klog.Fatalf("Failed to get cloud provider: %v", err.Error())
 		}
@@ -210,30 +204,4 @@ func handle() {
 	gce.WaitForOpBackoff.Cap = *waitForOpBackoffCap
 
 	gceDriver.Run(*endpoint, *grpcLogCharCap, *enableOtelTracing)
-}
-
-func enumFlag(target *gce.Environment, name string, allowedComputeEnvironment []gce.Environment, usage string) {
-	flag.Func(name, usage, func(flagValue string) error {
-		for _, allowedValue := range allowedComputeEnvironment {
-			if gce.Environment(flagValue) == allowedValue {
-				*target = gce.Environment(flagValue)
-				return nil
-			}
-		}
-		errMsg := fmt.Sprintf(`must be one of %v`, allowedComputeEnvironment)
-		return errors.New(errMsg)
-	})
-
-}
-
-func urlFlag(target **url.URL, name string, usage string) {
-	flag.Func(name, usage, func(flagValue string) error {
-		computeURL, err := url.ParseRequestURI(flagValue)
-		if err == nil {
-			*target = computeURL
-			return nil
-		}
-		klog.Infof("Error parsing endpoint compute endpoint %v", err)
-		return err
-	})
 }

--- a/pkg/gce-cloud-provider/compute/gce_test.go
+++ b/pkg/gce-cloud-provider/compute/gce_test.go
@@ -18,30 +18,14 @@ limitations under the License.
 package gcecloudprovider
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"testing"
-	"time"
 
-	"golang.org/x/oauth2"
-
-	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
 
-type mockTokenSource struct{}
-
-func (*mockTokenSource) Token() (*oauth2.Token, error) {
-	return &oauth2.Token{
-		AccessToken:  "access",
-		TokenType:    "Bearer",
-		RefreshToken: "refresh",
-		Expiry:       time.Now().Add(1 * time.Hour),
-	}, nil
-}
 func TestIsGCEError(t *testing.T) {
 	testCases := []struct {
 		name          string
@@ -99,62 +83,4 @@ func TestIsGCEError(t *testing.T) {
 			t.Fatalf("Got isGCEError '%t', expected '%t'", isGCEError, tc.expIsGCEError)
 		}
 	}
-}
-
-func TestGetComputeVersion(t *testing.T) {
-	testCases := []struct {
-		name               string
-		computeEndpoint    *url.URL
-		computeEnvironment Environment
-		computeVersion     Version
-		expectedEndpoint   string
-		expectError        bool
-	}{
-
-		{
-			name:               "check for production environment",
-			computeEndpoint:    convertStringToURL("https://compute.googleapis.com"),
-			computeEnvironment: EnvironmentProduction,
-			computeVersion:     versionBeta,
-			expectedEndpoint:   "https://compute.googleapis.com/compute/beta/",
-			expectError:        false,
-		},
-		{
-			name:               "check for staging environment",
-			computeEndpoint:    convertStringToURL("https://compute.googleapis.com"),
-			computeEnvironment: EnvironmentStaging,
-			computeVersion:     versionV1,
-			expectedEndpoint:   "https://compute.googleapis.com/compute/staging_v1/",
-			expectError:        false,
-		},
-		{
-			name:               "check for random string as endpoint",
-			computeEndpoint:    convertStringToURL(""),
-			computeEnvironment: "prod",
-			computeVersion:     "v1",
-			expectedEndpoint:   "compute/v1/",
-			expectError:        true,
-		},
-	}
-	for _, tc := range testCases {
-		ctx := context.Background()
-		computeOpts, err := getComputeVersion(ctx, &mockTokenSource{}, tc.computeEndpoint, tc.computeEnvironment, tc.computeVersion)
-		service, _ := compute.NewService(ctx, computeOpts...)
-		gotEndpoint := service.BasePath
-		if err != nil && !tc.expectError {
-			t.Fatalf("Got error %v", err)
-		}
-		if gotEndpoint != tc.expectedEndpoint && !tc.expectError {
-			t.Fatalf("expected endpoint %s, got endpoint %s", tc.expectedEndpoint, gotEndpoint)
-		}
-	}
-
-}
-
-func convertStringToURL(urlString string) *url.URL {
-	parsedURL, err := url.ParseRequestURI(urlString)
-	if err != nil {
-		return nil
-	}
-	return parsedURL
 }

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -159,7 +159,7 @@ const (
 )
 
 var (
-	validResourceApiVersions = map[string]bool{"v1": true, "alpha": true, "beta": true, "staging_v1": true, "staging_beta": true, "staging_alpha": true}
+	validResourceApiVersions = map[string]bool{"v1": true, "alpha": true, "beta": true}
 )
 
 func isDiskReady(disk *gce.CloudDisk) (bool, error) {

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -1280,7 +1280,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		}()
 	})
 
-	It("Should pass if valid compute endpoint is passed in", func() {
+	It("Should pass/fail if valid/invalid compute endpoint is passed in", func() {
 		// gets instance set up w/o compute-endpoint set from test setup
 		_, err := getRandomTestContext().Client.ListVolumes()
 		Expect(err).To(BeNil(), "no error expected when passed valid compute url")
@@ -1294,6 +1294,15 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		}
 
 		klog.Infof("Creating new driver and client for node %s\n", i.GetName())
+
+		// Create new driver and client w/ invalid endpoint
+		tcInvalid, err := testutils.GCEClientAndDriverSetup(i, "invalid-string")
+		if err != nil {
+			klog.Fatalf("Failed to set up Test Context for instance %v: %w", i.GetName(), err)
+		}
+
+		_, err = tcInvalid.Client.ListVolumes()
+		Expect(err.Error()).To(ContainSubstring("no such host"), "expected error when passed invalid compute url")
 
 		// Create new driver and client w/ valid, passed-in endpoint
 		tcValid, err := testutils.GCEClientAndDriverSetup(i, "https://compute.googleapis.com")

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -65,6 +65,7 @@ func GCEClientAndDriverSetup(instance *remote.InstanceInfo, computeEndpoint stri
 	// useful to see what's happening when debugging tests.
 	driverRunCmd := fmt.Sprintf("sh -c '/usr/bin/nohup %s/gce-pd-csi-driver -v=6 --endpoint=%s %s 2> %s/prog.out < /dev/null > /dev/null &'",
 		workspace, endpoint, strings.Join(extra_flags, " "), workspace)
+
 	config := &remote.ClientConfig{
 		PkgPath:      pkgPath,
 		BinPath:      binPath,


### PR DESCRIPTION
Reverts kubernetes-sigs/gcp-compute-persistent-disk-csi-driver#1614

```release-note
NONE
```