### PR TITLE
Update run-e2e.sh to use prow-build SA by in presubmit

### DIFF
--- a/test/e2e/tests/setup_e2e_test.go
+++ b/test/e2e/tests/setup_e2e_test.go
@@ -87,7 +87,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).To(BeNil())
 
 	if *runInProw {
-		*project, *serviceAccount = testutils.SetupProwConfig("gce-project")
+		projectInfo := testutils.SetupProwConfig("gce-project")
+		if *serviceAccount == "" {
+			*serviceAccount = testutils.GetDefaultServiceAccount(projectInfo)
+		}
+		*project = projectInfo.ProjectName
+		klog.Infof("Using project %v and service account %v", *project, *serviceAccount)
 	}
 
 	Expect(*project).ToNot(BeEmpty(), "Project should not be empty")

--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -265,7 +265,8 @@ func handle() error {
 		if err != nil {
 			return fmt.Errorf("failed to get gcloud project: %s, err: %w", oldProject, err)
 		}
-		newproject, _ := testutils.SetupProwConfig(*boskosResourceType)
+		projectInfo := testutils.SetupProwConfig(*boskosResourceType)
+		newproject := projectInfo.ProjectName
 		err = setEnvProject(newproject)
 		if err != nil {
 			return fmt.Errorf("failed to set project environment to %s: %w", newproject, err)

--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -5,4 +5,4 @@ set -x
 
 readonly PKGDIR=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 
-go test --timeout 30m --v "${PKGDIR}/test/e2e/tests" --run-in-prow=true --delete-instances=true --logtostderr
+go test --timeout 30m --v "${PKGDIR}/test/e2e/tests" --run-in-prow=true --service-account=prow-build@k8s-infra-prow-build.iam.gserviceaccount.com --delete-instances=true --logtostderr "$@"


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
This fixes the e2e prow tests (presubmit) to run with Boskos projects. e2e tests have been failing since https://github.com/kubernetes/test-infra/pull/32809 was submitted

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
