### PR TITLE
Automated cherry pick of #1593: Add support for a multi-zone volumeHandle

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -24,4 +24,12 @@ const (
 	VolumeAttributePartition = "partition"
 
 	UnspecifiedValue = "UNSPECIFIED"
+
+	// Keyword indicating a 'multi-zone' volumeHandle. Replaces "zones" in the volumeHandle:
+	// eg: projects/{project}/zones/multi-zone/disks/{name} vs.
+	// projects/{project}/zones/{zone}/disks/{name}
+	MultiZoneValue = "multi-zone"
+
+	// Label that is set on a disk when it is used by a 'multi-zone' VolumeHandle
+	MultiZoneLabel = "goog-gke-multi-zone"
 )

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -478,3 +478,15 @@ func UnorderedSlicesEqual(slice1 []string, slice2 []string) bool {
 	}
 	return true
 }
+
+func VolumeIdAsMultiZone(volumeId string) (string, error) {
+	splitId := strings.Split(volumeId, "/")
+	if len(splitId) != volIDTotalElements {
+		return "", fmt.Errorf("failed to get id components. Expected projects/{project}/zones/{zone}/disks/{name}. Got: %s", volumeId)
+	}
+	if splitId[volIDToplogyKey] != "zones" {
+		return "", fmt.Errorf("expected id to be zonal. Got: %s", volumeId)
+	}
+	splitId[volIDToplogyValue] = MultiZoneValue
+	return strings.Join(splitId, "/"), nil
+}

--- a/pkg/gce-cloud-provider/compute/cloud-disk.go
+++ b/pkg/gce-cloud-provider/compute/cloud-disk.go
@@ -290,3 +290,16 @@ func (d *CloudDisk) GetEnableStoragePools() bool {
 		return false
 	}
 }
+
+func (d *CloudDisk) GetLabels() map[string]string {
+	switch {
+	case d.disk != nil:
+		return d.disk.Labels
+	case d.betaDisk != nil:
+		return d.betaDisk.Labels
+	case d.alphaDisk != nil:
+		return d.alphaDisk.Labels
+	default:
+		return nil
+	}
+}

--- a/pkg/gce-cloud-provider/compute/cloud-disk_test.go
+++ b/pkg/gce-cloud-provider/compute/cloud-disk_test.go
@@ -20,6 +20,7 @@ package gcecloudprovider
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	computealpha "google.golang.org/api/compute/v0.alpha"
 	computebeta "google.golang.org/api/compute/v0.beta"
 	computev1 "google.golang.org/api/compute/v1"
@@ -126,6 +127,50 @@ func TestGetEnableStoragePools(t *testing.T) {
 		}
 		if enableStoragePools != tc.expectedEnableStoragePools {
 			t.Fatalf("%s got confidentialCompute value %t expected %t", input, enableStoragePools, tc.expectedEnableStoragePools)
+		}
+	}
+}
+
+func TestGetLabels(t *testing.T) {
+	testCases := []struct {
+		name       string
+		cloudDisk  *CloudDisk
+		wantLabels map[string]string
+	}{
+		{
+			name: "v1 disk labels",
+			cloudDisk: &CloudDisk{
+				disk: &computev1.Disk{
+					Labels: map[string]string{"foo": "v1", "goog-gke-multi-zone": "true"},
+				},
+			},
+			wantLabels: map[string]string{"foo": "v1", "goog-gke-multi-zone": "true"},
+		},
+		{
+			name: "beta disk labels",
+			cloudDisk: &CloudDisk{
+				betaDisk: &computebeta.Disk{
+					Labels: map[string]string{"bar": "beta", "goog-gke-multi-zone": "true"},
+				},
+			},
+			wantLabels: map[string]string{"bar": "beta", "goog-gke-multi-zone": "true"},
+		},
+		{
+			name: "alpha disk without storage pool returns false",
+			cloudDisk: &CloudDisk{
+				alphaDisk: &computealpha.Disk{
+					Labels: map[string]string{"baz": "alpha", "goog-gke-multi-zone": "true"},
+				},
+			},
+			wantLabels: map[string]string{"baz": "alpha", "goog-gke-multi-zone": "true"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Logf("Running test: %v", tc.name)
+		gotLabels := tc.cloudDisk.GetLabels()
+		if diff := cmp.Diff(tc.wantLabels, gotLabels); diff != "" {
+			t.Errorf("GetLabels() returned unexpected difference (-want +got):\n%s", diff)
 		}
 	}
 }

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -47,8 +47,8 @@ type GCEControllerServer struct {
 	CloudProvider gce.GCECompute
 	Metrics       metrics.MetricsManager
 
-	disks []*compute.Disk
-	seen  map[string]int
+	volumeEntries     []*csi.ListVolumesResponse_Entry
+	volumeEntriesSeen map[string]int
 
 	snapshots      []*csi.ListSnapshotsResponse_Entry
 	snapshotTokens map[string]int
@@ -103,6 +103,25 @@ type GCEControllerServer struct {
 
 	// If set to true, the CSI Driver will allow volumes to be provisioned in Storage Pools.
 	enableStoragePools bool
+
+	multiZoneVolumeHandleConfig MultiZoneVolumeHandleConfig
+}
+
+type MultiZoneVolumeHandleConfig struct {
+	// A set of supported disk types that are compatible with multi-zone volumeHandles.
+	// The disk type is only validated on ControllerPublish.
+	// Other operations that interacti with volumeHandle (ListVolumes/ControllerUnpublish)
+	// don't validate the disk type. This ensures existing published multi-zone volumes
+	// are listed and unpublished correctly. This allows this flag
+	// to be ratcheted to be more restricted without affecting volumes that are already
+	// published.
+	DiskTypes []string
+
+	// If set to true, the CSI driver will enable the multi-zone volumeHandle feature.
+	// If set to false, volumeHandles that contain 'multi-zone' will not be translated
+	// to their respective attachment zone (based on the node), which will result in
+	// an "Unknown zone" error on ControllerPublish/ControllerUnpublish.
+	Enable bool
 }
 
 type csiErrorBackoffId string
@@ -588,6 +607,25 @@ func parseMachineType(machineTypeUrl string) string {
 	return machineType
 }
 
+func convertMultiZoneVolKeyToZoned(volumeKey *meta.Key, instanceZone string) *meta.Key {
+	volumeKey.Zone = instanceZone
+	return volumeKey
+}
+
+func (gceCS *GCEControllerServer) validateMultiZoneDisk(volumeID string, disk *gce.CloudDisk) error {
+	if !slices.Contains(gceCS.multiZoneVolumeHandleConfig.DiskTypes, disk.GetPDType()) {
+		return status.Errorf(codes.InvalidArgument, "Multi-zone volumeID %q points to disk with unsupported disk type %q: %v", volumeID, disk.GetPDType(), disk.GetSelfLink())
+	}
+	if _, ok := disk.GetLabels()[common.MultiZoneLabel]; !ok {
+		return status.Errorf(codes.InvalidArgument, "Multi-zone volumeID %q points to disk that is missing label %q: %v", volumeID, common.MultiZoneLabel, disk.GetSelfLink())
+	}
+	return nil
+}
+
+func isMultiZoneVolKey(volumeKey *meta.Key) bool {
+	return volumeKey.Type() == meta.Zonal && volumeKey.Zone == common.MultiZoneValue
+}
+
 func (gceCS *GCEControllerServer) executeControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error, *gce.CloudDisk) {
 	project, volKey, pdcsiContext, err := gceCS.validateControllerPublishVolumeRequest(ctx, req)
 	if err != nil {
@@ -601,6 +639,21 @@ func (gceCS *GCEControllerServer) executeControllerPublishVolume(ctx context.Con
 
 	pubVolResp := &csi.ControllerPublishVolumeResponse{
 		PublishContext: nil,
+	}
+
+	instanceZone, instanceName, err := common.NodeIDToZoneAndName(nodeID)
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "could not split nodeID: %v", err.Error()), nil
+	}
+
+	volumeIsMultiZone := isMultiZoneVolKey(volKey)
+	if gceCS.multiZoneVolumeHandleConfig.Enable && volumeIsMultiZone {
+		// Only allow read-only attachment for "multi-zone" volumes
+		if !readOnly {
+			return nil, status.Errorf(codes.InvalidArgument, "'multi-zone' volume only supports 'readOnly': %v", volumeID), nil
+		}
+
+		volKey = convertMultiZoneVolKeyToZoned(volKey, instanceZone)
 	}
 
 	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey)
@@ -625,16 +678,18 @@ func (gceCS *GCEControllerServer) executeControllerPublishVolume(ctx context.Con
 		}
 		return nil, common.LoggedError("Failed to getDisk: ", err), disk
 	}
-	instanceZone, instanceName, err := common.NodeIDToZoneAndName(nodeID)
-	if err != nil {
-		return nil, status.Errorf(codes.NotFound, "could not split nodeID: %v", err.Error()), disk
-	}
 	instance, err := gceCS.CloudProvider.GetInstanceOrError(ctx, instanceZone, instanceName)
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
 			return nil, status.Errorf(codes.NotFound, "Could not find instance %v: %v", nodeID, err.Error()), disk
 		}
 		return nil, common.LoggedError("Failed to get instance: ", err), disk
+	}
+
+	if gceCS.multiZoneVolumeHandleConfig.Enable && volumeIsMultiZone {
+		if err := gceCS.validateMultiZoneDisk(volumeID, disk); err != nil {
+			return nil, err, disk
+		}
 	}
 
 	readWrite := "READ_WRITE"
@@ -739,6 +794,16 @@ func (gceCS *GCEControllerServer) executeControllerUnpublishVolume(ctx context.C
 
 	volumeID := req.GetVolumeId()
 	nodeID := req.GetNodeId()
+
+	instanceZone, instanceName, err := common.NodeIDToZoneAndName(nodeID)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "could not split nodeID: %v", err.Error()), nil
+	}
+
+	if gceCS.multiZoneVolumeHandleConfig.Enable && isMultiZoneVolKey(volKey) {
+		volKey = convertMultiZoneVolKeyToZoned(volKey, instanceZone)
+	}
+
 	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey)
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
@@ -756,10 +821,6 @@ func (gceCS *GCEControllerServer) executeControllerUnpublishVolume(ctx context.C
 	}
 	defer gceCS.volumeLocks.Release(lockingVolumeID)
 	diskToUnpublish, _ := gceCS.CloudProvider.GetDisk(ctx, project, volKey, gce.GCEAPIVersionV1)
-	instanceZone, instanceName, err := common.NodeIDToZoneAndName(nodeID)
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "could not split nodeID: %v", err.Error()), diskToUnpublish
-	}
 	instance, err := gceCS.CloudProvider.GetInstanceOrError(ctx, instanceZone, instanceName)
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
@@ -810,6 +871,7 @@ func (gceCS *GCEControllerServer) ValidateVolumeCapabilities(ctx context.Context
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "Volume ID is invalid: %v", err.Error())
 	}
+
 	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey)
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
@@ -879,8 +941,9 @@ func (gceCS *GCEControllerServer) ListVolumes(ctx context.Context, req *csi.List
 			"ListVolumes got max entries request %v. GCE only supports values >0", req.MaxEntries)
 	}
 
-	offset := 0
+	offsetLow := 0
 	var ok bool
+	var volumeEntries []*csi.ListVolumesResponse_Entry
 	if req.StartingToken == "" {
 		diskList, _, err := gceCS.CloudProvider.ListDisks(ctx)
 		if err != nil {
@@ -889,10 +952,14 @@ func (gceCS *GCEControllerServer) ListVolumes(ctx context.Context, req *csi.List
 			}
 			return nil, common.LoggedError("Failed to list disk: ", err)
 		}
-		gceCS.disks = diskList
-		gceCS.seen = map[string]int{}
+		volumeEntries = gceCS.disksToVolumeEntries(diskList)
+	}
+
+	if req.StartingToken == "" {
+		gceCS.volumeEntries = volumeEntries
+		gceCS.volumeEntriesSeen = map[string]int{}
 	} else {
-		offset, ok = gceCS.seen[req.StartingToken]
+		offsetLow, ok = gceCS.volumeEntriesSeen[req.StartingToken]
 		if !ok {
 			return nil, status.Errorf(codes.Aborted, "ListVolumes error with invalid startingToken: %s", req.StartingToken)
 		}
@@ -903,9 +970,50 @@ func (gceCS *GCEControllerServer) ListVolumes(ctx context.Context, req *csi.List
 		maxEntries = maxListVolumesResponseEntries
 	}
 
+	nextToken := ""
+	offsetHigh := offsetLow + maxEntries
+	if offsetHigh < len(gceCS.volumeEntries) {
+		nextToken = string(uuid.NewUUID())
+		gceCS.volumeEntriesSeen[nextToken] = offsetHigh
+	} else {
+		offsetHigh = len(gceCS.volumeEntries)
+	}
+
+	return &csi.ListVolumesResponse{
+		Entries:   gceCS.volumeEntries[offsetLow:offsetHigh],
+		NextToken: nextToken,
+	}, nil
+}
+
+// isMultiZoneDisk returns the multi-zone volumeId of a disk if it is
+// "multi-zone", otherwise returns an empty string
+// The second parameter indiciates if it is a "multi-zone" disk
+func isMultiZoneDisk(diskRsrc string, diskLabels map[string]string) (string, bool) {
+	isMultiZoneDisk := false
+	for l := range diskLabels {
+		if l == common.MultiZoneLabel {
+			isMultiZoneDisk = true
+		}
+	}
+	if !isMultiZoneDisk {
+		return "", false
+	}
+
+	multiZoneVolumeId, err := common.VolumeIdAsMultiZone(diskRsrc)
+	if err != nil {
+		klog.Warningf("Error converting multi-zone volume handle for disk %s, skipped: %v", diskRsrc, err)
+		return "", false
+	}
+	return multiZoneVolumeId, true
+}
+
+// disksToVolumeEntries converts a list of disks to a list of CSI ListVolumeResponse entries
+// It appends "multi-zone" volumeHandles at the end. These are volumeHandles which
+// map to multiple volumeHandles in different zones
+func (gceCS *GCEControllerServer) disksToVolumeEntries(disks []*compute.Disk) []*csi.ListVolumesResponse_Entry {
+	multiZoneNodesByVolumeId := map[string][]string{}
 	entries := []*csi.ListVolumesResponse_Entry{}
-	for i := 0; i+offset < len(gceCS.disks) && i < maxEntries; i++ {
-		d := gceCS.disks[i+offset]
+	for _, d := range disks {
 		diskRsrc, err := getResourceId(d.SelfLink)
 		if err != nil {
 			klog.Warningf("Bad ListVolumes disk resource %s, skipped: %v (%+v)", d.SelfLink, err, d)
@@ -920,6 +1028,16 @@ func (gceCS *GCEControllerServer) ListVolumes(ctx context.Context, req *csi.List
 				users = append(users, rsrc)
 			}
 		}
+
+		if gceCS.multiZoneVolumeHandleConfig.Enable {
+			if multiZoneVolumeId, isMultiZone := isMultiZoneDisk(diskRsrc, d.Labels); isMultiZone {
+				_, ok := multiZoneNodesByVolumeId[multiZoneVolumeId]
+				if !ok {
+					multiZoneNodesByVolumeId[multiZoneVolumeId] = []string{}
+				}
+				multiZoneNodesByVolumeId[multiZoneVolumeId] = append(multiZoneNodesByVolumeId[multiZoneVolumeId], users...)
+			}
+		}
 		entries = append(entries, &csi.ListVolumesResponse_Entry{
 			Volume: &csi.Volume{
 				VolumeId: diskRsrc,
@@ -929,17 +1047,17 @@ func (gceCS *GCEControllerServer) ListVolumes(ctx context.Context, req *csi.List
 			},
 		})
 	}
-
-	nextToken := ""
-	if len(entries)+offset < len(gceCS.disks) {
-		nextToken = string(uuid.NewUUID())
-		gceCS.seen[nextToken] = len(entries) + offset
+	for volumeId, nodeIds := range multiZoneNodesByVolumeId {
+		entries = append(entries, &csi.ListVolumesResponse_Entry{
+			Volume: &csi.Volume{
+				VolumeId: volumeId,
+			},
+			Status: &csi.ListVolumesResponse_VolumeStatus{
+				PublishedNodeIds: nodeIds,
+			},
+		})
 	}
-
-	return &csi.ListVolumesResponse{
-		Entries:   entries,
-		NextToken: nextToken,
-	}, nil
+	return entries
 }
 
 func (gceCS *GCEControllerServer) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -67,6 +67,7 @@ var (
 
 	testVolumeID           = fmt.Sprintf("projects/%s/zones/%s/disks/%s", project, zone, name)
 	underspecifiedVolumeID = fmt.Sprintf("projects/UNSPECIFIED/zones/UNSPECIFIED/disks/%s", name)
+	multiZoneVolumeID      = fmt.Sprintf("projects/%s/zones/multi-zone/disks/%s", project, name)
 
 	region, _      = common.GetRegionFromZones([]string{zone})
 	testRegionalID = fmt.Sprintf("projects/%s/regions/%s/disks/%s", project, region, name)
@@ -3781,10 +3782,10 @@ func backoffDriver(t *testing.T, config *backoffDriverConfig) *GCEDriver {
 
 	driver := GetGCEDriver()
 	driver.cs = &GCEControllerServer{
-		Driver:       driver,
-		seen:         map[string]int{},
-		volumeLocks:  common.NewVolumeLocks(),
-		errorBackoff: newFakeCSIErrorBackoff(config.clock),
+		Driver:            driver,
+		volumeEntriesSeen: map[string]int{},
+		volumeLocks:       common.NewVolumeLocks(),
+		errorBackoff:      newFakeCSIErrorBackoff(config.clock),
 	}
 
 	driver.cs.CloudProvider = fcp

--- a/pkg/gce-pd-csi-driver/gce-pd-driver.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver.go
@@ -152,15 +152,16 @@ func NewNodeServer(gceDriver *GCEDriver, mounter *mount.SafeFormatAndMount, devi
 	}
 }
 
-func NewControllerServer(gceDriver *GCEDriver, cloudProvider gce.GCECompute, errorBackoffInitialDuration, errorBackoffMaxDuration time.Duration, fallbackRequisiteZones []string, enableStoragePools bool) *GCEControllerServer {
+func NewControllerServer(gceDriver *GCEDriver, cloudProvider gce.GCECompute, errorBackoffInitialDuration, errorBackoffMaxDuration time.Duration, fallbackRequisiteZones []string, enableStoragePools bool, multiZoneVolumeHandleConfig MultiZoneVolumeHandleConfig) *GCEControllerServer {
 	return &GCEControllerServer{
-		Driver:                 gceDriver,
-		CloudProvider:          cloudProvider,
-		seen:                   map[string]int{},
-		volumeLocks:            common.NewVolumeLocks(),
-		errorBackoff:           newCsiErrorBackoff(errorBackoffInitialDuration, errorBackoffMaxDuration),
-		fallbackRequisiteZones: fallbackRequisiteZones,
-		enableStoragePools:     enableStoragePools,
+		Driver:                      gceDriver,
+		CloudProvider:               cloudProvider,
+		volumeEntriesSeen:           map[string]int{},
+		volumeLocks:                 common.NewVolumeLocks(),
+		errorBackoff:                newCsiErrorBackoff(errorBackoffInitialDuration, errorBackoffMaxDuration),
+		fallbackRequisiteZones:      fallbackRequisiteZones,
+		enableStoragePools:          enableStoragePools,
+		multiZoneVolumeHandleConfig: multiZoneVolumeHandleConfig,
 	}
 }
 

--- a/pkg/gce-pd-csi-driver/gce-pd-driver_test.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver_test.go
@@ -48,8 +48,9 @@ func initGCEDriverWithCloudProvider(t *testing.T, cloudProvider gce.GCECompute) 
 	errorBackoffMaxDuration := 5 * time.Minute
 	fallbackRequisiteZones := []string{}
 	enableStoragePools := false
+	multiZoneVolumeHandleConfig := MultiZoneVolumeHandleConfig{}
 
-	controllerServer := NewControllerServer(gceDriver, cloudProvider, errorBackoffInitialDuration, errorBackoffMaxDuration, fallbackRequisiteZones, enableStoragePools)
+	controllerServer := NewControllerServer(gceDriver, cloudProvider, errorBackoffInitialDuration, errorBackoffMaxDuration, fallbackRequisiteZones, enableStoragePools, multiZoneVolumeHandleConfig)
 	err := gceDriver.SetupGCEDriver(driver, vendorVersion, nil, nil, controllerServer, nil)
 	if err != nil {
 		t.Fatalf("Failed to setup GCE Driver: %v", err)

--- a/test/e2e/tests/resize_e2e_test.go
+++ b/test/e2e/tests/resize_e2e_test.go
@@ -67,7 +67,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		}()
 
 		// Attach Disk
-		err = client.ControllerPublishVolume(volume.VolumeId, instance.GetNodeID(), false /* forceAttach */)
+		err = client.ControllerPublishVolumeReadWrite(volume.VolumeId, instance.GetNodeID(), false /* forceAttach */)
 		Expect(err).To(BeNil(), "Controller publish volume failed")
 
 		defer func() {
@@ -189,7 +189,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		Expect(cloudDisk.SizeGb).To(Equal(newSizeGb))
 
 		// Attach and mount again
-		err = client.ControllerPublishVolume(volume.VolumeId, instance.GetNodeID(), false /* forceAttach */)
+		err = client.ControllerPublishVolumeReadWrite(volume.VolumeId, instance.GetNodeID(), false /* forceAttach */)
 		Expect(err).To(BeNil(), "Controller publish volume failed")
 
 		defer func() {
@@ -281,7 +281,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		}()
 
 		// Attach Disk
-		err = client.ControllerPublishVolume(volume.VolumeId, instance.GetNodeID(), false /* forceAttach */)
+		err = client.ControllerPublishVolumeReadWrite(volume.VolumeId, instance.GetNodeID(), false /* forceAttach */)
 		Expect(err).To(BeNil(), "Controller publish volume failed")
 
 		defer func() {

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -63,7 +63,7 @@ func GCEClientAndDriverSetup(instance *remote.InstanceInfo, computeEndpoint stri
 	workspace := remote.NewWorkspaceDir("gce-pd-e2e-")
 	// Log at V(6) as the compute API calls are emitted at that level and it's
 	// useful to see what's happening when debugging tests.
-	driverRunCmd := fmt.Sprintf("sh -c '/usr/bin/nohup %s/gce-pd-csi-driver -v=6 --endpoint=%s %s 2> %s/prog.out < /dev/null > /dev/null &'",
+	driverRunCmd := fmt.Sprintf("sh -c '/usr/bin/nohup %s/gce-pd-csi-driver -v=6 --endpoint=%s --multi-zone-volume-handle-enable --multi-zone-volume-handle-disk-types=pd-standard %s 2> %s/prog.out < /dev/null > /dev/null &'",
 		workspace, endpoint, strings.Join(extra_flags, " "), workspace)
 
 	config := &remote.ClientConfig{

--- a/test/remote/client-wrappers.go
+++ b/test/remote/client-wrappers.go
@@ -134,12 +134,20 @@ func (c *CsiClient) DeleteVolume(volId string) error {
 	return err
 }
 
-func (c *CsiClient) ControllerPublishVolume(volId, nodeId string, forceAttach bool) error {
+func (c *CsiClient) ControllerPublishVolumeReadOnly(volId, nodeId string) error {
+	return c.ControllerPublishVolume(volId, nodeId, false /* forceAttach */, true /* readOnly */)
+}
+
+func (c *CsiClient) ControllerPublishVolumeReadWrite(volId, nodeId string, forceAttach bool) error {
+	return c.ControllerPublishVolume(volId, nodeId, forceAttach, false /* readOnly */)
+}
+
+func (c *CsiClient) ControllerPublishVolume(volId, nodeId string, forceAttach bool, readOnly bool) error {
 	cpreq := &csipb.ControllerPublishVolumeRequest{
 		VolumeId:         volId,
 		NodeId:           nodeId,
 		VolumeCapability: stdVolCap,
-		Readonly:         false,
+		Readonly:         readOnly,
 	}
 	if forceAttach {
 		cpreq.VolumeContext = map[string]string{

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -63,13 +63,14 @@ func TestSanity(t *testing.T) {
 
 	fallbackRequisiteZones := []string{}
 	enableStoragePools := false
+	multiZoneVolumeHandleConfig := driver.MultiZoneVolumeHandleConfig{}
 
 	mounter := mountmanager.NewFakeSafeMounter()
 	deviceUtils := deviceutils.NewFakeDeviceUtils(true)
 
 	//Initialize GCE Driver
 	identityServer := driver.NewIdentityServer(gceDriver)
-	controllerServer := driver.NewControllerServer(gceDriver, cloudProvider, 0, 5*time.Minute, fallbackRequisiteZones, enableStoragePools)
+	controllerServer := driver.NewControllerServer(gceDriver, cloudProvider, 0, 5*time.Minute, fallbackRequisiteZones, enableStoragePools, multiZoneVolumeHandleConfig)
 	nodeServer := driver.NewNodeServer(gceDriver, mounter, deviceUtils, metadataservice.NewFakeService(), mountmanager.NewFakeStatter(mounter))
 	err = gceDriver.SetupGCEDriver(driverName, vendorVersion, extraLabels, identityServer, controllerServer, nodeServer)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #1593 on release-1.13.

#1593: Add support for a multi-zone volumeHandle

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Add support for multi-zone volumeHandle
```