### PR TITLE
Install golang version inside  run-k8s-integration-ci.sh script run by prow tests 

### DIFF
--- a/test/run-k8s-integration-ci.sh
+++ b/test/run-k8s-integration-ci.sh
@@ -33,6 +33,15 @@ readonly test_disk_image_snapshot=${TEST_DISK_IMAGE_SNAPSHOT:-true}
 
 readonly GCE_PD_TEST_FOCUS="PersistentVolumes\sGCEPD|[V|v]olume\sexpand|\[sig-storage\]\sIn-tree\sVolumes\s\[Driver:\sgcepd\]|allowedTopologies|Pod\sDisks|PersistentVolumes\sDefault"
 
+# Install golang.
+version=1.22.3
+wget -O go_tar.tar.gz https://go.dev/dl/go${version}.linux-amd64.tar.gz -q
+# Remove the existing GoLang installation directory
+rm -rf /usr/local/go && tar -xzf go_tar.tar.gz -C /usr/local
+# Add the GoLang binary directory to systems PATH env, allowing prow tests
+# to run go commands with this go version.
+export PATH=$PATH:/usr/local/go/bin && go version && rm go_tar.tar.gz
+
 storage_classes=sc-balanced.yaml,sc-ssd.yaml,sc-xfs.yaml
 
 if [[ $test_pd_labels = true ]] ; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:
Prow tests are failing with two errors; 
go: errors parsing go.mod:
/home/prow/go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/go.mod:3: invalid go version '1.22.0': must match format 1.23
/home/prow/go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/go.mod:5: unknown directive: toolchain

I think this is because prow tests use 1.21, and we are declaring toolchain 1.22.2 meaning the tests need a golang version of 1.22.2 +. I think installing golang will force prow to use this version of golang. This is what GCS fuse driver does, and the prow tests are passing even though GCS fuse is specifying toolchain 1.22.2, and go version 1.22.0 in the Dockerfile. If this doesn't work, it also prints out go version to help with debugging. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
