### PR TITLE
Enable VolumeAttributesClass feature gate for CI runs

### DIFF
--- a/deploy/kubernetes/overlays/prow-stable-sidecar-rc-master/driver-args.yaml
+++ b/deploy/kubernetes/overlays/prow-stable-sidecar-rc-master/driver-args.yaml
@@ -1,7 +1,0 @@
-- op: add
-  path: /spec/template/spec/containers/4/args/-
-  value: --supports-dynamic-throughput-provisioning=hyperdisk-balanced,hyperdisk-throughput,hyperdisk-ml
-
-- op: add
-  path: /spec/template/spec/containers/4/args/-
-  value: --supports-dynamic-iops-provisioning=hyperdisk-balanced,hyperdisk-extreme

--- a/deploy/kubernetes/overlays/prow-stable-sidecar-rc-master/kustomization.yaml
+++ b/deploy/kubernetes/overlays/prow-stable-sidecar-rc-master/kustomization.yaml
@@ -24,11 +24,5 @@ patchesJson6902:
     kind: Deployment
     name: csi-gce-pd-controller
     version: v1
-- path: driver-args.yaml
-  target:
-    group: apps
-    kind: Deployment
-    name: csi-gce-pd-controller
-    version: v1
 transformers:
 - ../../images/prow-stable-sidecar-rc-master

--- a/docs/kubernetes/user-guides/volume-attributes-class.md
+++ b/docs/kubernetes/user-guides/volume-attributes-class.md
@@ -1,8 +1,8 @@
-# ControllerModifyVolume User Guide
+# VolumeAttributesClass User Guide
 
 >**Attention:** VolumeAttributesClass is a Kubernetes Beta feature since v1.31, but was initially introduced as an alpha feature in v1.29. See [this blog post](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) for more information on VolumeAttributesClasses and how to enable the feature gate.
 
-### ControllerModifyVolume Example
+### VolumeAttributesClass Example
 
 This example provisions a hyperdisk-balanced and then updates its IOPS and throughput.
 

--- a/test/run-k8s-integration-ci.sh
+++ b/test/run-k8s-integration-ci.sh
@@ -120,6 +120,9 @@ fi
 
 if [ "$test_volumeattributesclass" = true ]; then
   base_cmd="${base_cmd} --volumeattributesclass-files=hdb-volumeattributesclass.yaml --storageclass-for-vac-file=sc-hdb.yaml --kube-runtime-config=api/all=true"
+  if [ "$deployment_strategy" = "gce" ]; then
+    base_cmd="${base_cmd} --kube-feature-gates=VolumeAttributesClass=true"
+  fi
 fi
 
 eval "$base_cmd"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR fixes an issue where the CI tests do not have the feature gate for VolumeAttributesClass set. Additionally, duplicate definitions for --supports-dynamic-iops-provisioning and --supports-dynamic-throughput-provisioning are removed now that the command line arguments are default. ControllerModifyVolume has been replaced with VolumeAttributesClass in the user guide for clarity purposes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
