### PR TITLE
Add verify-docker-deps.sh to verify-all.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ init-buildx:
 	$(DOCKER) run --rm --privileged multiarch/qemu-user-static --reset --credential yes --persistent yes
 	# Ensure we use a builder that can leverage it (the default on linux will not)
 	-$(DOCKER) buildx rm multiarch-multiplatform-builder
-	$(DOCKER) buildx create --use --name=multiarch-multiplatform-builder --driver-opt network=host --driver-opt image=moby/buildkit:v0.11.3
+	$(DOCKER) buildx create --use --name=multiarch-multiplatform-builder --driver-opt network=host --driver-opt image=moby/buildkit:v0.14.1
 	# Register gcloud as a Docker credential helper.
 	# Required for "docker buildx build --push".
 	gcloud auth configure-docker --quiet

--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -22,5 +22,6 @@ PKG_ROOT=$(git rev-parse --show-toplevel)
 
 "${PKG_ROOT}/hack/verify-gofmt.sh"
 "${PKG_ROOT}/hack/verify-govet.sh"
+"${PKG_ROOT}/hack/verify-docker-deps.sh"
 
 make -C "${PKG_ROOT}" all


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
This validates that both production container images (amd64,arm64) have hermetic dependencies for all executables in their container images. It runs the `verify-docker-deps.sh` script as part of `verify-all.sh`, which is run in PDCSI github presubmit.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
