### PR TITLE
Reverting the Dockerfile debian image from bookworm to bullseye due to regression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,15 +22,13 @@ ADD . .
 RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') GCE_PD_CSI_STAGING_VERSION=$STAGINGVERSION make gce-pd-driver
 
 # Start from Kubernetes Debian base.
-
-FROM gke.gcr.io/debian-base:bookworm-v1.0.3-gke.0 as debian
-
+FROM gke.gcr.io/debian-base:bullseye-v1.4.3-gke.5 as debian
 # Install necessary dependencies
 # google_nvme_id script depends on the following packages: nvme-cli, xxd, bash
 RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs nvme-cli xxd bash
 
 # Since we're leveraging apt to pull in dependencies, we use `gcr.io/distroless/base` because it includes glibc.
-FROM gcr.io/distroless/base-debian12 as distroless-base
+FROM gcr.io/distroless/base-debian11 as distroless-base
 
 # The distroless amd64 image has a target triplet of x86_64
 FROM distroless-base AS distroless-amd64
@@ -74,7 +72,8 @@ COPY --from=debian /bin/ln /bin/ln
 COPY --from=debian /bin/udevadm /bin/udevadm
 
 # Copy shared libraries into distroless base.
-COPY --from=debian /lib/${LIB_DIR_PREFIX}-linux-gnu/libselinux.so.1 \
+COPY --from=debian /lib/${LIB_DIR_PREFIX}-linux-gnu/libpcre.so.3 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libselinux.so.1 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libtinfo.so.6 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libe2p.so.2 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libcom_err.so.2 \
@@ -83,20 +82,7 @@ COPY --from=debian /lib/${LIB_DIR_PREFIX}-linux-gnu/libselinux.so.1 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libgcc_s.so.1 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/liblzma.so.5 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libreadline.so.8 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libz.so.1 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libc.so.6 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/liburcu.so.8 \ 
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libcap.so.2 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libcrypto.so.3 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libdbus-1.so.3 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libgcrypt.so.20 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libjson-c.so.5 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/liblz4.so.1 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libm.so.6 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libnvme-mi.so.1 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libnvme.so.1 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libsystemd.so.0 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libzstd.so.1 /lib/${LIB_DIR_PREFIX}-linux-gnu/
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libz.so.1 /lib/${LIB_DIR_PREFIX}-linux-gnu/
 
 COPY --from=debian /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libblkid.so.1 \
                    /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libbsd.so.0 \
@@ -107,9 +93,9 @@ COPY --from=debian /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libblkid.so.1 \
                    /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libacl.so.1 \
                    /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libattr.so.1 \
                    /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libedit.so.2 \
-                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libicudata.so.72 \
-                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libicui18n.so.72 \
-                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libicuuc.so.72 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libicudata.so.67 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libicui18n.so.67 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libicuuc.so.67 \
                    /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libkmod.so.2 \
                    /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libmd.so.0 \
                    /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libpcre2-8.so.0 \


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This reverts the debian image version which was updated in #1738. #1738 introduced a regression due to a missing dependency, we will allow some soak for the fix in 1.30 before backporting.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Updates the debian base image to `debian-base:bullseye-v1.4.3-gke.5` from `debian-base:bookworm-v1.0.3-gke.0`
```
