### PR TITLE
Add support for running tests on confidential VMs that use NVMe

### DIFF
--- a/test/e2e/tests/setup_e2e_test.go
+++ b/test/e2e/tests/setup_e2e_test.go
@@ -36,16 +36,19 @@ import (
 )
 
 var (
-	project          = flag.String("project", "", "Project to run tests in")
-	serviceAccount   = flag.String("service-account", "", "Service account to bring up instance with")
-	architecture     = flag.String("arch", "amd64", "Architecture pd csi driver build on")
-	zones            = flag.String("zones", "us-east4-a,us-east4-c", "Zones to run tests in. If there are multiple zones, separate each by comma")
-	machineType      = flag.String("machine-type", "n2-standard-2", "Type of machine to provision instance on")
-	imageURL         = flag.String("image-url", "projects/debian-cloud/global/images/family/debian-11", "OS image url to get image from")
-	runInProw        = flag.Bool("run-in-prow", false, "If true, use a Boskos loaned project and special CI service accounts and ssh keys")
-	deleteInstances  = flag.Bool("delete-instances", false, "Delete the instances after tests run")
-	cloudtopHost     = flag.Bool("cloudtop-host", false, "The local host is cloudtop, a kind of googler machine with special requirements to access GCP")
-	extraDriverFlags = flag.String("extra-driver-flags", "", "Extra flags to pass to the driver")
+	project                   = flag.String("project", "", "Project to run tests in")
+	serviceAccount            = flag.String("service-account", "", "Service account to bring up instance with")
+	vmNamePrefix              = flag.String("vm-name-prefix", "gce-pd-csi-e2e", "VM name prefix")
+	architecture              = flag.String("arch", "amd64", "Architecture pd csi driver build on")
+	minCpuPlatform            = flag.String("min-cpu-platform", "AMD Milan", "Minimum CPU architecture")
+	zones                     = flag.String("zones", "us-east4-a,us-east4-c", "Zones to run tests in. If there are multiple zones, separate each by comma")
+	machineType               = flag.String("machine-type", "n2d-standard-2", "Type of machine to provision instance on")
+	imageURL                  = flag.String("image-url", "projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2310-amd64", "OS image url to get image from")
+	runInProw                 = flag.Bool("run-in-prow", false, "If true, use a Boskos loaned project and special CI service accounts and ssh keys")
+	deleteInstances           = flag.Bool("delete-instances", false, "Delete the instances after tests run")
+	cloudtopHost              = flag.Bool("cloudtop-host", false, "The local host is cloudtop, a kind of googler machine with special requirements to access GCP")
+	extraDriverFlags          = flag.String("extra-driver-flags", "", "Extra flags to pass to the driver")
+	enableConfidentialCompute = flag.Bool("enable-confidential-compute", false, "Create VMs with confidential compute mode. This uses NVMe devices")
 
 	testContexts        = []*remote.TestContext{}
 	computeService      *compute.Service
@@ -130,21 +133,24 @@ func getDriverConfig() testutils.DriverConfig {
 	}
 }
 
-func getRemoteInstanceConfig() *remote.InstanceConfig {
-	return &remote.InstanceConfig{
-		Project:        *project,
-		Architecture:   *architecture,
-		MachineType:    *machineType,
-		ServiceAccount: *serviceAccount,
-		ImageURL:       *imageURL,
-		CloudtopHost:   *cloudtopHost}
-}
-
 func NewTestContext(zone string) *remote.TestContext {
-	nodeID := fmt.Sprintf("gce-pd-csi-e2e-%s", zone)
+	nodeID := fmt.Sprintf("%s-%s", *vmNamePrefix, zone)
 	klog.Infof("Setting up node %s", nodeID)
 
-	i, err := remote.SetupInstance(getRemoteInstanceConfig(), zone, nodeID, computeService)
+	instanceConfig := remote.InstanceConfig{
+		Project:                   *project,
+		Architecture:              *architecture,
+		MinCpuPlatform:            *minCpuPlatform,
+		Zone:                      zone,
+		Name:                      nodeID,
+		MachineType:               *machineType,
+		ServiceAccount:            *serviceAccount,
+		ImageURL:                  *imageURL,
+		CloudtopHost:              *cloudtopHost,
+		EnableConfidentialCompute: *enableConfidentialCompute,
+		ComputeService:            computeService,
+	}
+	i, err := remote.SetupInstance(instanceConfig)
 	if err != nil {
 		klog.Fatalf("Failed to setup instance %v: %v", nodeID, err)
 	}

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -76,7 +76,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		Expect(volumeLimit).To(Equal(defaultVolumeLimit))
 	})
 
-	It("Should create->attach->stage->mount volume and check if it is writable, then unmount->unstage->detach->delete and check disk is deleted", func() {
+	It("[NVMe] Should create->attach->stage->mount volume and check if it is writable, then unmount->unstage->detach->delete and check disk is deleted", func() {
 		testContext := getRandomTestContext()
 
 		p, z, _ := testContext.Instance.GetIdentity()
@@ -173,7 +173,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		}()
 	})
 
-	It("Should automatically add a symlink between /dev/* and /dev/by-id if disk is not found", func() {
+	It("[NVMe] Should automatically add a symlink between /dev/* and /dev/by-id if disk is not found", func() {
 		testContext := getRandomTestContext()
 
 		p, z, _ := testContext.Instance.GetIdentity()
@@ -331,7 +331,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		Entry("on pd-ssd", ssdDiskType),
 	)
 
-	DescribeTable("Should complete publish/unpublish lifecycle with underspecified volume ID and missing volume",
+	DescribeTable("[NVMe] Should complete publish/unpublish lifecycle with underspecified volume ID and missing volume",
 		func(diskType string) {
 			testContext := getRandomTestContext()
 
@@ -1317,15 +1317,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		_, err := getRandomTestContext().Client.ListVolumes()
 		Expect(err).To(BeNil(), "no error expected when passed valid compute url")
 
-		zone := "us-central1-c"
-		nodeID := fmt.Sprintf("gce-pd-csi-e2e-%s", zone)
-		i, err := remote.SetupInstance(getRemoteInstanceConfig(), zone, nodeID, computeService)
-
-		if err != nil {
-			klog.Fatalf("Failed to setup instance %v: %v", nodeID, err)
-		}
-
-		klog.Infof("Creating new driver and client for node %s\n", i.GetName())
+		i := getRandomTestContext().Instance
 
 		// Create new driver and client with valid, empty endpoint
 		klog.Infof("Setup driver with empty compute endpoint %s\n", i.GetName())
@@ -1349,7 +1341,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		Expect(err).To(BeNil(), "no error expected when passed valid compute url")
 	})
 
-	It("Should update readahead if read_ahead_kb passed on mount", func() {
+	It("[NVMe] Should update readahead if read_ahead_kb passed on mount", func() {
 		testContext := getRandomTestContext()
 
 		p, z, _ := testContext.Instance.GetIdentity()
@@ -1410,7 +1402,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 				Expect(err).To(BeNil(), "Failed to symlink devicePath")
 				devFsPathPieces := strings.Split(devFsPath, "/")
 				devName = devFsPathPieces[len(devFsPathPieces)-1]
-
+				break
 			}
 		}
 		Expect(validated).To(BeTrue(), "could not find device in %v that links to volume %s", devicePaths, volName)

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -293,11 +293,13 @@ func ValidateLogicalLinkIsDisk(instance *remote.InstanceInfo, link, diskName str
 
 	devFsPath, err := instance.SSH("find", link, "-printf", "'%l'")
 	if err != nil {
-		return false, fmt.Errorf("failed to find symbolic link for %s. Output: %v, errror: %v", link, devFsPath, err.Error())
+		// Skip over if there is no matching symlink.
+		return false, nil
 	}
 	if len(devFsPath) == 0 {
 		return false, nil
 	}
+
 	if sdx := sdRegex.FindString(devFsPath); len(sdx) != 0 {
 		fullDevPath := path.Join("/dev/", string(sdx))
 		scsiIDOut, err := instance.SSH("/lib/udev_containerized/scsi_id", "--page=0x83", "--whitelisted", fmt.Sprintf("--device=%v", fullDevPath))

--- a/test/remote/instance.go
+++ b/test/remote/instance.go
@@ -47,61 +47,66 @@ const (
 
 // InstanceConfig is the common bundle of options used for instance creation.
 type InstanceConfig struct {
-	Project        string
-	Architecture   string
-	MachineType    string
-	ServiceAccount string
-	ImageURL       string
-	CloudtopHost   bool
+	Project                   string
+	Architecture              string
+	Zone                      string
+	Name                      string
+	MachineType               string
+	ServiceAccount            string
+	ImageURL                  string
+	CloudtopHost              bool
+	MinCpuPlatform            string
+	ComputeService            *compute.Service
+	EnableConfidentialCompute bool
 }
 
 type InstanceInfo struct {
-	project        string
-	architecture   string
-	zone           string
-	name           string
-	machineType    string
-	serviceAccount string
-	imageURL       string
-	cloudtopHost   bool
-
+	cfg InstanceConfig
 	// External IP is filled in after instance creation
 	externalIP string
-
-	computeService *compute.Service
 }
 
 func (i *InstanceInfo) GetIdentity() (string, string, string) {
-	return i.project, i.zone, i.name
+	return i.cfg.Project, i.cfg.Zone, i.cfg.Name
 }
 
 func (i *InstanceInfo) GetName() string {
-	return i.name
+	return i.cfg.Name
 }
 
 func (i *InstanceInfo) GetNodeID() string {
-	return common.CreateNodeID(i.project, i.zone, i.name)
+	return common.CreateNodeID(i.cfg.Project, i.cfg.Zone, i.cfg.Name)
 }
 
-func CreateInstanceInfo(config *InstanceConfig, zone, name string, cs *compute.Service) (*InstanceInfo, error) {
-	return &InstanceInfo{
-		project:        config.Project,
-		architecture:   config.Architecture,
-		zone:           zone,
-		name:           name,
-		machineType:    config.MachineType,
-		cloudtopHost:   config.CloudtopHost,
-		serviceAccount: config.ServiceAccount,
-		imageURL:       config.ImageURL,
-		computeService: cs,
-	}, nil
+func machineTypeMismatch(curInst *compute.Instance, newInst *compute.Instance) bool {
+	if !strings.Contains(curInst.MachineType, newInst.MachineType) {
+		klog.Infof("Machine type mismatch")
+		return true
+	}
+	// Ideally we could compare to see if the new instance has a greater minCpuPlatfor
+	// For now we just check it was set and it's different.
+	if curInst.MinCpuPlatform != "" && curInst.MinCpuPlatform != newInst.MinCpuPlatform {
+		klog.Infof("CPU Platform mismatch")
+		return true
+	}
+	if (curInst.ConfidentialInstanceConfig != nil && newInst.ConfidentialInstanceConfig == nil) ||
+		(curInst.ConfidentialInstanceConfig == nil && newInst.ConfidentialInstanceConfig != nil) ||
+		(curInst.ConfidentialInstanceConfig != nil && newInst.ConfidentialInstanceConfig != nil && curInst.ConfidentialInstanceConfig.EnableConfidentialCompute != newInst.ConfidentialInstanceConfig.EnableConfidentialCompute) {
+		klog.Infof("Confidential compute mismatch")
+		return true
+	}
+	if curInst.SourceMachineImage != newInst.SourceMachineImage {
+		klog.Infof("Source Machine Mismatch")
+		return true
+	}
+	return false
 }
 
 // Provision a gce instance using image
 func (i *InstanceInfo) CreateOrGetInstance() error {
 	var err error
 	var instance *compute.Instance
-	klog.V(4).Infof("Creating instance: %v", i.name)
+	klog.V(4).Infof("Creating instance: %v", i.cfg.Name)
 
 	myuuid := string(uuid.NewUUID())
 
@@ -111,8 +116,8 @@ func (i *InstanceInfo) CreateOrGetInstance() error {
 	}
 
 	newInst := &compute.Instance{
-		Name:        i.name,
-		MachineType: fmt.Sprintf("zones/%s/machineTypes/%s", i.zone, i.machineType),
+		Name:        i.cfg.Name,
+		MachineType: fmt.Sprintf("zones/%s/machineTypes/%s", i.cfg.Zone, i.cfg.MachineType),
 		NetworkInterfaces: []*compute.NetworkInterface{
 			{
 				AccessConfigs: []*compute.AccessConfig{
@@ -129,14 +134,21 @@ func (i *InstanceInfo) CreateOrGetInstance() error {
 				Type:       "PERSISTENT",
 				InitializeParams: &compute.AttachedDiskInitializeParams{
 					DiskName:    "my-root-pd-" + myuuid,
-					SourceImage: i.imageURL,
+					SourceImage: i.cfg.ImageURL,
 				},
 			},
 		},
+		MinCpuPlatform: i.cfg.MinCpuPlatform,
+	}
+
+	if i.cfg.EnableConfidentialCompute {
+		newInst.ConfidentialInstanceConfig = &compute.ConfidentialInstanceConfig{
+			EnableConfidentialCompute: true,
+		}
 	}
 
 	saObj := &compute.ServiceAccount{
-		Email:  i.serviceAccount,
+		Email:  i.cfg.ServiceAccount,
 		Scopes: []string{"https://www.googleapis.com/auth/cloud-platform"},
 	}
 	newInst.ServiceAccounts = []*compute.ServiceAccount{saObj}
@@ -150,19 +162,19 @@ func (i *InstanceInfo) CreateOrGetInstance() error {
 		newInst.Metadata = meta
 	}
 
-	// If instance exists but machine-type doesn't match, delete instance
-	curInst, _ := i.computeService.Instances.Get(i.project, i.zone, newInst.Name).Do()
+	// If instance exists but settings differ, delete instance
+	curInst, _ := i.cfg.ComputeService.Instances.Get(i.cfg.Project, i.cfg.Zone, newInst.Name).Do()
 	if curInst != nil {
-		if !strings.Contains(curInst.MachineType, newInst.MachineType) {
+		if machineTypeMismatch(curInst, newInst) {
 			klog.V(4).Infof("Instance machine type doesn't match the required one. Delete instance.")
-			if _, err := i.computeService.Instances.Delete(i.project, i.zone, i.name).Do(); err != nil {
+			if _, err := i.cfg.ComputeService.Instances.Delete(i.cfg.Project, i.cfg.Zone, i.cfg.Name).Do(); err != nil {
 				return err
 			}
 
 			start := time.Now()
 			err := wait.Poll(15*time.Second, 5*time.Minute, func() (bool, error) {
 				klog.V(2).Infof("Waiting for instance to be deleted. %v elapsed", time.Since(start))
-				if curInst, _ = i.computeService.Instances.Get(i.project, i.zone, i.name).Do(); curInst != nil {
+				if curInst, _ = i.cfg.ComputeService.Instances.Get(i.cfg.Project, i.cfg.Zone, i.cfg.Name).Do(); curInst != nil {
 					return false, nil
 				}
 				return true, nil
@@ -174,16 +186,16 @@ func (i *InstanceInfo) CreateOrGetInstance() error {
 	}
 
 	if curInst == nil {
-		op, err := i.computeService.Instances.Insert(i.project, i.zone, newInst).Do()
-		klog.V(4).Infof("Inserted instance %v in project: %v, zone: %v", newInst.Name, i.project, i.zone)
+		op, err := i.cfg.ComputeService.Instances.Insert(i.cfg.Project, i.cfg.Zone, newInst).Do()
+		klog.V(4).Infof("Inserted instance %v in project: %v, zone: %v", newInst.Name, i.cfg.Project, i.cfg.Zone)
 		if err != nil {
-			ret := fmt.Sprintf("could not create instance %s: API error: %v", i.name, err.Error())
+			ret := fmt.Sprintf("could not create instance %s: API error: %v", i.cfg.Name, err.Error())
 			if op != nil {
 				ret = fmt.Sprintf("%s. op error: %v", ret, op.Error)
 			}
 			return errors.New(ret)
 		} else if op.Error != nil {
-			return fmt.Errorf("could not create instance %s: %+v", i.name, op.Error)
+			return fmt.Errorf("could not create instance %s: %+v", i.cfg.Name, op.Error)
 		}
 	} else {
 		klog.V(4).Infof("Compute service GOT instance %v, skipping instance creation", newInst.Name)
@@ -191,26 +203,26 @@ func (i *InstanceInfo) CreateOrGetInstance() error {
 
 	start := time.Now()
 	err = wait.Poll(15*time.Second, 5*time.Minute, func() (bool, error) {
-		klog.V(2).Infof("Waiting for instance %v to come up. %v elapsed", i.name, time.Since(start))
+		klog.V(2).Infof("Waiting for instance %v to come up. %v elapsed", i.cfg.Name, time.Since(start))
 
-		instance, err = i.computeService.Instances.Get(i.project, i.zone, i.name).Do()
+		instance, err = i.cfg.ComputeService.Instances.Get(i.cfg.Project, i.cfg.Zone, i.cfg.Name).Do()
 		if err != nil {
-			klog.Errorf("Failed to get instance %q: %v", i.name, err)
+			klog.Errorf("Failed to get instance %q: %v", i.cfg.Name, err)
 			return false, nil
 		}
 
 		if strings.ToUpper(instance.Status) != "RUNNING" {
-			klog.Warningf("instance %s not in state RUNNING, was %s", i.name, instance.Status)
+			klog.Warningf("instance %s not in state RUNNING, was %s", i.cfg.Name, instance.Status)
 			return false, nil
 		}
 
-		if i.cloudtopHost {
-			output, err := exec.Command("gcloud", "compute", "ssh", i.name, "--zone", i.zone, "--project", i.project, "--", "-o", "ProxyCommand=corp-ssh-helper %h %p", "--", "echo").CombinedOutput()
+		if i.cfg.CloudtopHost {
+			output, err := exec.Command("gcloud", "compute", "ssh", i.cfg.Name, "--zone", i.cfg.Zone, "--project", i.cfg.Project, "--", "-o", "ProxyCommand=corp-ssh-helper %h %p", "--", "echo").CombinedOutput()
 			if err != nil {
 				klog.Errorf("Failed to bootstrap ssh (%v): %s", err, string(output))
 				return false, nil
 			}
-			klog.V(4).Infof("Bootstrapped cloudtop ssh for instance %v", i.name)
+			klog.V(4).Infof("Bootstrapped cloudtop ssh for instance %v", i.cfg.Name)
 		}
 
 		externalIP := getexternalIP(instance)
@@ -219,11 +231,11 @@ func (i *InstanceInfo) CreateOrGetInstance() error {
 		}
 
 		if sshOut, err := i.SSHCheckAlive(); err != nil {
-			err = fmt.Errorf("Instance %v in state RUNNING but not available by SSH: %v", i.name, err.Error())
+			err = fmt.Errorf("Instance %v in state RUNNING but not available by SSH: %v", i.cfg.Name, err.Error())
 			klog.Warningf("SSH encountered an error: %v, output: %v", err, sshOut)
 			return false, nil
 		}
-		klog.V(4).Infof("Instance %v in state RUNNING and available by SSH", i.name)
+		klog.V(4).Infof("Instance %v in state RUNNING and available by SSH", i.cfg.Name)
 		return true, nil
 	})
 
@@ -233,24 +245,24 @@ func (i *InstanceInfo) CreateOrGetInstance() error {
 	}
 
 	// Instance reached running state in time, make sure that cloud-init is complete
-	klog.V(2).Infof("Instance %v has been created successfully", i.name)
+	klog.V(2).Infof("Instance %v has been created successfully", i.cfg.Name)
 	return nil
 }
 
 func (i *InstanceInfo) DeleteInstance() {
-	klog.V(4).Infof("Deleting instance %q", i.name)
-	_, err := i.computeService.Instances.Delete(i.project, i.zone, i.name).Do()
+	klog.V(4).Infof("Deleting instance %q", i.cfg.Name)
+	_, err := i.cfg.ComputeService.Instances.Delete(i.cfg.Project, i.cfg.Zone, i.cfg.Name).Do()
 	if err != nil {
 		if isGCEError(err, "notFound") {
 			return
 		}
-		klog.Errorf("Error deleting instance %q: %v", i.name, err)
+		klog.Errorf("Error deleting instance %q: %v", i.cfg.Name, err)
 	}
 }
 
 func (i *InstanceInfo) DetachDisk(diskName string) error {
 	klog.V(4).Infof("Detaching disk %q", diskName)
-	op, err := i.computeService.Instances.DetachDisk(i.project, i.zone, i.name, diskName).Do()
+	op, err := i.cfg.ComputeService.Instances.DetachDisk(i.cfg.Project, i.cfg.Zone, i.cfg.Name, diskName).Do()
 	if err != nil {
 		if isGCEError(err, "notFound") {
 			return nil
@@ -260,9 +272,9 @@ func (i *InstanceInfo) DetachDisk(diskName string) error {
 
 	start := time.Now()
 	if err := wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
-		klog.V(2).Infof("Waiting for disk %q to be detached from instance %q. %v elapsed", diskName, i.name, time.Since(start))
+		klog.V(2).Infof("Waiting for disk %q to be detached from instance %q. %v elapsed", diskName, i.cfg.Name, time.Since(start))
 
-		op, err = i.computeService.ZoneOperations.Get(i.project, i.zone, op.Name).Do()
+		op, err = i.cfg.ComputeService.ZoneOperations.Get(i.cfg.Project, i.cfg.Zone, op.Name).Do()
 		if err != nil {
 			return true, fmt.Errorf("Failed to get operation %q, err: %v", op.Name, err)
 		}
@@ -271,7 +283,7 @@ func (i *InstanceInfo) DetachDisk(diskName string) error {
 		return err
 	}
 
-	klog.V(4).Infof("Disk %q has been successfully detached from instance %q\n%v", diskName, i.name, op.Error)
+	klog.V(4).Infof("Disk %q has been successfully detached from instance %q\n%v", diskName, i.cfg.Name, op.Error)
 	return nil
 }
 
@@ -297,7 +309,7 @@ func (i *InstanceInfo) createDefaultFirewallRule() error {
 	var err error
 	klog.V(4).Infof("Creating default firewall rule %s...", defaultFirewallRule)
 
-	if _, err = i.computeService.Firewalls.Get(i.project, defaultFirewallRule).Do(); err != nil {
+	if _, err = i.cfg.ComputeService.Firewalls.Get(i.cfg.Project, defaultFirewallRule).Do(); err != nil {
 		klog.V(4).Infof("Default firewall rule %v does not exist, creating", defaultFirewallRule)
 		f := &compute.Firewall{
 			Name: defaultFirewallRule,
@@ -308,7 +320,7 @@ func (i *InstanceInfo) createDefaultFirewallRule() error {
 				},
 			},
 		}
-		_, err = i.computeService.Firewalls.Insert(i.project, f).Do()
+		_, err = i.cfg.ComputeService.Firewalls.Insert(i.cfg.Project, f).Do()
 		if err != nil {
 			if gce.IsGCEError(err, "alreadyExists") {
 				klog.V(4).Infof("Default firewall rule %v already exists, skipping creation", defaultFirewallRule)

--- a/test/remote/runner.go
+++ b/test/remote/runner.go
@@ -29,12 +29,12 @@ import (
 func (i *InstanceInfo) UploadAndRun(archivePath, remoteWorkspace, driverRunCmd string) (int, error) {
 
 	// Create the temp staging directory
-	klog.V(4).Infof("Staging test binaries on %q", i.name)
+	klog.V(4).Infof("Staging test binaries on %q", i.cfg.Name)
 
 	// Do not sudo here, so that we can use scp to copy test archive to the directdory.
 	if output, err := i.SSHNoSudo("mkdir", remoteWorkspace); err != nil {
 		// Exit failure with the error
-		return -1, fmt.Errorf("failed to create remoteWorkspace directory %q on i.name %q: %v output: %q", remoteWorkspace, i.name, err.Error(), output)
+		return -1, fmt.Errorf("failed to create remoteWorkspace directory %q on instance %q: %v output: %q", remoteWorkspace, i.cfg.Name, err.Error(), output)
 	}
 
 	// Copy the archive to the staging directory
@@ -49,7 +49,7 @@ func (i *InstanceInfo) UploadAndRun(archivePath, remoteWorkspace, driverRunCmd s
 		fmt.Sprintf("cd %s", remoteWorkspace),
 		fmt.Sprintf("tar -xzvf ./%s", archiveName),
 	)
-	klog.V(4).Infof("Extracting tar on %q", i.name)
+	klog.V(4).Infof("Extracting tar on %q", i.cfg.Name)
 	// Do not use sudo here, because `sudo tar -x` will recover the file ownership inside the tar ball, but
 	// we want the extracted files to be owned by the current user.
 	if output, err := i.SSHNoSudo("sh", "-c", cmd); err != nil {
@@ -57,7 +57,7 @@ func (i *InstanceInfo) UploadAndRun(archivePath, remoteWorkspace, driverRunCmd s
 		return -1, fmt.Errorf("failed to extract test archive: %v, output: %q", err.Error(), output)
 	}
 
-	klog.V(4).Infof("Starting driver on %q", i.name)
+	klog.V(4).Infof("Starting driver on %q", i.cfg.Name)
 	// When the process is killed the driver should close the TCP endpoint, then we want to download the logs
 	output, err := i.SSH(driverRunCmd)
 	if err != nil {

--- a/test/remote/setup-teardown.go
+++ b/test/remote/setup-teardown.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 
-	compute "google.golang.org/api/compute/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/klog/v2"
 )
@@ -54,14 +53,13 @@ type processes struct {
 }
 
 // SetupInstance sets up the specified GCE Instance for E2E testing and returns a handle to the instance object for future use.
-func SetupInstance(config *InstanceConfig, instanceZone, instanceName string, cs *compute.Service) (*InstanceInfo, error) {
+func SetupInstance(cfg InstanceConfig) (*InstanceInfo, error) {
 	// Create the instance in the requisite zone
-	instance, err := CreateInstanceInfo(config, instanceZone, instanceName, cs)
-	if err != nil {
-		return nil, err
+	instance := &InstanceInfo{
+		cfg: cfg,
 	}
 
-	err = instance.CreateOrGetInstance()
+	err := instance.CreateOrGetInstance()
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +71,7 @@ func SetupInstance(config *InstanceConfig, instanceZone, instanceName string, cs
 // that the driver is on and the CSI Client object to make CSI calls to the remote driver.
 func SetupNewDriverAndClient(instance *InstanceInfo, config *ClientConfig) (*TestContext, error) {
 	archiveName := fmt.Sprintf("e2e_driver_binaries_%s.tar.gz", uuid.NewUUID())
-	archivePath, err := CreateDriverArchive(archiveName, instance.architecture, config.PkgPath, config.BinPath)
+	archivePath, err := CreateDriverArchive(archiveName, instance.cfg.Architecture, config.PkgPath, config.BinPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/run-e2e-local.sh
+++ b/test/run-e2e-local.sh
@@ -16,4 +16,4 @@ if hostname | grep -q c.googlers.com ; then
   CLOUDTOP_HOST=--cloudtop-host
 fi
 
-ginkgo --v "test/e2e/tests" -- --project "${PROJECT}" --service-account "${IAM_NAME}" "${CLOUDTOP_HOST}" --v=6 --logtostderr
+ginkgo --v "test/e2e/tests" -- --project "${PROJECT}" --service-account "${IAM_NAME}" "${CLOUDTOP_HOST}" --v=6 --logtostderr $@

--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -5,4 +5,4 @@ set -x
 
 readonly PKGDIR=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 
-go test --timeout 30m --v "${PKGDIR}/test/e2e/tests" --run-in-prow=true --delete-instances=true --logtostderr
+go test --timeout 30m --v "${PKGDIR}/test/e2e/tests" --run-in-prow=true --delete-instances=true --logtostderr $@


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This adds support to run e2e tests in a configuration that uses NVMe devices. Currently the e2e tests default to using `n2` machine family, which uses SCSI by default. Passing in the `--enable-confidential-compute` flag is a cost effective way to use NVMe (an alternative being running against `c3-standard-4` machine type, but this requires additional test refactoring, or skipping tests, as there are restrictions on disk types).

To support toggling with just the binary flag, this also updates the defaults of the test to use `n2d` as well as a Ubuntu guest OS image instead of Debian.

Support for running "\[NVMe\]" tagged tests are presubmit will be added in https://github.com/kubernetes/test-infra/pull/32214. These can also be run locally with:

```
./test/run-e2e-local.sh --enable-confidential-compute
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
