### PR TITLE
switch to use snapshots.insert instead of disks.createsnapshot

### DIFF
--- a/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
+++ b/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
@@ -31,7 +31,7 @@ metadata:
   name: imagetag-csi-snapshotter-prow-head
 imageTag:
   name: registry.k8s.io/sig-storage/csi-snapshotter
-  newTag: "v6.3.3"
+  newTag: "v7.0.2"
 ---
 apiVersion: builtin
 kind: ImageTagTransformer

--- a/deploy/kubernetes/images/stable-master/image.yaml
+++ b/deploy/kubernetes/images/stable-master/image.yaml
@@ -31,7 +31,7 @@ metadata:
   name: imagetag-csi-snapshotter
 imageTag:
   name: registry.k8s.io/sig-storage/csi-snapshotter
-  newTag: "v6.3.3"
+  newTag: "v7.0.2"
 ---
 
 apiVersion: builtin


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
If we use disks.CreateSnapshot, there could be a race condition where snapshot.Status is "READY" but the snapshot creation is not actually done. Snapshots.Insert API avoids this problem.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
- snapshot.insert will try to grab resource lock too according to Xin.
- CMEK implicitly will be populated from PD if left blank, which keeps the previous behavior

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
use `snapshots.insert` instead of `disks.createsnapshot` when creating pd snapshots.
pdcsi release including this change **MUST** upgrade csi-snapshotter sidecar to v7.0.0+.
```
