### PR TITLE
Add newline character when writing offline to block device state

### DIFF
--- a/pkg/deviceutils/device-utils_linux.go
+++ b/pkg/deviceutils/device-utils_linux.go
@@ -24,5 +24,5 @@ import (
 
 func (_ *deviceUtils) DisableDevice(devicePath string) error {
 	deviceName := filepath.Base(devicePath)
-	return os.WriteFile(fmt.Sprintf("/sys/block/%s/device/state", deviceName), []byte("offline"), 0644)
+	return os.WriteFile(fmt.Sprintf("/sys/block/%s/device/state", deviceName), []byte("offline\n"), 0644)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR adds "\n" character to the disable device command (when writing to `/sys/block/<devX>/device/state`). Currently the command emits `invalid argument` (but the error is ignored).

**Which issue(s) this PR fixes**:
Fixes #1146

**Special notes for your reviewer**:

Without this fix, the `prog.out` in e2e test prints out:

```
W0404 01:22:27.876675   49081 node.go:460] Failed to disabled device /dev/disk/by-id/google-gcepd-csi-e2e-b3c295b8-24d2-4804-b363-385a66c7ffd0 (aka /dev/sdj) for volume projects/psch-gke-dev/zones/us-east4-c/disks/gcepd-csi-e2e-b3c295b8-24d2-4804-b363-385a66c7ffd0. Device may not be detached cleanly (ignored, unstaging continues): write /sys/block/sdj/device/state: invalid argument
```

Validated that with this fix, this warning is not printed.

**Does this PR introduce a user-facing change?**:
```release-note
Bugfix: Correctly disable device by writing `offline`
```
