### PR TITLE
Format byte array error output from google_nvme_id as string

### DIFF
--- a/pkg/deviceutils/device-utils.go
+++ b/pkg/deviceutils/device-utils.go
@@ -170,7 +170,7 @@ func getNvmeSerial(devicePath string) (string, error) {
 		nvmeIdPath,
 		fmt.Sprintf("-d%s", devicePath)).CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("google_nvme_id failed for device %q with output %v: %w", devicePath, out, err)
+		return "", fmt.Errorf("google_nvme_id failed for device %q with output %s: %w", devicePath, out, err)
 	}
 
 	return parseNvmeSerial(string(out))


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Error message is currently being printed out as a byte array (%v). It should be printed out as a string (%s). This is done elsewhere `exec.CombinedOutput()` is parsed.

Current error message is formatted like:

```
couldn't get serial number for disk pvc-b161d218-87e9-4657-9339-a11ef1eb7a54 at device path /dev/nvme1n2: google_nvme_id failed for device "/dev/nvme1n2" with output [91 50 48 50 52 45 48 54 45 50 48 84 49 57 58 50 52 58 52 48 43 48 48 48 48 93 58 32 80 97 115 115 101 100 32 100 101 118 105 99 101 32 119 97 115 32 110 111 116 32 97 110 32 78 86 77 101 32 100 101 118 105 99 101 46 32 32 40 89 111 117 32 109 97 121 32 110 101 101 100 32 116 111 32 114 117 110 32 116 104 105 115 32 115 99 114 105 112 116 32 97 115 32 114 111 111 116 47 119 105 116 104 32 115 117 100 111 41 46 10]: exit status 1
```

This should be:

```
couldn't get serial number for disk pvc-b161d218-87e9-4657-9339-a11ef1eb7a54 at device path /dev/nvme1n2: google_nvme_id failed for device "/dev/nvme1n2" with output [2024-06-22T07:26:12+0000]: Passed device was not an NVMe device.  (You may need to run this script as root/with sudo).: exit status 1
```


**Special notes for your reviewer**:
This was discovered when debugging the issue for #1760

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Improve error message when `google_nvme_id` returns a non-zero exit code
```
