### PR TITLE
Map RESOURCE_OPERATION_RATE_EXCEEDED to ResourceExhausted

### DIFF
--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -1244,6 +1244,7 @@ func codeForGCEOpError(err computev1.OperationErrorErrors) codes.Code {
 		"RATE_LIMIT_EXCEEDED":                       codes.ResourceExhausted,
 		"INVALID_USAGE":                             codes.InvalidArgument,
 		"UNSUPPORTED_OPERATION":                     codes.InvalidArgument,
+		"RESOURCE_OPERATION_RATE_EXCEEDED":          codes.ResourceExhausted,
 	}
 	if code, ok := userErrors[err.Code]; ok {
 		return code

--- a/pkg/gce-cloud-provider/compute/gce-compute_test.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute_test.go
@@ -164,6 +164,11 @@ func TestCodeForGCEOpError(t *testing.T) {
 			inputErr: computev1.OperationErrorErrors{Code: "UNSUPPORTED_OPERATION"},
 			expCode:  codes.InvalidArgument,
 		},
+		{
+			name:     "RESOURCE_OPERATION_RATE_EXCEEDED error",
+			inputErr: computev1.OperationErrorErrors{Code: "RESOURCE_OPERATION_RATE_EXCEEDED"},
+			expCode:  codes.ResourceExhausted,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Map RESOURCE_OPERATION_RATE_EXCEEDED to ResourceExhausted. Prevents us from being alerted for erros like: 

`CreateVolume failed to create single zonal disk pvc-xxx: failed to insert zonal disk: unknown error when polling the operation: rpc error: code = Internal desc = operation operation-xxx failed (RESOURCE_OPERATION_RATE_EXCEEDED): Operation rate exceeded for resource 'projects/xxx/global/snapshots/snapshot-pvc-xxx'. Too frequent operations from the source resource.`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Map RESOURCE_OPERATION_RATE_EXCEEDED to ResourceExhausted.
```
