### PR TITLE
Remove validation image from our Dockerfile

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,21 @@
+name: Sync upstream
+# This runs every day on 1000 UTC
+on:
+  schedule:
+    - cron: '0 10 * * *'
+  # Allows manual workflow run
+  workflow_dispatch:
+
+permissions: write-all
+
+jobs:
+ build:
+  runs-on: ubuntu-latest
+  steps:
+    - name: Create upstream version tag
+      uses: DataDog/sync-upstream-release-tag@v0.3.2
+      with:
+        github_actor: "${GITHUB_ACTOR}"
+        github_repository: "${GITHUB_REPOSITORY}"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        upstream_repo: kubernetes-sigs/gcp-compute-persistent-disk-csi-driver

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,7 +13,7 @@ jobs:
   runs-on: ubuntu-latest
   steps:
     - name: Create upstream version tag
-      uses: DataDog/sync-upstream-release-tag@v0.3.2
+      uses: DataDog/sync-upstream-release-tag@v0.3.3
       with:
         github_actor: "${GITHUB_ACTOR}"
         github_repository: "${GITHUB_REPOSITORY}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,5 +11,5 @@ test:
 
 build-docker-image:
   variables:
-    EXTRA_ARGS: "--build-arg=BUILDPLATFORM=linux --build-arg=STAGINGVERSION=$CI_COMMIT_TAG"
+    EXTRA_ARGS: "--build-arg=BUILDPLATFORM=linux --build-arg=STAGINGVERSION=$CI_COMMIT_TAG -f Dockerfile.dd"
   extends: .build-docker-image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,6 @@
+include: https://gitlab-templates.ddbuild.io/compute-delivery/v2/compute-delivery.yml
+
+build-docker-image:
+  variables:
+    EXTRA_ARGS: "--build-arg=BUILDPLATFORM=linux --build-arg=STAGINGVERSION=$CI_COMMIT_TAG"
+  extends: .build-docker-image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,12 @@
 include: https://gitlab-templates.ddbuild.io/compute-delivery/v2/compute-delivery.yml
 
+test:
+  stage: verify
+  tags: [ "arch:amd64" ]
+  image: registry.ddbuild.io/images/mirror/golang:1.20
+  script:
+    - cd pkg && go test ./... -v
+
 build-docker-image:
   variables:
     EXTRA_ARGS: "--build-arg=BUILDPLATFORM=linux --build-arg=STAGINGVERSION=$CI_COMMIT_TAG"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,9 @@ include: https://gitlab-templates.ddbuild.io/compute-delivery/v2/compute-deliver
 test:
   stage: verify
   tags: [ "arch:amd64" ]
-  image: registry.ddbuild.io/images/mirror/golang:1.20
+  image: registry.ddbuild.io/images/mirror/golang:1.22.2
+  variables:
+    GOTOOLCHAIN: "auto"
   script:
     - cd pkg && go test ./... -v
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+
+ARG BASE_IMAGE
 # Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,11 +35,11 @@ RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs nvme-
 FROM gcr.io/distroless/base-debian12 as distroless-base
 
 # The distroless amd64 image has a target triplet of x86_64
-FROM distroless-base AS distroless-amd64
+FROM $BASE_IMAGE AS distroless-amd64
 ENV LIB_DIR_PREFIX x86_64
 
 # The distroless arm64 image has a target triplet of aarch64
-FROM distroless-base AS distroless-arm64
+FROM $BASE_IMAGE AS distroless-arm64
 ENV LIB_DIR_PREFIX aarch64
 
 FROM distroless-$TARGETARCH as output-image

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ FROM --platform=$BUILDPLATFORM golang:1.22.4 as builder
 
 ARG STAGINGVERSION
 ARG TARGETPLATFORM
+ENV GOTOOLCHAIN auto
 
 WORKDIR /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 ADD . .

--- a/Dockerfile.dd
+++ b/Dockerfile.dd
@@ -1,0 +1,38 @@
+ARG BASE_IMAGE
+ARG BUILDER_IMAGE
+
+FROM --platform=$BUILDPLATFORM $BUILDER_IMAGE as builder
+
+ARG STAGINGVERSION
+ARG TARGETPLATFORM
+ENV GOTOOLCHAIN auto
+
+WORKDIR /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+ADD . .
+RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') GCE_PD_CSI_STAGING_VERSION=$STAGINGVERSION make gce-pd-driver
+
+# Start from BASE_IMAGE.
+FROM $BASE_IMAGE as output-image
+
+# Install necessary dependencies
+# google_nvme_id script depends on the following packages: nvme-cli, xxd, bash
+USER root
+RUN clean-apt install util-linux e2fsprogs mount ca-certificates udev xfsprogs nvme-cli xxd bash
+USER dog
+
+# Copy NVME support required script and rules into base image.
+COPY deploy/kubernetes/udev/google_nvme_id /lib/udev_containerized/google_nvme_id
+
+# Build stage used for validation of the output-image
+# See validate-container-linux-* targets in Makefile
+FROM output-image as validation-image
+
+COPY --from=output-image /usr/bin/ldd /usr/bin/find /usr/bin/xargs /usr/bin/
+COPY --from=builder /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/hack/print-missing-deps.sh /print-missing-deps.sh
+SHELL ["/bin/bash", "-c"]
+RUN /print-missing-deps.sh
+
+# Final build stage, create the real Docker image with ENTRYPOINT
+FROM output-image
+
+ENTRYPOINT ["/gce-pd-csi-driver"]

--- a/Dockerfile.dd
+++ b/Dockerfile.dd
@@ -12,7 +12,7 @@ ADD . .
 RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') GCE_PD_CSI_STAGING_VERSION=$STAGINGVERSION make gce-pd-driver
 
 # Start from BASE_IMAGE.
-FROM $BASE_IMAGE as output-image
+FROM $BASE_IMAGE
 
 # Install necessary dependencies
 # google_nvme_id script depends on the following packages: nvme-cli, xxd, bash
@@ -22,17 +22,5 @@ USER dog
 
 # Copy NVME support required script and rules into base image.
 COPY deploy/kubernetes/udev/google_nvme_id /lib/udev_containerized/google_nvme_id
-
-# Build stage used for validation of the output-image
-# See validate-container-linux-* targets in Makefile
-FROM output-image as validation-image
-
-COPY --from=output-image /usr/bin/ldd /usr/bin/find /usr/bin/xargs /usr/bin/
-COPY --from=builder /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/hack/print-missing-deps.sh /print-missing-deps.sh
-SHELL ["/bin/bash", "-c"]
-RUN /print-missing-deps.sh
-
-# Final build stage, create the real Docker image with ENTRYPOINT
-FROM output-image
 
 ENTRYPOINT ["/gce-pd-csi-driver"]

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ endif
 all: gce-pd-driver gce-pd-driver-windows
 gce-pd-driver: require-GCE_PD_CSI_STAGING_VERSION
 	mkdir -p bin
-	CGO_ENABLED=0 go build -mod=vendor -gcflags=$(GCFLAGS) -ldflags "-extldflags=static -X main.version=$(STAGINGVERSION)" -o bin/${DRIVERBINARY} ./cmd/gce-pd-csi-driver/
+	CGO_ENABLED=0 go build -mod=vendor -gcflags=$(GCFLAGS) -ldflags "-extldflags=static -X main.version=$(STAGINGVERSION)" -o bin/${DRIVERBINARY} -buildvcs=false ./cmd/gce-pd-csi-driver/
 
 gce-pd-driver-windows: require-GCE_PD_CSI_STAGING_VERSION
 ifeq (${GOARCH}, amd64)


### PR DESCRIPTION
We actually don't need to check if libraries are present as we install the required binaries using apt instead of cherry-picking libs and binaries from a different image.