### PR TITLE
Improve error messages for ControllerExpandVolume / CreateSnapshot of multi-zone PV.

### DIFF
--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -1160,7 +1160,7 @@ func (gceCS *GCEControllerServer) CreateSnapshot(ctx context.Context, req *csi.C
 
 	volumeIsMultiZone := isMultiZoneVolKey(volKey)
 	if gceCS.multiZoneVolumeHandleConfig.Enable && volumeIsMultiZone {
-		return nil, fmt.Errorf("Snapshots are not supported with the `multi-zone` PV volumeHandle feature.")
+		return nil, status.Errorf(codes.InvalidArgument, "Snapshots are not supported with the multi-zone PV volumeHandle feature")
 	}
 
 	if acquired := gceCS.volumeLocks.TryAcquire(volumeID); !acquired {
@@ -1521,7 +1521,7 @@ func (gceCS *GCEControllerServer) ControllerExpandVolume(ctx context.Context, re
 
 	volumeIsMultiZone := isMultiZoneVolKey(volKey)
 	if gceCS.multiZoneVolumeHandleConfig.Enable && volumeIsMultiZone {
-		return nil, fmt.Errorf("Resize operation is not supported with the `multi-zone` PVC volumeHandle feature. Please re-create the disk from source if you want a larger size.")
+		return nil, status.Errorf(codes.InvalidArgument, "ControllerExpandVolume is not supported with the multi-zone PVC volumeHandle feature. Please re-create the volume %v from source if you want a larger size", volumeID)
 	}
 
 	sourceDisk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey, gce.GCEAPIVersionV1)

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -1160,7 +1160,7 @@ func (gceCS *GCEControllerServer) CreateSnapshot(ctx context.Context, req *csi.C
 
 	volumeIsMultiZone := isMultiZoneVolKey(volKey)
 	if gceCS.multiZoneVolumeHandleConfig.Enable && volumeIsMultiZone {
-		return nil, status.Errorf(codes.InvalidArgument, "Snapshots are not supported with the multi-zone PV volumeHandle feature")
+		return nil, status.Errorf(codes.InvalidArgument, "CreateSnapshot for volume %v failed. Snapshots are not supported with the multi-zone PV volumeHandle feature", volumeID)
 	}
 
 	if acquired := gceCS.volumeLocks.TryAcquire(volumeID); !acquired {

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -255,6 +255,77 @@ func TestCreateSnapshotArguments(t *testing.T) {
 	}
 }
 
+func TestUnsupporteddMultiZoneCreateSnapshot(t *testing.T) {
+	testCase := struct {
+		name       string
+		req        *csi.CreateSnapshotRequest
+		expErrCode codes.Code
+	}{
+		name: "failed create snapshot for multi-zone PV", // Example values
+		req: &csi.CreateSnapshotRequest{
+			Name:           name,
+			SourceVolumeId: multiZoneVolumeID,
+		},
+		expErrCode: codes.InvalidArgument,
+	}
+
+	t.Logf("test case: %s", testCase.name)
+
+	gceDriver := initGCEDriver(t, nil)
+	gceDriver.cs.multiZoneVolumeHandleConfig = MultiZoneVolumeHandleConfig{
+		Enable: true,
+	}
+
+	// Start Test
+	_, err := gceDriver.cs.CreateSnapshot(context.Background(), testCase.req)
+	if err != nil {
+		serverError, ok := status.FromError(err)
+		if !ok {
+			t.Fatalf("Could not get error status code from err: %v", serverError)
+		}
+		if serverError.Code() != testCase.expErrCode {
+			t.Fatalf("Expected error code: %v, got: %v. err : %v", testCase.expErrCode, serverError.Code(), err)
+		}
+	} else {
+		t.Fatalf("Expected error: %v, got no error", testCase.expErrCode)
+	}
+}
+
+func TestUnsupportedMultiZoneControllerExpandVolume(t *testing.T) {
+	testCase := struct {
+		name       string
+		req        *csi.ControllerExpandVolumeRequest
+		expErrCode codes.Code
+	}{
+		name: "failed create snapshot for multi-zone PV", // Example values
+		req: &csi.ControllerExpandVolumeRequest{
+			VolumeId: multiZoneVolumeID,
+		},
+		expErrCode: codes.InvalidArgument,
+	}
+
+	t.Logf("test case: %s", testCase.name)
+
+	gceDriver := initGCEDriver(t, nil)
+	gceDriver.cs.multiZoneVolumeHandleConfig = MultiZoneVolumeHandleConfig{
+		Enable: true,
+	}
+
+	// Start Test
+	_, err := gceDriver.cs.ControllerExpandVolume(context.Background(), testCase.req)
+	if err != nil {
+		serverError, ok := status.FromError(err)
+		if !ok {
+			t.Fatalf("Could not get error status code from err: %v", serverError)
+		}
+		if serverError.Code() != testCase.expErrCode {
+			t.Fatalf("Expected error code: %v, got: %v. err : %v", testCase.expErrCode, serverError.Code(), err)
+		}
+	} else {
+		t.Fatalf("Expected error: %v, got no error", testCase.expErrCode)
+	}
+}
+
 func TestDeleteSnapshot(t *testing.T) {
 	testCases := []struct {
 		name       string

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -255,7 +255,7 @@ func TestCreateSnapshotArguments(t *testing.T) {
 	}
 }
 
-func TestUnsupporteddMultiZoneCreateSnapshot(t *testing.T) {
+func TestUnsupportedMultiZoneCreateSnapshot(t *testing.T) {
 	testCase := struct {
 		name       string
 		req        *csi.CreateSnapshotRequest


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
#### What this PR does / why we need it:
Improve error messages for ControllerExpandVolume / CreateSnapshot of multi-zone PV.

Before:
CreateSnapshot: "Failed to create snapshot: failed to take snapshot of the volume projects/psch-gke-dev/zones/multi-zone/disks/hdml-llama2-70b-hf: "rpc error: code = Unknown desc = CreateSnapshot, failed 
to getDisk: googleapi: Error 400: Invalid value for field 'zone': 'multi-zone'. Unknown zone., invalid""
ControllerExpandVolume: "resize volume "my-disk-pv" by resizer "pd.csi.storage.gke.io" failed: rpc error: code = Unknown desc = ControllerExpandVolume failed to resize disk: failed to get disk: googleapi: Error 400: In
valid value for field 'zone': 'multi-zone'. Unknown zone., invalid"

After:
CreateSnapshot: "Snapshots are not supported with the `multi-zone` PV volumeHandle feature"
ControllerExpandVolume: "Resize operation is not supported with the `multi-zone` PVC volumeHandle feature. Please re-create the disk from source if you want a larger size."
#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Update logging on multi-zone feature support for volume snapshot and resize
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
