### PR TITLE
Reassign error returned from validateStoragePools so InvalidArgument is recorded

### DIFF
--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -326,7 +326,9 @@ func (gceCS *GCEControllerServer) CreateVolume(ctx context.Context, req *csi.Cre
 
 	err = validateStoragePools(req, params, gceCS.CloudProvider.GetDefaultProject())
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "CreateVolume failed to validate storage pools: %v", err)
+		// Reassign error so that all errors are reported as InvalidArgument to RecordOperationErrorMetrics.
+		err = status.Errorf(codes.InvalidArgument, "CreateVolume failed to validate storage pools: %v", err)
+		return nil, err
 	}
 
 	// Verify that the regional availability class is only used on regional disks.


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Reassign error returned from validateStoragePools so InvalidArgument is recorded. Currently, since the error is not reassigned to have the InvalidArgumentCode, when `defer	gceCS.Metrics.RecordOperationErrorMetrics("CreateVolume", err, diskTypeForMetric, enableConfidentialCompute, enableStoragePools)` is executed, it passes an error that looks like fmt.Errorf("error") to `RecordOperationErrorMetrics`, which is technically an Internal error. 

 I'm fixing this first for Storage Pools, but it looks like we have this issue in a lot of places. In some cases, we don't reassign the error at all, meaning `defer	gceCS.Metrics.RecordOperationErrorMetrics("CreateVolume", err, diskTypeForMetric, enableConfidentialCompute, enableStoragePools)` will actually pass a nil error, resulting in a OK status CreateVolume call being reported to the operation error metric. In some places (like in the Storage Pools case), we reassign the err, but we add an error code onto the error before returning. This won't get recorded to  RecordOperationErrorMetrics unless we actually reassign this error, or implement RecordOperationErrorMetrics in a different way. 


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Reassign error returned from validateStoragePools so InvalidArgument is recorded
```
