### PR TITLE
Remove short variable declaration from validateStoragePools

### DIFF
--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -288,7 +288,8 @@ func (gceCS *GCEControllerServer) CreateVolume(ctx context.Context, req *csi.Cre
 		gceAPIVersion = gce.GCEAPIVersionBeta
 	}
 
-	if err := validateStoragePools(req, params, gceCS.CloudProvider.GetDefaultProject()); err != nil {
+	err = validateStoragePools(req, params, gceCS.CloudProvider.GetDefaultProject())
+	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "CreateVolume failed to validate storage pools: %v", err)
 	}
 


### PR DESCRIPTION
Remove short variable declaration from validateStoragePools for correct error to be passed to RecordOperationErrorMetrics

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Remove short variable declaration from validateStoragePools for error to be passed to RecordOperationErrorMetrics. Right now, the scope for validateStoragePools is incorrect leading to us passing nil to RecordOperationErrorMetrics, which results in a [OK grpc status code](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/28591b6c6020e1e5addba87b188a2b07cc53e4b5/pkg/metrics/metrics.go#L175) being reported to our metric. 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Remove short variable declaration from validateStoragePools.
```
