### PR TITLE
Fix e2e tests to run on cloudtop

### DIFF
--- a/test/e2e/tests/setup_e2e_test.go
+++ b/test/e2e/tests/setup_e2e_test.go
@@ -43,6 +43,7 @@ var (
 	imageURL        = flag.String("image-url", "projects/debian-cloud/global/images/family/debian-11", "OS image url to get image from")
 	runInProw       = flag.Bool("run-in-prow", false, "If true, use a Boskos loaned project and special CI service accounts and ssh keys")
 	deleteInstances = flag.Bool("delete-instances", false, "Delete the instances after tests run")
+	cloudtopHost    = flag.Bool("cloudtop-host", false, "The local host is cloudtop, a kind of googler machine with special requirements to access GCP")
 
 	testContexts        = []*remote.TestContext{}
 	computeService      *compute.Service
@@ -116,11 +117,21 @@ var _ = AfterSuite(func() {
 	}
 })
 
+func getRemoteInstanceConfig() *remote.InstanceConfig {
+	return &remote.InstanceConfig{
+		Project:        *project,
+		Architecture:   *architecture,
+		MachineType:    *machineType,
+		ServiceAccount: *serviceAccount,
+		ImageURL:       *imageURL,
+		CloudtopHost:   *cloudtopHost}
+}
+
 func NewTestContext(zone string) *remote.TestContext {
 	nodeID := fmt.Sprintf("gce-pd-csi-e2e-%s", zone)
 	klog.Infof("Setting up node %s", nodeID)
 
-	i, err := remote.SetupInstance(*project, *architecture, zone, nodeID, *machineType, *serviceAccount, *imageURL, computeService)
+	i, err := remote.SetupInstance(getRemoteInstanceConfig(), zone, nodeID, computeService)
 	if err != nil {
 		klog.Fatalf("Failed to setup instance %v: %v", nodeID, err)
 	}

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -1289,7 +1289,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 
 		zone := "us-central1-c"
 		nodeID := fmt.Sprintf("gce-pd-csi-e2e-%s", zone)
-		i, err := remote.SetupInstance(*project, *architecture, zone, nodeID, *machineType, *serviceAccount, *imageURL, computeService)
+		i, err := remote.SetupInstance(getRemoteInstanceConfig(), zone, nodeID, computeService)
 
 		if err != nil {
 			klog.Fatalf("Failed to setup instance %v: %v", nodeID, err)

--- a/test/remote/setup-teardown.go
+++ b/test/remote/setup-teardown.go
@@ -54,14 +54,14 @@ type processes struct {
 }
 
 // SetupInstance sets up the specified GCE Instance for E2E testing and returns a handle to the instance object for future use.
-func SetupInstance(instanceProject, instanceArchitecture, instanceZone, instanceName, instanceMachineType, instanceServiceAccount, instanceImageURL string, cs *compute.Service) (*InstanceInfo, error) {
+func SetupInstance(config *InstanceConfig, instanceZone, instanceName string, cs *compute.Service) (*InstanceInfo, error) {
 	// Create the instance in the requisite zone
-	instance, err := CreateInstanceInfo(instanceProject, instanceArchitecture, instanceZone, instanceName, instanceMachineType, cs)
+	instance, err := CreateInstanceInfo(config, instanceZone, instanceName, cs)
 	if err != nil {
 		return nil, err
 	}
 
-	err = instance.CreateOrGetInstance(instanceImageURL, instanceServiceAccount)
+	err = instance.CreateOrGetInstance()
 	if err != nil {
 		return nil, err
 	}

--- a/test/run-e2e-local.sh
+++ b/test/run-e2e-local.sh
@@ -11,4 +11,9 @@ readonly PKGDIR=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 # This requires application default credentials to be set up, eg by
 # `gcloud auth application-default login`
 
-ginkgo --v "test/e2e/tests" -- --project "${PROJECT}" --service-account "${IAM_NAME}" --v=6 --logtostderr
+CLOUDTOP_HOST=
+if hostname | grep -q c.googlers.com ; then
+  CLOUDTOP_HOST=--cloudtop-host
+fi
+
+ginkgo --v "test/e2e/tests" -- --project "${PROJECT}" --service-account "${IAM_NAME}" "${CLOUDTOP_HOST}" --v=6 --logtostderr


### PR DESCRIPTION

**What this PR does / why we need it**:

Make e2e tests work from googler cloudtop instances. Note that service accounts that can download keys are still required.

```release-note
None
```

/assign @msau42 