### PR TITLE
Add support for checking if a device is being used by a filesystem

### DIFF
--- a/pkg/deviceutils/device-utils.go
+++ b/pkg/deviceutils/device-utils.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
+	"k8s.io/mount-utils"
 	pathutils "k8s.io/utils/path"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/resizefs"
 )
@@ -91,6 +92,13 @@ type DeviceUtils interface {
 
 	// Resize returns whether or not a device needs resizing.
 	Resize(resizer resizefs.Resizefs, devicePath string, deviceMountPath string) (bool, error)
+
+	// IsDeviceFilesystemInUse returns if a device path with the specified fstype
+	// TODO: Mounter is passed in in order to call GetDiskFormat()
+	// This is currently only implemented in mounter_linux, not mounter_windows.
+	// Refactor this interface and function call up the stack to the caller once it is
+	// implemented in mounter_windows.
+	IsDeviceFilesystemInUse(mounter *mount.SafeFormatAndMount, devicePath, devFsPath string) (bool, error)
 }
 
 type deviceUtils struct {

--- a/pkg/deviceutils/device-utils_linux.go
+++ b/pkg/deviceutils/device-utils_linux.go
@@ -20,9 +20,31 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"k8s.io/mount-utils"
 )
 
 func (_ *deviceUtils) DisableDevice(devicePath string) error {
 	deviceName := filepath.Base(devicePath)
 	return os.WriteFile(fmt.Sprintf("/sys/block/%s/device/state", deviceName), []byte("offline"), 0644)
+}
+
+func (_ *deviceUtils) IsDeviceFilesystemInUse(mounter *mount.SafeFormatAndMount, devicePath, devFsPath string) (bool, error) {
+	fstype, err := mounter.GetDiskFormat(devicePath)
+	if err != nil {
+		return false, fmt.Errorf("failed to get disk format for %s (aka %s): %v", devicePath, devFsPath, err)
+	}
+
+	devFsName := filepath.Base(devFsPath)
+	sysFsTypePath := fmt.Sprintf("/sys/fs/%s/%s", fstype, devFsName)
+	stat, err := os.Stat(sysFsTypePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Path doesn't exist, indicating the device is NOT in use
+			return false, nil
+		}
+		return false, err
+	}
+
+	return stat.IsDir(), nil
 }

--- a/pkg/deviceutils/device-utils_windows.go
+++ b/pkg/deviceutils/device-utils_windows.go
@@ -16,7 +16,15 @@ limitations under the License.
 
 package deviceutils
 
+import "k8s.io/mount-utils"
+
 func (_ *deviceUtils) DisableDevice(devicePath string) error {
 	// No disabling is necessary on windows.
 	return nil
+}
+
+func (_ *deviceUtils) IsDeviceFilesystemInUse(mounter *mount.SafeFormatAndMount, devicePath, devFsPath string) (bool, error) {
+	// We don't support checking if a device filesystem is captured elsewhere by the system
+	// Return false, to skip this check. Assume the filesystem is not in use.
+	return false, nil
 }

--- a/pkg/deviceutils/fake-device-utils.go
+++ b/pkg/deviceutils/fake-device-utils.go
@@ -14,7 +14,10 @@ limitations under the License.
 
 package deviceutils
 
-import "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/resizefs"
+import (
+	"k8s.io/mount-utils"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/resizefs"
+)
 
 type fakeDeviceUtils struct {
 	skipResize bool
@@ -49,4 +52,10 @@ func (du *fakeDeviceUtils) Resize(resizer resizefs.Resizefs, devicePath string, 
 		return false, nil
 	}
 	return resizer.Resize(devicePath, deviceMountPath)
+}
+
+func (_ *fakeDeviceUtils) IsDeviceFilesystemInUse(mounter *mount.SafeFormatAndMount, devicePath, devFsPath string) (bool, error) {
+	// We don't support checking if a device filesystem is captured elsewhere by the system
+	// Return false, to skip this check.
+	return false, nil
 }

--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -16,6 +16,7 @@ package gceGCEDriver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -450,19 +451,44 @@ func (ns *GCENodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUns
 		return nil, status.Error(codes.Internal, fmt.Sprintf("NodeUnstageVolume failed: %v\nUnmounting arguments: %s\n", err.Error(), stagingTargetPath))
 	}
 
-	devicePath, err := getDevicePath(ns, volumeID, "" /* partition, which is unused */)
-	if err != nil {
-		klog.Errorf("Failed to find device path for volume %s. Device may not be detached cleanly (error is ignored and unstaging is continuing): %v", volumeID, err.Error())
-	} else {
-		if devFsPath, err := filepath.EvalSymlinks(devicePath); err != nil {
-			klog.Warningf("filepath.EvalSymlinks(%q) failed when trying to disable device: %v (ignored, unstaging continues)", devicePath, err)
-		} else if err := ns.DeviceUtils.DisableDevice(devFsPath); err != nil {
-			klog.Warningf("Failed to disabled device %s (aka %s) for volume %s. Device may not be detached cleanly (ignored, unstaging continues): %v", devicePath, devFsPath, volumeID, err)
+	if err := ns.safelyDisableDevice(volumeID); err != nil {
+		var targetErr *ignoreableError
+		if errors.As(err, &targetErr) {
+			klog.Warningf("Device may not be detached cleanly for volume %s (ignored, unstaging continues): %v", volumeID, err)
+		} else {
+			return nil, status.Errorf(codes.Internal, "NodeUnstageVolume for volume %s failed: %v", volumeID, err)
 		}
 	}
 
 	klog.V(4).Infof("NodeUnstageVolume succeeded on %v from %s", volumeID, stagingTargetPath)
 	return &csi.NodeUnstageVolumeResponse{}, nil
+}
+
+// A private error wrapper used to pass control flow decisions up to the caller
+type ignoreableError struct{ error }
+
+func (ns *GCENodeServer) safelyDisableDevice(volumeID string) error {
+	devicePath, err := getDevicePath(ns, volumeID, "" /* partition, which is unused */)
+	if err != nil {
+		return &ignoreableError{fmt.Errorf("failed to find device path for volume %s: %v", volumeID, err.Error())}
+	}
+
+	devFsPath, err := filepath.EvalSymlinks(devicePath)
+	if err != nil {
+		return &ignoreableError{fmt.Errorf("filepath.EvalSymlinks(%q) failed: %v", devicePath, err)}
+	}
+
+	if inUse, err := ns.DeviceUtils.IsDeviceFilesystemInUse(ns.Mounter, devicePath, devFsPath); err != nil {
+		return &ignoreableError{fmt.Errorf("failed to check if device %s (aka %s) is in use: %v", devicePath, devFsPath, err)}
+	} else if inUse {
+		return fmt.Errorf("device %s (aka %s) is still in use", devicePath, devFsPath)
+	}
+
+	if err := ns.DeviceUtils.DisableDevice(devFsPath); err != nil {
+		return &ignoreableError{fmt.Errorf("failed to disable device %s (aka %s): %v", devicePath, devFsPath, err)}
+	}
+
+	return nil
 }
 
 func (ns *GCENodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Summary: If a PD block device is still being used by the filesystem (misconfiguration, mount namespace capture), return an error during NodeUnstage.

Currently the PDCSI driver performs an unmount on the globalmount during NodeUnstage, and success signals that ControllerUnpublish (GCE disk detach) can proceed. Normally successful mount is an indicator that there is no other consumer of the device on the OS. There are some sitautions where this may not be true:
1) Mount Namespace Capture: If a mount namespace is held open by a container process, due to an open file descriptor to `/proc/<pid>/ns/mnt`, a private mount point to the block device may exist in a container's mount namespace. Typically this only occurs if there is some other process that has root access to the OS and causes this to occur.
2) If there is some other user on the system which creates a private bind mount from the globalmount. The unmount and removal of the globalmount does not private to private bind mounts, resulting in a successful unmount in PDCSI, despite the device still being in use.

**Which issue(s) this PR fixes**:
Fixes #1657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Check if volume's block device is still in use during NodeUnstage
```
