### PR TITLE
Add StatusConflict http kind to userErrorCodeMap.

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -98,6 +98,7 @@ var (
 		http.StatusBadRequest:      codes.InvalidArgument,
 		http.StatusTooManyRequests: codes.ResourceExhausted,
 		http.StatusNotFound:        codes.NotFound,
+		http.StatusConflict:        codes.FailedPrecondition,
 	}
 
 	// Regular expressions for validating parent_id, key and value of a resource tag.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR accounts for http error code 409 (Status conflict) and inputting it into the user error code map as FailedPrecondition. This will be used to filter out unactionable SLO triggering alerts.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
for internal bug.
**Does this PR introduce a user-facing change?**:
no
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/assign mattcary