### PR TITLE
Migrate Hyperdisk/CHD/StoragePools to GCE v1 disk API

### DIFF
--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -249,7 +249,7 @@ func (cloud *FakeCloudProvider) InsertDisk(ctx context.Context, project string, 
 	}
 
 	if containsBetaDiskType(hyperdiskTypes, params.DiskType) {
-		betaDisk := convertV1DiskToBetaDisk(computeDisk, params.ProvisionedThroughputOnCreate)
+		betaDisk := convertV1DiskToBetaDisk(computeDisk)
 		betaDisk.EnableConfidentialCompute = params.EnableConfidentialCompute
 		cloud.disks[volKey.Name] = CloudDiskFromBeta(betaDisk)
 	} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Now that the provisionedIops, provisionedThroughput, enableConfidentialCompute, and storagePool are supported by the [GCE v1 disks insert API](https://cloud.google.com/compute/docs/reference/rest/v1/disks/insert), this PR migrates the disk insert call to alpha/beta --> v1 for these features. This allows us to clean up the code in /pkg/gce-cloud-provider/compute/gce-compute.go. Multiwriter still requires the [GCE beta disks insert API](https://cloud.google.com/compute/docs/reference/rest/beta/disks/insert), so the multiwriter feature cannot be migrated to v1 API. I will clean up the Alpha API support, added in [PR 1524](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1524), in a child PR.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Migrate the Hyperdisk/CHD/StoragePools features to the GCE v1 insert disk API.
```
