### PR TITLE
Remove unused DisableDevice method

### DIFF
--- a/pkg/deviceutils/device-utils.go
+++ b/pkg/deviceutils/device-utils.go
@@ -86,10 +86,6 @@ type DeviceUtils interface {
 	// exists on the machine, or an empty string if none exists
 	VerifyDevicePath(devicePaths []string, deviceName string) (string, error)
 
-	// DisableDevice performs necessary disabling prior to a device being
-	// detached from a node. The path is that from GetDiskByIdPaths.
-	DisableDevice(devicePath string) error
-
 	// Resize returns whether or not a device needs resizing.
 	Resize(resizer resizefs.Resizefs, devicePath string, deviceMountPath string) (bool, error)
 

--- a/pkg/deviceutils/device-utils_linux.go
+++ b/pkg/deviceutils/device-utils_linux.go
@@ -24,18 +24,6 @@ import (
 	"k8s.io/mount-utils"
 )
 
-// DisableDevice asks the kernel to disable a device via /sys.
-// NB: this can be dangerous to use. Once a device is disabled, it's unusable, and can't be enabled
-// unless the serial number is known. But the serial number cannot be read from the device as it's
-// disabled. If a device is disabled in NodeUnstage, and then NodeStage is called without a
-// NodeUnpublish & publish sequence, the disabled state of the device will cause NodeStage to fail.
-// So this can only be used if we track the serial numbers of disabled devices in a persisent way
-// that survives driver restarts.
-func (_ *deviceUtils) DisableDevice(devicePath string) error {
-	deviceName := filepath.Base(devicePath)
-	return os.WriteFile(fmt.Sprintf("/sys/block/%s/device/state", deviceName), []byte("offline\n"), 0644)
-}
-
 func (_ *deviceUtils) IsDeviceFilesystemInUse(mounter *mount.SafeFormatAndMount, devicePath, devFsPath string) (bool, error) {
 	fstype, err := mounter.GetDiskFormat(devicePath)
 	if err != nil {


### PR DESCRIPTION
The DisableDevice call is no longer used. The comment around the device explains why so that if we ever decide to put it back in we'll have context.

/assign @pwschuurman 

/kind cleanup

```release-note
None
```
