### PR TITLE
Use instances.list to determine PublishedNodeIds in ListVolume API

### DIFF
--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -127,12 +127,20 @@ func (cloud *FakeCloudProvider) ListZones(ctx context.Context, region string) ([
 	return []string{cloud.zone, "country-region-fakesecondzone"}, nil
 }
 
-func (cloud *FakeCloudProvider) ListDisks(ctx context.Context) ([]*computev1.Disk, string, error) {
+func (cloud *FakeCloudProvider) ListDisks(ctx context.Context, fields []googleapi.Field) ([]*computev1.Disk, string, error) {
 	d := []*computev1.Disk{}
 	for _, cd := range cloud.disks {
 		d = append(d, cd.disk)
 	}
 	return d, "", nil
+}
+
+func (cloud *FakeCloudProvider) ListInstances(ctx context.Context, fields []googleapi.Field) ([]*computev1.Instance, string, error) {
+	instances := []*computev1.Instance{}
+	for _, instance := range cloud.instances {
+		instances = append(instances, instance)
+	}
+	return instances, "", nil
 }
 
 func (cloud *FakeCloudProvider) ListSnapshots(ctx context.Context, filter string) ([]*computev1.Snapshot, string, error) {

--- a/pkg/gce-cloud-provider/compute/gce.go
+++ b/pkg/gce-cloud-provider/compute/gce.go
@@ -102,12 +102,18 @@ type CloudProvider struct {
 	waitForAttachConfig WaitForAttachConfig
 
 	tagsRateLimiter *rate.Limiter
+
+	listInstancesConfig ListInstancesConfig
 }
 
 var _ GCECompute = &CloudProvider{}
 
 type ConfigFile struct {
 	Global ConfigGlobal `gcfg:"global"`
+}
+
+type ListInstancesConfig struct {
+	Filters []string
 }
 
 type WaitForAttachConfig struct {
@@ -128,7 +134,7 @@ type ConfigGlobal struct {
 	Zone      string `gcfg:"zone"`
 }
 
-func CreateCloudProvider(ctx context.Context, vendorVersion string, configPath string, computeEndpoint *url.URL, computeEnvironment Environment, waitForAttachConfig WaitForAttachConfig) (*CloudProvider, error) {
+func CreateCloudProvider(ctx context.Context, vendorVersion string, configPath string, computeEndpoint *url.URL, computeEnvironment Environment, waitForAttachConfig WaitForAttachConfig, listInstancesConfig ListInstancesConfig) (*CloudProvider, error) {
 	configFile, err := readConfig(configPath)
 	if err != nil {
 		return nil, err
@@ -168,6 +174,7 @@ func CreateCloudProvider(ctx context.Context, vendorVersion string, configPath s
 		zone:                zone,
 		zonesCache:          make(map[string]([]string)),
 		waitForAttachConfig: waitForAttachConfig,
+		listInstancesConfig: listInstancesConfig,
 		// GCP has a rate limit of 600 requests per minute, restricting
 		// here to 8 requests per second.
 		tagsRateLimiter: common.NewLimiter(gcpTagsRequestRateLimit, gcpTagsRequestTokenBucketSize, true),

--- a/pkg/gce-pd-csi-driver/gce-pd-driver.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver.go
@@ -154,7 +154,7 @@ func NewNodeServer(gceDriver *GCEDriver, mounter *mount.SafeFormatAndMount, devi
 	}
 }
 
-func NewControllerServer(gceDriver *GCEDriver, cloudProvider gce.GCECompute, errorBackoffInitialDuration, errorBackoffMaxDuration time.Duration, fallbackRequisiteZones []string, enableStoragePools bool, multiZoneVolumeHandleConfig MultiZoneVolumeHandleConfig) *GCEControllerServer {
+func NewControllerServer(gceDriver *GCEDriver, cloudProvider gce.GCECompute, errorBackoffInitialDuration, errorBackoffMaxDuration time.Duration, fallbackRequisiteZones []string, enableStoragePools bool, multiZoneVolumeHandleConfig MultiZoneVolumeHandleConfig, listVolumesConfig ListVolumesConfig) *GCEControllerServer {
 	return &GCEControllerServer{
 		Driver:                      gceDriver,
 		CloudProvider:               cloudProvider,
@@ -164,6 +164,7 @@ func NewControllerServer(gceDriver *GCEDriver, cloudProvider gce.GCECompute, err
 		fallbackRequisiteZones:      fallbackRequisiteZones,
 		enableStoragePools:          enableStoragePools,
 		multiZoneVolumeHandleConfig: multiZoneVolumeHandleConfig,
+		listVolumesConfig:           listVolumesConfig,
 	}
 }
 

--- a/pkg/gce-pd-csi-driver/gce-pd-driver_test.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver_test.go
@@ -49,8 +49,9 @@ func initGCEDriverWithCloudProvider(t *testing.T, cloudProvider gce.GCECompute) 
 	fallbackRequisiteZones := []string{}
 	enableStoragePools := false
 	multiZoneVolumeHandleConfig := MultiZoneVolumeHandleConfig{}
+	listVolumesConfig := ListVolumesConfig{}
 
-	controllerServer := NewControllerServer(gceDriver, cloudProvider, errorBackoffInitialDuration, errorBackoffMaxDuration, fallbackRequisiteZones, enableStoragePools, multiZoneVolumeHandleConfig)
+	controllerServer := NewControllerServer(gceDriver, cloudProvider, errorBackoffInitialDuration, errorBackoffMaxDuration, fallbackRequisiteZones, enableStoragePools, multiZoneVolumeHandleConfig, listVolumesConfig)
 	err := gceDriver.SetupGCEDriver(driver, vendorVersion, nil, nil, nil, controllerServer, nil)
 	if err != nil {
 		t.Fatalf("Failed to setup GCE Driver: %v", err)

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -56,13 +56,17 @@ func GCEClientAndDriverSetup(instance *remote.InstanceInfo, computeEndpoint stri
 	extra_flags := []string{
 		fmt.Sprintf("--extra-labels=%s=%s", DiskLabelKey, DiskLabelValue),
 		"--max-concurrent-format-and-mount=20", // otherwise the serialization times out the e2e test.
+		"--multi-zone-volume-handle-enable",
+		"--multi-zone-volume-handle-disk-types=pd-standard",
+		"--use-instance-api-to-poll-attachment-disk-types=pd-ssd",
+		"--use-instance-api-to-list-volumes-published-nodes",
 	}
 	extra_flags = append(extra_flags, fmt.Sprintf("--compute-endpoint=%s", computeEndpoint))
 
 	workspace := remote.NewWorkspaceDir("gce-pd-e2e-")
 	// Log at V(6) as the compute API calls are emitted at that level and it's
 	// useful to see what's happening when debugging tests.
-	driverRunCmd := fmt.Sprintf("sh -c '/usr/bin/nohup %s/gce-pd-csi-driver -v=6 --endpoint=%s --multi-zone-volume-handle-enable --multi-zone-volume-handle-disk-types=pd-standard --use-instance-api-to-poll-attachment-disk-types=pd-ssd %s 2> %s/prog.out < /dev/null > /dev/null &'",
+	driverRunCmd := fmt.Sprintf("sh -c '/usr/bin/nohup %s/gce-pd-csi-driver -v=6 --endpoint=%s %s 2> %s/prog.out < /dev/null > /dev/null &'",
 		workspace, endpoint, strings.Join(extra_flags, " "), workspace)
 	config := &remote.ClientConfig{
 		PkgPath:      pkgPath,

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -64,13 +64,14 @@ func TestSanity(t *testing.T) {
 	fallbackRequisiteZones := []string{}
 	enableStoragePools := false
 	multiZoneVolumeHandleConfig := driver.MultiZoneVolumeHandleConfig{}
+	listVolumesConfig := driver.ListVolumesConfig{}
 
 	mounter := mountmanager.NewFakeSafeMounter()
 	deviceUtils := deviceutils.NewFakeDeviceUtils(true)
 
 	//Initialize GCE Driver
 	identityServer := driver.NewIdentityServer(gceDriver)
-	controllerServer := driver.NewControllerServer(gceDriver, cloudProvider, 0, 5*time.Minute, fallbackRequisiteZones, enableStoragePools, multiZoneVolumeHandleConfig)
+	controllerServer := driver.NewControllerServer(gceDriver, cloudProvider, 0, 5*time.Minute, fallbackRequisiteZones, enableStoragePools, multiZoneVolumeHandleConfig, listVolumesConfig)
 	fakeStatter := mountmanager.NewFakeStatterWithOptions(mounter, mountmanager.FakeStatterOptions{IsBlock: false})
 	nodeServer := driver.NewNodeServer(gceDriver, mounter, deviceUtils, metadataservice.NewFakeService(), fakeStatter)
 	err = gceDriver.SetupGCEDriver(driverName, vendorVersion, extraLabels, nil, identityServer, controllerServer, nodeServer)


### PR DESCRIPTION
  **What type of PR is this?**
  /kind bug
  
  **What this PR does / why we need it**:
  
  The `disks.list` API is currently used in ListVolumes RPC. This looks up all disks within a project/region. The response includes a `items[].users[]` field, which contains the list of all VMs that are attached to a given disk. Thehe `items[].users[]` array has an implicit limit of 50 VMs. If a disk is attached to more than 50 instances, only 50 instances will be returned in `items[].users[]`. This causes problems with the [`external-attacher`](https://github.com/kubernetes-csi/external-attacher/blob/5f016e3d49b561d4e72375468684c6e19e56044a/pkg/controller/csi_handler.go#L134) reconciliation logic, since these disks appear to not be attached. When this occurs, the `external-attacher` will re-issue unnecessary ControllerPublishVolume calls for these disk/VM pairs. This causes additional RPC calls to the compute API (2x per ControllerPublish for `instances.get` and `disks.get`), and increases load on the PDCSI controller. The user facing effect is that GCP quota can be consumed unnecessarily.
  
The `instances.list` API has a `items[].disks[]` field which indicates all attached disks for an instance.  By moving to `instances.list` API to determine which VMs a disk is attached to, this gets around the 50 instance limit. Each VM can attach up to 128 disks (127 excluding the boot disk), so the `instances.list` API does not limit responses.
  
By making this new API call, the PDCSI controller will receive more data from the GCE API (from `instances.list` and `instances.get`). This has the potential to increase the latency of the ListVolume RPC call. This PR attempts to offset cost of this additional (paginated) API call by introducing two enhancements:
   *  This PR adds a new command line flag to filter disks that are returned in `instances.list` API call. This allows a driver to limit disks with particular features. For example, in Kubernetes, the driver should only be concerned about determining if disks are attached to VMs associated with the Kubernetes cluster the driver is running in. To limit total responses from `instances.list`, an administrator can pre-tag node VMs with a label (eg: the Kubernetes cluster name) and run the driver with the `--instances-list-filters` flag, targeting this label.
   * This PR limits the response fields returned from the GCE API for `disks.list` and `instances.list` API calls. Only a subset of the available response fields are actually used by the PDCSI controller client. This should reduce the payload response size, reducing the memory burst footprint of ListVolumes API calls (since partial results are cached in memory), and response latency of each paginated call, as less data needs to be transfered from the GCE server endpoint.
  
  **Does this PR introduce a user-facing change?**:
  ```release-note
The --instances-list-filters command line flag allows the driver to filter on response properties when listing VMs from the GCE API in ListVolumes RPC.
The --use-instance-api-to-list-volumes-published-nodes command line flag allows the driver to use the instances.list API instead of disks.list API when determining PublishedNodeIs in ListVolumes RPC.
  ```

**Testing**:

Validated existing behavior with:

```
./test/run-e2e-local.sh --enable-confidential-compute --use-instance-api-to-list-volumes-published-nodes=false
```

Validated new behavior:

```
./test/run-e2e-local.sh --enable-confidential-compute --use-instance-api-to-list-volumes-published-nodes
```
