### PR TITLE
[WIP] Make defer RecordOperationErrorMetrics always report the correct error code

### DIFF
--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -326,7 +326,9 @@ func (gceCS *GCEControllerServer) CreateVolume(ctx context.Context, req *csi.Cre
 
 	err = validateStoragePools(req, params, gceCS.CloudProvider.GetDefaultProject())
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "CreateVolume failed to validate storage pools: %v", err)
+		// Reassign error so that all errors are reported as InvalidArgument to RecordOperationErrorMetrics.
+		err = status.Errorf(codes.InvalidArgument, "CreateVolume failed to validate storage pools: %v", err)
+		return nil, err
 	}
 
 	// Verify that the regional availability class is only used on regional disks.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -92,6 +92,20 @@ func (mm *MetricsManager) recordComponentVersionMetric() error {
 	return nil
 }
 
+type Fields struct {
+	DiskType                  string
+	EnableConfidentialCompute string
+	EnableStoragePools        string
+}
+
+func NewFields() Fields {
+	return Fields{
+		DiskType:                  DefaultDiskTypeForMetric,
+		EnableConfidentialCompute: DefaultEnableConfidentialCompute,
+		EnableStoragePools:        DefaultEnableStoragePools,
+	}
+}
+
 func (mm *MetricsManager) RecordOperationErrorMetrics(
 	operationName string,
 	operationErr error,
@@ -101,6 +115,14 @@ func (mm *MetricsManager) RecordOperationErrorMetrics(
 	errCode := errorCodeLabelValue(operationErr)
 	pdcsiOperationErrorsMetric.WithLabelValues(pdcsiDriverName, "/csi.v1.Controller/"+operationName, errCode, diskType, enableConfidentialStorage, enableStoragePools).Inc()
 	klog.Infof("Recorded PDCSI operation error code: %q", errCode)
+}
+
+func (mm *MetricsManager) RecordOperationErrorMetricsFields(
+	operationName string,
+	operationErr error,
+	fields Fields,
+) {
+	RecordOperationErrorMetrics(operationName, operationErr, fields.DiskType, fields.EnableConfidentialCompute, fields.EnableStoragePools)
 }
 
 func (mm *MetricsManager) EmitGKEComponentVersion() error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

 /kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Currently, we rely on gceCS.Metrics.RecordOperationErrorMetrics within a defer call to record error codes to the pdcsi operation error metric. We define this at the beginning of each CSI Call, but this only works if we reassign the error (err) before returning from the CSI call (CreateVolume). 

**Issue 1**
In lots of places, we do not reassign createVolErr, and just return errors directly. This leads to a nil error being reported to RecordOperationErrorMetrics, which makes us report this error as a success (status OK) to the pdcsi operation error metric.

```
func (gceCS *GCEControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
	var err error 
	diskTypeForMetric := metrics.DefaultDiskTypeForMetric
	enableConfidentialCompute := metrics.DefaultEnableConfidentialCompute
	enableStoragePools := metrics.DefaultEnableStoragePools
	defer func() {
		gceCS.Metrics.RecordOperationErrorMetrics("CreateVolume", err, diskTypeForMetric, enableConfidentialCompute, enableStoragePools)
	}()
       ...
}
```

**Issue 2**
In some places we do something like the following. We call a function (validateVolumeCapabilities) that returns an error that doesn't specify an error code. Inline, we add on an InvalidArgument error code to the error, and return without reassigning the error. This leads to the error without the error code being reported to  RecordOperationErrorMetrics, which will count as an Internal error code, when we clearly meant for it to be an InvalidArgument error code. 

```
	err = validateVolumeCapabilities(volumeCapabilities)
	if err != nil {
		return nil, status.Errorf(codes.InvalidArgument, "VolumeCapabilities is invalid: %v", err.Error())
	}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Make defer RecordOperationErrorMetrics always report the correct error code
```
