### PR TITLE
Do not use beta API for hyperdisk in multi-writer mode.

### DIFF
--- a/CHANGELOG/CHANGELOG-1.12.md
+++ b/CHANGELOG/CHANGELOG-1.12.md
@@ -1,3 +1,45 @@
+# v1.12.13 - Changelog since v1.12.11
+
+## Changes by Kind
+
+### Bug
+- Update Go version and dependencies to fix CVE-2024-24790,CVE-2024-24789 by @Sneha-at in #1851
+
+# v1.12.12 - Changelog since v1.12.11
+
+## Changes by Kind
+
+### Bug
+- Automated cherry pick of #1658: Add support for checking if a device is being used by a filesystem by @pwschuurman in #1845
+
+
+# v1.12.11 - Changelog since v1.12.10
+
+## Changes by Kind
+
+### Bug
+- [release-1.12] Update debian image from bullseye to bookworm to fix CVEs by @k8s-infra-cherrypick-robot in #1735
+- Reverting the Dockerfile debian image from bookworm to bullseye due to regression by @Sneha-at in #1774
+- [release-1.12] Return Unavailable for 'connection reset by peer' errors by @k8s-infra-cherrypick-robot in #1813
+- Automated cherry pick of #1708: Properly unwrap gce-compute error code. by @hime in #1840
+
+# v1.12.10 - Changelog since v1.12.9
+
+## Changes by Kind
+
+### Bug
+- Fix CVE-2023-45288 by @dannawang0221 in #1682
+
+
+# v1.12.9 - Changelog since v1.12.8
+
+## Changes by Kind
+
+### Bug
+
+- Change GetDisk error reporting to temporary in CreateVolume codepath ([#1600])https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1600), [@k8s-infra-cherrypick-robot](https://github.com/k8s-infra-cherrypick-robot))
+- [release-1.12] Fix nvme path filtering logic for udevadm trigger by @k8s-infra-cherrypick-robot in #1647
+
 # v1.12.8 - Changelog since v1.12.7
 
 ## Changes by Kind

--- a/CHANGELOG/CHANGELOG-1.13.md
+++ b/CHANGELOG/CHANGELOG-1.13.md
@@ -1,3 +1,46 @@
+# v1.13.8 - Changelog since v1.13.7
+
+## Changes by Kind
+
+### Uncategorized
+
+- [release-1.13] Properly unwrap gce-compute error code. by @hime in #1839
+
+
+# v1.13.7 - Changelog since v1.13.6
+
+## Changes by Kind
+
+### Uncategorized
+
+- [release-1.13] Reassign error returned from validateStoragePools so InvalidArgument is recorded by @k8s-infra-cherrypick-robot in #1721
+- [release-1.13] Return Unavailable for 'connection reset by peer' errors by @k8s-infra-cherrypick-robot in #1724
+- [release-1.13] Update debian image from bullseye to bookworm to fix CVEs by @k8s-infra-cherrypick-robot in #1734
+- Reverting the Dockerfile debian image from bookworm to bullseye due to regression by @Sneha-at in #1775
+- Automated cherry pick of #1658: Add support for checking if a device is being used by a by @pwschuurman in #1805
+
+
+# v1.13.6 - Changelog since v1.13.5
+
+## Changes by Kind
+
+### Uncategorized
+
+- Automated cherry pick of #1666: migrate hyperdisk/chd/storagepools to GCE v1 disk API
+#1667: remove support for GCE Alpha Disks by @amacaskill in #1669
+- [release-1.13] Record original error code to operation_errors metric for temporary errors by @k8s-infra-cherrypick-robot in #1672
+- [release-1.13] Remove short variable declaration from validateStoragePools by @k8s-infra-cherrypick-robot in #1674
+- Fix CVE-2023-45288 by @dannawang0221 in #1683
+
+
+# v1.13.5 - Changelog since v1.13.4
+
+## Changes by Kind
+
+### Uncategorized
+_Nothing has changed._
+
+
 # v1.13.4 - Changelog since v1.13.3
 
 ## Changes by Kind

--- a/CHANGELOG/CHANGELOG-1.14.md
+++ b/CHANGELOG/CHANGELOG-1.14.md
@@ -1,3 +1,26 @@
+# v1.14.3 - Changelog since v1.14.2
+
+## Changes by Kind
+
+### Bug or Regression
+- Update base image to bookworm-v1.0.4-gke.2 by @k8s-infra-cherrypick-robot in #1834
+
+
+# v1.14.2 - Changelog since v1.14.1
+
+## Changes by Kind
+
+### Uncategorized
+- [release-1.14] Change OPERATION_CANCELED_BY_USER to Canceled instead of Aborted by @k8s-infra-cherrypick-robot in #1790
+
+# v1.14.1 - Changelog since v1.14.0
+
+## Changes by Kind
+
+### Bug or Regression
+- [release-1.14] Adding missing libgpg-error.so.0 required by nvme-cli by @k8s-infra-cherrypick-robot in #1765
+
+
 # v1.14.0 - Changelog since v1.13.6
 
 ## Changes by Kind

--- a/CHANGELOG/CHANGELOG-1.15.md
+++ b/CHANGELOG/CHANGELOG-1.15.md
@@ -1,0 +1,36 @@
+# v1.15.2 - Changelog since v1.15.1
+
+- [release-1.15] Map RESOURCE_OPERATION_RATE_EXCEEDED to ResourceExhausted by @k8s-infra-cherrypick-robot in #1848
+- [release-1.15] Add StatusConflict http kind to userErrorCodeMap. by @k8s-infra-cherrypick-robot in #1850
+- Automated cherry pick of #1826: Add ControllerModifyVolume E2E tests
+- #1836: Create documentation for ControllerModifyVolume and controller default
+- #1838: Enable VolumeAttributesClass feature gate for CI runs
+
+
+# v1.15.1 - Changelog since v1.15.0
+### Bug
+- Update base image to bookworm-v1.0.4-gke.2 by @k8s-infra-cherrypick-robot in #1833
+
+# v1.15.0 - Changelog since v1.14.3
+
+## Changes by Kind
+
+### Bug or Regression
+- Adding missing libgpg-error.so.0 required by nvme-cli by @pwschuurman in #1760
+- Format byte array error output from google_nvme_id as string by @pwschuurman in #1761
+
+### Feature
+- Add ControllerModifyVolume functionality by @travisyx in #1801
+
+### Uncategorized
+- Add verify-docker-deps.sh to verify-all.sh by @pwschuurman in #1762
+- Change OPERATION_CANCELED_BY_USER to Canceled instead of Aborted by @amacaskill in #1789
+- Bump the onsi group across 1 directory with 2 updates by @dependabot in #1811
+- Upgrade sanity tests to v5.3.0 and CSI Spec to v1.10.0 by @travisyx in #1814
+- Add manual deployment instructions for Storage Pools by @amacaskill in #1817
+- Update stable rc master image to point to v1.14.2-rc1 by @amacaskill in #1806
+- Bump golang from 1.22.5 to 1.23.0 by @dependabot in #1808
+- Bump golang from 1.22.4 to 1.22.5 by @dependabot in #1778
+- prune changelog for 1.14 by @pwschuurman in #1745
+- Add back CHANGELOG, removed in #1745 by mistake by @pwschuurman in #1746
+- Add support for running tests on confidential VMs that use NVMe by @pwschuurman in #1636

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,6 @@ COPY --from=debian /lib/${LIB_DIR_PREFIX}-linux-gnu/libselinux.so.1 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/liblzma.so.5 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libreadline.so.8 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libz.so.1 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libc.so.6 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/liburcu.so.8 \ 
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libcap.so.2 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libcrypto.so.3 \

--- a/Makefile
+++ b/Makefile
@@ -73,20 +73,24 @@ build-and-push-multi-arch-debug: build-and-push-container-linux-debug build-and-
 push-container: build-container
 
 # Used by hack/verify-docker-deps.sh, not used for building artifacts
-validate-container-linux-amd64: init-buildx
-	$(DOCKER) buildx build --platform=linux/amd64 \
-		-t validation_linux_amd64 \
-		--target validation-image \
-		--build-arg BUILDPLATFORM=linux \
-		--build-arg STAGINGVERSION=$(STAGINGVERSION) .
+validate-container-linux-amd64: build-and-load-container-linux-amd64
+	./hack/print-missing-deps.sh $(STAGINGIMAGE):$(STAGINGVERSION)_linux_amd64
 
 # Used by hack/verify-docker-deps.sh, not used for building artifacts
-validate-container-linux-arm64: init-buildx
-	$(DOCKER) buildx build --platform=linux/arm64 \
-		-t validation_linux_arm64 \
-		--target validation-image \
-		--build-arg BUILDPLATFORM=linux \
-		--build-arg STAGINGVERSION=$(STAGINGVERSION) .
+validate-container-linux-arm64: build-and-load-container-linux-arm64
+	./hack/print-missing-deps.sh $(STAGINGIMAGE):$(STAGINGVERSION)_linux_arm64
+
+validate-container-linux: validate-container-linux-amd64 validate-container-linux-arm64
+
+build-and-load-container-linux-amd64: require-GCE_PD_CSI_STAGING_IMAGE init-buildx
+	$(DOCKER) buildx build --platform=linux/amd64 \
+		-t $(STAGINGIMAGE):$(STAGINGVERSION)_linux_amd64 \
+		--build-arg STAGINGVERSION=$(STAGINGVERSION) --load .
+
+build-and-load-container-linux-arm64: require-GCE_PD_CSI_STAGING_IMAGE init-buildx
+	$(DOCKER) buildx build --file=Dockerfile --platform=linux/arm64 \
+		-t $(STAGINGIMAGE):$(STAGINGVERSION)_linux_arm64 \
+		--build-arg STAGINGVERSION=$(STAGINGVERSION) --load .
 
 build-and-push-container-linux-amd64: require-GCE_PD_CSI_STAGING_IMAGE init-buildx
 	$(DOCKER) buildx build --platform=linux/amd64 \

--- a/cmd/gce-pd-csi-driver/main.go
+++ b/cmd/gce-pd-csi-driver/main.go
@@ -143,6 +143,7 @@ func handle() {
 		}()
 	}
 
+	var metricsManager *metrics.MetricsManager = nil
 	if *runControllerService && *httpEndpoint != "" {
 		mm := metrics.NewMetricsManager()
 		mm.InitializeHttpHandler(*httpEndpoint, *metricsPath)
@@ -151,6 +152,7 @@ func handle() {
 		if metrics.IsGKEComponentVersionAvailable() {
 			mm.EmitGKEComponentVersion()
 		}
+		metricsManager = &mm
 	}
 
 	if len(*extraVolumeLabelsStr) > 0 && !*runControllerService {
@@ -261,7 +263,7 @@ func handle() {
 	gce.WaitForOpBackoff.Steps = *waitForOpBackoffSteps
 	gce.WaitForOpBackoff.Cap = *waitForOpBackoffCap
 
-	gceDriver.Run(*endpoint, *grpcLogCharCap, *enableOtelTracing)
+	gceDriver.Run(*endpoint, *grpcLogCharCap, *enableOtelTracing, metricsManager)
 }
 
 func notEmpty(v string) bool {

--- a/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
+++ b/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
@@ -48,6 +48,6 @@ metadata:
 imageTag:
   name: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
   newName: gcr.io/k8s-staging-cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.15.2-rc3"
+  newTag: "v1.15.3-rc1"
 ---
 

--- a/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
+++ b/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
@@ -23,7 +23,7 @@ metadata:
   name: imagetag-csi-resize-prow-rc
 imageTag:
   name: registry.k8s.io/sig-storage/csi-resizer
-  newTag: "v1.11.1"
+  newTag: "v1.12.0"
 ---
 apiVersion: builtin
 kind: ImageTagTransformer

--- a/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
+++ b/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
@@ -48,6 +48,6 @@ metadata:
 imageTag:
   name: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
   newName: gcr.io/k8s-staging-cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.15.3-rc1"
+  newTag: "v1.15.3-rc2"
 ---
 

--- a/deploy/kubernetes/images/stable-master/image.yaml
+++ b/deploy/kubernetes/images/stable-master/image.yaml
@@ -22,7 +22,7 @@ metadata:
   name: imagetag-csi-resizer
 imageTag:
   name: registry.k8s.io/sig-storage/csi-resizer
-  newTag: "v1.11.1"
+  newTag: "v1.12.0"
 ---
 
 apiVersion: builtin

--- a/examples/kubernetes/demo-vol-create.yaml
+++ b/examples/kubernetes/demo-vol-create.yaml
@@ -16,7 +16,7 @@ metadata:
 driverName: pd.csi.storage.gke.io
 parameters:
   iops: "3000"
-  throughput: "150"
+  throughput: "150Mi"
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: VolumeAttributesClass
@@ -25,7 +25,7 @@ metadata:
 driverName: pd.csi.storage.gke.io
 parameters:
   iops: "3013"
-  throughput: "151"
+  throughput: "151Mi"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -23,5 +23,3 @@ PKG_ROOT=$(git rev-parse --show-toplevel)
 "${PKG_ROOT}/hack/verify-gofmt.sh"
 "${PKG_ROOT}/hack/verify-govet.sh"
 "${PKG_ROOT}/hack/verify-docker-deps.sh"
-
-make -C "${PKG_ROOT}" all

--- a/hack/verify-docker-deps.sh
+++ b/hack/verify-docker-deps.sh
@@ -22,4 +22,5 @@ echo "Verifying Docker Image Dependencies"
 
 PKG_ROOT=$(git rev-parse --show-toplevel)
 
-make -C "${PKG_ROOT}" validate-container-linux-amd64 validate-container-linux-arm64
+export GCE_PD_CSI_STAGING_IMAGE=validation-image
+make -C "${PKG_ROOT}" validate-container-linux

--- a/pkg/common/parameters.go
+++ b/pkg/common/parameters.go
@@ -106,6 +106,9 @@ type DiskParameters struct {
 	// Values: {bool}
 	// Default: false
 	MultiZoneProvisioning bool
+	// Values: READ_WRITE_SINGLE, READ_ONLY_MANY, READ_WRITE_MANY
+	// Default: READ_WRITE_SINGLE
+	AccessMode string
 }
 
 // SnapshotParameters contains normalized and defaulted parameters for snapshots
@@ -148,6 +151,7 @@ func (pp *ParameterProcessor) ExtractAndDefaultParameters(parameters map[string]
 		Tags:                 make(map[string]string), // Default
 		Labels:               make(map[string]string), // Default
 		ResourceTags:         make(map[string]string), // Default
+		AccessMode:           "READ_WRITE_SINGLE",     // Default
 	}
 
 	for k, v := range extraVolumeLabels {

--- a/pkg/common/parameters.go
+++ b/pkg/common/parameters.go
@@ -343,7 +343,7 @@ func ExtractModifyVolumeParameters(parameters map[string]string) (ModifyVolumePa
 			}
 			modifyVolumeParams.IOPS = &iops
 		case "throughput":
-			throughput, err := ConvertStringToInt64(value)
+			throughput, err := ConvertMiStringToInt64(value)
 			if err != nil {
 				return ModifyVolumeParameters{}, fmt.Errorf("parameters contain invalid throughput parameter: %w", err)
 			}

--- a/pkg/common/parameters_test.go
+++ b/pkg/common/parameters_test.go
@@ -485,7 +485,7 @@ func TestSnapshotParameters(t *testing.T) {
 func TestExtractModifyVolumeParameters(t *testing.T) {
 	parameters := map[string]string{
 		"iops":       "1000",
-		"throughput": "500",
+		"throughput": "500Mi",
 	}
 
 	iops := int64(1000)

--- a/pkg/deviceutils/device-utils.go
+++ b/pkg/deviceutils/device-utils.go
@@ -194,7 +194,7 @@ func ensureUdevToolExists(toolPath string) error {
 	if !exists {
 		// The driver should be containerized with the tool so maybe something is
 		// wrong with the build process
-		return fmt.Errorf("could not find tool at %q, unable to verify device paths", nvmeIdPath)
+		return fmt.Errorf("could not find tool at %q, unable to verify device paths", toolPath)
 	}
 	return nil
 }

--- a/pkg/gce-cloud-provider/compute/cloud-disk.go
+++ b/pkg/gce-cloud-provider/compute/cloud-disk.go
@@ -217,6 +217,8 @@ func (d *CloudDisk) GetMultiWriter() bool {
 	switch {
 	case d.disk != nil:
 		return false
+	case d.disk != nil && d.disk.AccessMode == "READ_WRITE_MANY":
+		return true
 	case d.betaDisk != nil:
 		return d.betaDisk.MultiWriter
 	default:

--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -638,6 +638,11 @@ func (cloud *CloudProvider) insertRegionalDisk(
 		gceAPIVersion = GCEAPIVersionV1
 	)
 
+	// Use beta API for non-hyperdisk types in multi-writer mode.
+	if multiWriter && !strings.Contains(params.DiskType, "hyperdisk") {
+		gceAPIVersion = GCEAPIVersionBeta
+	}
+
 	diskToCreate := &computev1.Disk{
 		Name:        volKey.Name,
 		SizeGb:      common.BytesToGbRoundUp(capBytes),
@@ -761,6 +766,11 @@ func (cloud *CloudProvider) insertZonalDisk(
 		opName        string
 		gceAPIVersion = GCEAPIVersionV1
 	)
+
+	// Use beta API for non-hyperdisk types in multi-writer mode.
+	if multiWriter && !strings.Contains(params.DiskType, "hyperdisk") {
+		gceAPIVersion = GCEAPIVersionBeta
+	}
 
 	diskToCreate := &computev1.Disk{
 		Name:        volKey.Name,

--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -324,8 +324,6 @@ func (cloud *CloudProvider) ListSnapshots(ctx context.Context, filter string) ([
 func (cloud *CloudProvider) GetDisk(ctx context.Context, project string, key *meta.Key, gceAPIVersion GCEAPIVersion) (*CloudDisk, error) {
 	klog.V(5).Infof("Getting disk %v", key)
 
-	// Override GCEAPIVersion as hyperdisk is only available in beta and we cannot get the disk-type with get disk call.
-	gceAPIVersion = GCEAPIVersionBeta
 	switch key.Type() {
 	case meta.Zonal:
 		if gceAPIVersion == GCEAPIVersionBeta {
@@ -405,11 +403,6 @@ func (cloud *CloudProvider) ValidateExistingDisk(ctx context.Context, resp *Clou
 		return fmt.Errorf(
 			"disk already exists with incompatible capacity. Need %v (Required) < %v (Existing) < %v (Limit)",
 			reqBytes, common.GbToBytes(resp.GetSizeGb()), limBytes)
-	}
-
-	// We are assuming here that a multiWriter disk could be used as non-multiWriter
-	if multiWriter && !resp.GetMultiWriter() {
-		return fmt.Errorf("disk already exists with incompatible capability. Need MultiWriter. Got non-MultiWriter")
 	}
 
 	return ValidateDiskParameters(resp, params)
@@ -553,9 +546,6 @@ func convertV1DiskToBetaDisk(v1Disk *computev1.Disk) *computebeta.Disk {
 		AccessMode:        v1Disk.AccessMode,
 	}
 
-	// Hyperdisk doesn't currently support multiWriter (https://cloud.google.com/compute/docs/disks/hyperdisks#limitations),
-	// but if multiWriter + hyperdisk is supported in the future, we want the PDCSI driver to support this feature without
-	// any additional code change.
 	if v1Disk.ProvisionedIops > 0 {
 		betaDisk.ProvisionedIops = v1Disk.ProvisionedIops
 	}
@@ -619,9 +609,6 @@ func convertBetaDiskToV1Disk(betaDisk *computebeta.Disk) *computev1.Disk {
 		AccessMode:        betaDisk.AccessMode,
 	}
 
-	// Hyperdisk doesn't currently support multiWriter (https://cloud.google.com/compute/docs/disks/hyperdisks#limitations),
-	// but if multiWriter + hyperdisk is supported in the future, we want the PDCSI driver to support this feature without
-	// any additional code change.
 	if betaDisk.ProvisionedIops > 0 {
 		v1Disk.ProvisionedIops = betaDisk.ProvisionedIops
 	}
@@ -650,10 +637,6 @@ func (cloud *CloudProvider) insertRegionalDisk(
 		opName        string
 		gceAPIVersion = GCEAPIVersionV1
 	)
-
-	if multiWriter {
-		gceAPIVersion = GCEAPIVersionBeta
-	}
 
 	diskToCreate := &computev1.Disk{
 		Name:        volKey.Name,
@@ -778,9 +761,6 @@ func (cloud *CloudProvider) insertZonalDisk(
 		opName        string
 		gceAPIVersion = GCEAPIVersionV1
 	)
-	if multiWriter {
-		gceAPIVersion = GCEAPIVersionBeta
-	}
 
 	diskToCreate := &computev1.Disk{
 		Name:        volKey.Name,

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -1789,7 +1789,7 @@ func TestCreateVolumeWithVolumeAttributeClassParameters(t *testing.T) {
 						},
 					},
 				},
-				MutableParameters: map[string]string{"iops": "20000", "throughput": "600"},
+				MutableParameters: map[string]string{"iops": "20000", "throughput": "600Mi"},
 			},
 			expIops:       20000,
 			expThroughput: 600,
@@ -1822,7 +1822,7 @@ func TestCreateVolumeWithVolumeAttributeClassParameters(t *testing.T) {
 						},
 					},
 				},
-				MutableParameters: map[string]string{"iops": "20000", "throughput": "600"},
+				MutableParameters: map[string]string{"iops": "20000", "throughput": "600Mi"},
 			},
 			expIops:       0,
 			expThroughput: 0,
@@ -1890,7 +1890,7 @@ func TestVolumeModifyOperation(t *testing.T) {
 			name: "Update volume with valid parameters",
 			req: &csi.ControllerModifyVolumeRequest{
 				VolumeId:          testVolumeID,
-				MutableParameters: map[string]string{"iops": "20000", "throughput": "600"},
+				MutableParameters: map[string]string{"iops": "20000", "throughput": "600Mi"},
 			},
 			diskType: "hyperdisk-balanced",
 			params: &common.DiskParameters{
@@ -1906,7 +1906,7 @@ func TestVolumeModifyOperation(t *testing.T) {
 			name: "Update volume with invalid parameters",
 			req: &csi.ControllerModifyVolumeRequest{
 				VolumeId:          testVolumeID,
-				MutableParameters: map[string]string{"iops": "0", "throughput": "0"},
+				MutableParameters: map[string]string{"iops": "0", "throughput": "0Mi"},
 			},
 			diskType: "hyperdisk-balanced",
 			params: &common.DiskParameters{
@@ -1922,7 +1922,7 @@ func TestVolumeModifyOperation(t *testing.T) {
 			name: "Update volume with valid parameters but invalid disk type",
 			req: &csi.ControllerModifyVolumeRequest{
 				VolumeId:          testVolumeID,
-				MutableParameters: map[string]string{"iops": "20000", "throughput": "600"},
+				MutableParameters: map[string]string{"iops": "20000", "throughput": "600Mi"},
 			},
 			diskType: "pd-ssd",
 			params: &common.DiskParameters{
@@ -2053,7 +2053,7 @@ func TestVolumeModifyErrorHandling(t *testing.T) {
 				},
 			},
 			modifyReq: &csi.ControllerModifyVolumeRequest{
-				MutableParameters: map[string]string{"iops": "3001", "throughput": "151"},
+				MutableParameters: map[string]string{"iops": "3001", "throughput": "151Mi"},
 			},
 			modifyVolumeErrors: map[*meta.Key]error{
 				meta.ZonalKey(name, "us-central1-a"): &googleapi.Error{
@@ -2089,7 +2089,7 @@ func TestVolumeModifyErrorHandling(t *testing.T) {
 				},
 			},
 			modifyReq: &csi.ControllerModifyVolumeRequest{
-				MutableParameters: map[string]string{"iops": "10000", "throughput": "2400"},
+				MutableParameters: map[string]string{"iops": "10000", "throughput": "2400Mi"},
 			},
 			modifyVolumeErrors: map[*meta.Key]error{
 				meta.ZonalKey(name, "us-central1-a"): &googleapi.Error{Code: int(codes.InvalidArgument), Message: "InvalidArgument"},

--- a/pkg/gce-pd-csi-driver/gce-pd-driver.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/deviceutils"
 	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute"
 	metadataservice "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/metadata"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/metrics"
 	mountmanager "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/mount-manager"
 )
 
@@ -170,12 +171,12 @@ func NewControllerServer(gceDriver *GCEDriver, cloudProvider gce.GCECompute, err
 	}
 }
 
-func (gceDriver *GCEDriver) Run(endpoint string, grpcLogCharCap int, enableOtelTracing bool) {
+func (gceDriver *GCEDriver) Run(endpoint string, grpcLogCharCap int, enableOtelTracing bool, metricsManager *metrics.MetricsManager) {
 	maxLogChar = grpcLogCharCap
 
 	klog.V(4).Infof("Driver: %v", gceDriver.name)
 	//Start the nonblocking GRPC
-	s := NewNonBlockingGRPCServer(enableOtelTracing)
+	s := NewNonBlockingGRPCServer(enableOtelTracing, metricsManager)
 	// TODO(#34): Only start specific servers based on a flag.
 	// In the future have this only run specific combinations of servers depending on which version this is.
 	// The schema for that was in util. basically it was just s.start but with some nil servers.

--- a/pkg/gce-pd-csi-driver/gce-pd-driver_test.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver_test.go
@@ -41,8 +41,7 @@ func initBlockingGCEDriver(t *testing.T, cloudDisks []*gce.CloudDisk, readyToExe
 	return initGCEDriverWithCloudProvider(t, fakeBlockingBlockProvider)
 }
 
-func initGCEDriverWithCloudProvider(t *testing.T, cloudProvider gce.GCECompute) *GCEDriver {
-	vendorVersion := "test-vendor"
+func controllerServerForTest(cloudProvider gce.GCECompute) *GCEControllerServer {
 	gceDriver := GetGCEDriver()
 	errorBackoffInitialDuration := 200 * time.Millisecond
 	errorBackoffMaxDuration := 5 * time.Minute
@@ -55,7 +54,13 @@ func initGCEDriverWithCloudProvider(t *testing.T, cloudProvider gce.GCECompute) 
 		SupportsThroughputChange: []string{"hyperdisk-balanced", "hyperdisk-throughput", "hyperdisk-ml"},
 	}
 
-	controllerServer := NewControllerServer(gceDriver, cloudProvider, errorBackoffInitialDuration, errorBackoffMaxDuration, fallbackRequisiteZones, enableStoragePools, multiZoneVolumeHandleConfig, listVolumesConfig, provisionableDisksConfig)
+	return NewControllerServer(gceDriver, cloudProvider, errorBackoffInitialDuration, errorBackoffMaxDuration, fallbackRequisiteZones, enableStoragePools, multiZoneVolumeHandleConfig, listVolumesConfig, provisionableDisksConfig)
+}
+
+func initGCEDriverWithCloudProvider(t *testing.T, cloudProvider gce.GCECompute) *GCEDriver {
+	vendorVersion := "test-vendor"
+	gceDriver := GetGCEDriver()
+	controllerServer := controllerServerForTest(cloudProvider)
 	err := gceDriver.SetupGCEDriver(driver, vendorVersion, nil, nil, nil, controllerServer, nil)
 	if err != nil {
 		t.Fatalf("Failed to setup GCE Driver: %v", err)

--- a/pkg/gce-pd-csi-driver/server_test.go
+++ b/pkg/gce-pd-csi-driver/server_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package gceGCEDriver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	csipb "github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
+	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/metrics"
+)
+
+func createSocketFile() (string, func(), error) {
+	tmpDir, err := os.MkdirTemp("", "socket-dir")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create temporary socket directory: %v", err)
+	}
+	cleanup := func() {
+		os.RemoveAll(tmpDir)
+	}
+	socketFile := fmt.Sprintf("%s/test.sock", tmpDir)
+	return socketFile, cleanup, nil
+}
+
+func createServerClient(mm *metrics.MetricsManager, socketFile string, seedDisks []*gce.CloudDisk) (*grpc.ClientConn, error) {
+	socketEndpoint := fmt.Sprintf("unix:%s", socketFile)
+	file, err := os.Create(socketFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary socket file: %v", err)
+	}
+	file.Close()
+
+	metricsPath := "/metrics"
+	metricEndpoint := "localhost:0" // random port
+	mm.InitializeHttpHandler(metricEndpoint, metricsPath)
+	mm.RegisterPDCSIMetric()
+
+	server := NewNonBlockingGRPCServer(false /* enableOtelTracing */, mm)
+	gceDriver := GetGCEDriver()
+	identityServer := NewIdentityServer(gceDriver)
+	fakeCloudProvider, err := gce.CreateFakeCloudProvider(project, zone, seedDisks)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create fake cloud provider: %v", err)
+	}
+	controllerServer := controllerServerForTest(fakeCloudProvider)
+	if err := gceDriver.SetupGCEDriver(driver, "test-vendor", nil, nil, identityServer, controllerServer, nil); err != nil {
+		return nil, fmt.Errorf("failed to setup GCE Driver: %v", err)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create volume %v", err)
+	}
+	server.Start(socketEndpoint, gceDriver.ids, gceDriver.cs, gceDriver.ns)
+
+	conn, err := grpc.Dial(
+		socketEndpoint,
+		grpc.WithInsecure(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client connection")
+	}
+	return conn, nil
+}
+
+func TestServerCreateVolumeMetric(t *testing.T) {
+	mm := metrics.NewMetricsManager()
+	mm.ResetMetrics()
+	socketFile, cleanup, err := createSocketFile()
+	if err != nil {
+		t.Fatalf("Failed to create socket file: %v", err)
+	}
+	defer cleanup()
+	conn, err := createServerClient(&mm, socketFile, nil)
+	if err != nil {
+		t.Fatalf("Failed to create server client: %v", err)
+	}
+	controllerClient := csipb.NewControllerClient(conn)
+	req := &csi.CreateVolumeRequest{
+		Name:               name,
+		CapacityRange:      stdCapRange,
+		VolumeCapabilities: stdVolCaps,
+		Parameters: map[string]string{
+			common.ParameterKeyType: "pd-balanced",
+		},
+	}
+	resp, err := controllerClient.CreateVolume(context.Background(), req)
+
+	if err != nil {
+		t.Fatalf("CreateVolume returned unexpected error: %v", err)
+	}
+
+	wantName := "projects/test-project/zones/country-region-zone/disks/test-name"
+	if resp.Volume.GetVolumeId() != wantName {
+		t.Fatalf("Response name expected: %v, got: %v", wantName, resp.Volume.GetVolumeId())
+	}
+
+	reg := mm.GetRegistry()
+	metrics, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gailed to gather metrics: %v", err)
+	}
+	if len(metrics) != 1 {
+		t.Fatalf("Expected 1 metric, got %d", len(metrics))
+	}
+	gotMetric := fmt.Sprint(metrics[0])
+	wantMetric := `name:"csidriver_operation_errors" help:"[ALPHA] CSI server side error metrics" type:COUNTER metric:<label:<name:"disk_type" value:"pd-balanced" > label:<name:"driver_name" value:"pd.csi.storage.gke.io" > label:<name:"enable_confidential_storage" value:"false" > label:<name:"enable_storage_pools" value:"false" > label:<name:"grpc_status_code" value:"OK" > label:<name:"method_name" value:"/csi.v1.Controller/CreateVolume" > counter:<value:1 > > `
+	if gotMetric != wantMetric {
+		t.Fatalf("Metric mismatch: \ngot: %v\nwant: %v", gotMetric, wantMetric)
+	}
+}
+
+func TestServerValidateVolumeCapabilitiesMetric(t *testing.T) {
+	mm := metrics.NewMetricsManager()
+	mm.ResetMetrics()
+	seedDisks := []*gce.CloudDisk{
+		createZonalCloudDisk(name),
+	}
+	socketFile, cleanup, err := createSocketFile()
+	if err != nil {
+		t.Fatalf("Failed to create socket file: %v", err)
+	}
+	defer cleanup()
+	conn, err := createServerClient(&mm, socketFile, seedDisks)
+	if err != nil {
+		t.Fatalf("Failed to create server client: %v", err)
+	}
+	controllerClient := csipb.NewControllerClient(conn)
+	req := &csi.ValidateVolumeCapabilitiesRequest{
+		VolumeId:           fmt.Sprintf("projects/%s/zones/%s/disks/%s", project, zone, name),
+		VolumeCapabilities: stdVolCaps,
+	}
+	resp, err := controllerClient.ValidateVolumeCapabilities(context.Background(), req)
+
+	if err != nil {
+		t.Fatalf("CreateVolume returned unexpected error: %v", err)
+	}
+
+	if resp.Confirmed != nil {
+		t.Fatalf("Expected not nil response, got: %v", resp)
+	}
+
+	reg := mm.GetRegistry()
+	metrics, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gailed to gather metrics: %v", err)
+	}
+	if len(metrics) != 1 {
+		t.Fatalf("Expected 1 metric, got %d", len(metrics))
+	}
+	gotMetric := fmt.Sprint(metrics[0])
+	wantMetric := `name:"csidriver_operation_errors" help:"[ALPHA] CSI server side error metrics" type:COUNTER metric:<label:<name:"disk_type" value:"" > label:<name:"driver_name" value:"pd.csi.storage.gke.io" > label:<name:"enable_confidential_storage" value:"false" > label:<name:"enable_storage_pools" value:"false" > label:<name:"grpc_status_code" value:"OK" > label:<name:"method_name" value:"/csi.v1.Controller/ValidateVolumeCapabilities" > counter:<value:1 > > `
+	if gotMetric != wantMetric {
+		t.Fatalf("Metric mismatch: \ngot: %v\nwant: %v", gotMetric, wantMetric)
+	}
+}
+
+func TestServerGetPluginInfoMetric(t *testing.T) {
+	mm := metrics.NewMetricsManager()
+	mm.ResetMetrics()
+	socketFile, cleanup, err := createSocketFile()
+	if err != nil {
+		t.Fatalf("Failed to create socket file: %v", err)
+	}
+	defer cleanup()
+	conn, err := createServerClient(&mm, socketFile, nil)
+	if err != nil {
+		t.Fatalf("Failed to create server client: %v", err)
+	}
+	idClient := csipb.NewIdentityClient(conn)
+	resp, err := idClient.GetPluginInfo(context.Background(), &csi.GetPluginInfoRequest{})
+	if err != nil {
+		t.Fatalf("GetPluginInfo returned unexpected error: %v", err)
+	}
+
+	if resp.GetName() != driver {
+		t.Fatalf("Response name expected: %v, got: %v", driver, resp.GetName())
+	}
+
+	reg := mm.GetRegistry()
+	metrics, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gailed to gather metrics: %v", err)
+	}
+	if len(metrics) != 1 {
+		t.Fatalf("Expected 1 metric, got %d", len(metrics))
+	}
+	gotMetric := fmt.Sprint(metrics[0])
+	wantMetric := `name:"csidriver_operation_errors" help:"[ALPHA] CSI server side error metrics" type:COUNTER metric:<label:<name:"disk_type" value:"unknownDiskType" > label:<name:"driver_name" value:"pd.csi.storage.gke.io" > label:<name:"enable_confidential_storage" value:"unknownConfidentialMode" > label:<name:"enable_storage_pools" value:"unknownStoragePools" > label:<name:"grpc_status_code" value:"OK" > label:<name:"method_name" value:"/csi.v1.Identity/GetPluginInfo" > counter:<value:1 > > `
+	if gotMetric != wantMetric {
+		t.Fatalf("Metric mismatch: \ngot: %v\nwant: %v", gotMetric, wantMetric)
+	}
+}

--- a/pkg/metrics/interceptor.go
+++ b/pkg/metrics/interceptor.go
@@ -1,0 +1,23 @@
+package metrics
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+type MetricInterceptor struct {
+	MetricsManager *MetricsManager
+}
+
+func (m *MetricInterceptor) unaryInterceptorInternal(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	requestMetadata := newRequestMetadata()
+	newCtx := context.WithValue(ctx, requestMetadataKey, requestMetadata)
+	result, err := handler(newCtx, req)
+	m.MetricsManager.RecordOperationErrorMetrics(info.FullMethod, err, requestMetadata.diskType, requestMetadata.enableConfidentialStorage, requestMetadata.enableStoragePools)
+	return result, err
+}
+
+func (m *MetricInterceptor) UnaryInterceptor() grpc.UnaryServerInterceptor {
+	return m.unaryInterceptorInternal
+}

--- a/pkg/metrics/metadata.go
+++ b/pkg/metrics/metadata.go
@@ -1,0 +1,55 @@
+package metrics
+
+import (
+	"context"
+	"strconv"
+
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
+	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute"
+)
+
+const (
+	// envGKEPDCSIVersion is an environment variable set in the PDCSI controller manifest
+	// with the current version of the GKE component.
+	requestMetadataKey = "requestMetadata"
+)
+
+// RequestMetadata represents metadata about a gRPC CSI request
+type RequestMetadata struct {
+	diskType                  string
+	enableConfidentialStorage string
+	enableStoragePools        string
+}
+
+func newRequestMetadata() *RequestMetadata {
+	return &RequestMetadata{
+		diskType:                  DefaultDiskTypeForMetric,
+		enableConfidentialStorage: DefaultEnableConfidentialCompute,
+		enableStoragePools:        DefaultEnableStoragePools,
+	}
+}
+
+// MetadataFromContext returns a mutable from a request context
+func MetadataFromContext(ctx context.Context) *RequestMetadata {
+	requestMetadata, _ := ctx.Value(requestMetadataKey).(*RequestMetadata)
+	return requestMetadata
+}
+
+func UpdateRequestMetadataFromParams(ctx context.Context, params common.DiskParameters) {
+	metadata := MetadataFromContext(ctx)
+	if metadata != nil {
+		metadata.diskType = params.DiskType
+		metadata.enableConfidentialStorage = strconv.FormatBool(params.EnableConfidentialCompute)
+		hasStoragePools := len(params.StoragePools) > 0
+		metadata.enableStoragePools = strconv.FormatBool(hasStoragePools)
+	}
+}
+
+func UpdateRequestMetadataFromDisk(ctx context.Context, disk *gce.CloudDisk) {
+	metadata := MetadataFromContext(ctx)
+	if metadata != nil && disk != nil {
+		metadata.diskType = disk.GetPDType()
+		metadata.enableConfidentialStorage = strconv.FormatBool(disk.GetEnableConfidentialCompute())
+		metadata.enableStoragePools = strconv.FormatBool(disk.GetEnableStoragePools())
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -39,11 +39,6 @@ const (
 )
 
 var (
-	gkeComponentVersion        *metrics.GaugeVec
-	pdcsiOperationErrorsMetric *metrics.CounterVec
-)
-
-func initMetrics() {
 	// This metric is exposed only from the controller driver component when GKE_PDCSI_VERSION env variable is set.
 	gkeComponentVersion = metrics.NewGaugeVec(&metrics.GaugeOpts{
 		Name: "component_version",
@@ -58,7 +53,7 @@ func initMetrics() {
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"driver_name", "method_name", "grpc_status_code", "disk_type", "enable_confidential_storage", "enable_storage_pools"})
-}
+)
 
 type MetricsManager struct {
 	registry metrics.KubeRegistry

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -99,15 +99,18 @@ func TestGetMetricParameters(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Logf("Running test: %v", tc.name)
-		diskType, confidentialCompute, enableStoragePools := GetMetricParameters(tc.disk)
-		if confidentialCompute != tc.expectedEnableConfidentialCompute {
-			t.Fatalf("Got confidentialCompute value %q expected %q", confidentialCompute, tc.expectedEnableConfidentialCompute)
+		ctx := context.TODO()
+		requestMetadata := newRequestMetadata()
+		newCtx := context.WithValue(ctx, requestMetadataKey, requestMetadata)
+		UpdateRequestMetadataFromDisk(newCtx, tc.disk)
+		if requestMetadata.enableConfidentialStorage != tc.expectedEnableConfidentialCompute {
+			t.Fatalf("Got confidentialCompute value %q expected %q", requestMetadata.enableConfidentialStorage, tc.expectedEnableConfidentialCompute)
 		}
-		if diskType != tc.expectedDiskType {
-			t.Fatalf("Got diskType value %q expected %q", diskType, tc.expectedDiskType)
+		if requestMetadata.diskType != tc.expectedDiskType {
+			t.Fatalf("Got diskType value %q expected %q", requestMetadata.enableConfidentialStorage, tc.expectedDiskType)
 		}
-		if enableStoragePools != tc.expectedEnableStoragePools {
-			t.Fatalf("Got enableStoragePools value %q expected %q", enableStoragePools, tc.expectedEnableStoragePools)
+		if requestMetadata.enableStoragePools != tc.expectedEnableStoragePools {
+			t.Fatalf("Got enableStoragePools value %q expected %q", requestMetadata.enableStoragePools, tc.expectedEnableStoragePools)
 		}
 	}
 }

--- a/pkg/metrics/metrics_test_util.go
+++ b/pkg/metrics/metrics_test_util.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+// Test-only method used for resetting metric counts.
+func (mm *MetricsManager) ResetMetrics() {
+	// Re-initialize metrics
+	initMetrics()
+}

--- a/pkg/metrics/metrics_test_util.go
+++ b/pkg/metrics/metrics_test_util.go
@@ -19,5 +19,6 @@ package metrics
 // Test-only method used for resetting metric counts.
 func (mm *MetricsManager) ResetMetrics() {
 	// Re-initialize metrics
-	initMetrics()
+	gkeComponentVersion.Reset()
+	pdcsiOperationErrorsMetric.Reset()
 }

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -904,8 +904,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		Expect(err).To(BeNil(), "Failed to go through volume lifecycle")
 	})
 
-	// Pending while multi-writer feature is in Alpha
-	PIt("Should create and delete multi-writer disk", func() {
+	It("Should create and delete multi-writer disk", func() {
 		Expect(testContexts).ToNot(BeEmpty())
 		testContext := getRandomTestContext()
 
@@ -916,7 +915,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		zone := "us-east1-a"
 
 		// Create and Validate Disk
-		volName, volID := createAndValidateUniqueZonalMultiWriterDisk(client, p, zone, standardDiskType)
+		volName, volID := createAndValidateUniqueZonalMultiWriterDisk(client, p, zone, hdbDiskType)
 
 		defer func() {
 			// Delete Disk
@@ -929,8 +928,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		}()
 	})
 
-	// Pending while multi-writer feature is in Alpha
-	PIt("Should complete entire disk lifecycle with multi-writer disk", func() {
+	It("Should complete entire disk lifecycle with multi-writer disk", func() {
 		testContext := getRandomTestContext()
 
 		p, z, _ := testContext.Instance.GetIdentity()
@@ -938,7 +936,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		instance := testContext.Instance
 
 		// Create and Validate Disk
-		volName, volID := createAndValidateUniqueZonalMultiWriterDisk(client, p, z, standardDiskType)
+		volName, volID := createAndValidateUniqueZonalMultiWriterDisk(client, p, z, hdbDiskType)
 
 		defer func() {
 			// Delete Disk
@@ -1710,6 +1708,7 @@ func deleteVolumeOrError(client *remote.CsiClient, volID string) {
 func createAndValidateUniqueZonalMultiWriterDisk(client *remote.CsiClient, project, zone string, diskType string) (string, string) {
 	// Create Disk
 	disk := typeToDisk[diskType]
+	disk.params.AccessMode = "READ_WRITE_MANY"
 	volName := testNamePrefix + string(uuid.NewUUID())
 	volume, err := client.CreateVolumeWithCaps(volName, disk.params, defaultMwSizeGb,
 		&csi.TopologyRequirement{

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -1622,7 +1622,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 			stringPtr(provisionedIOPSOnCreateHdb),
 			stringPtr(provisionedThroughputOnCreateHdb),
 			stringPtr("3013"),
-			stringPtr("181"),
+			stringPtr("181Mi"),
 		),
 		Entry(
 			"for hyperdisk-extreme",
@@ -1640,7 +1640,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 			nil,
 			stringPtr(provisionedThroughputOnCreate),
 			nil,
-			stringPtr("70"),
+			stringPtr("70Mi"),
 		),
 	)
 })

--- a/test/k8s-integration/config/hdb-volumeattributesclass.yaml
+++ b/test/k8s-integration/config/hdb-volumeattributesclass.yaml
@@ -5,4 +5,4 @@ metadata:
 driverName: pd.csi.storage.gke.io
 parameters:
   iops: "3600"
-  throughput: "290"
+  throughput: "290Mi"

--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -635,6 +635,9 @@ func handle() error {
 
 func generateGCETestSkip(testParams *testParameters) string {
 	skipString := "\\[Disruptive\\]|\\[Serial\\]"
+	// Skip mount options test until we fix the invalid mount options for xfs.
+	skipString = skipString + "|csi-gcepd-sc-xfs.*provisioning.should.provision.storage.with.mount.options"
+
 	v := apimachineryversion.MustParseSemantic(testParams.clusterVersion)
 
 	// "volumeMode should not mount / map unused volumes in a pod" tests a

--- a/test/run-k8s-integration.sh
+++ b/test/run-k8s-integration.sh
@@ -28,6 +28,7 @@ readonly teardown_driver=${GCE_PD_TEARDOWN_DRIVER:-true}
 readonly gke_node_version=${GKE_NODE_VERSION:-}
 readonly use_kubetest2=${USE_KUBETEST2:-true}
 readonly migration_test=${MIGRATION_TEST:-false}
+readonly volumeattributesclass_files=${VOLUME_ATTRIBUTES_CLASS_FILES:-hdb-volumeattributesclass.yaml}
 
 export GCE_PD_VERBOSITY=9
 
@@ -48,11 +49,14 @@ base_cmd="${PKGDIR}/bin/k8s-integration-test \
             --do-driver-build=${do_driver_build} --teardown-driver=${teardown_driver} \
             --do-k8s-build=${do_k8s_build} --boskos-resource-type=${boskos_resource_type} \
             --storageclass-files=sc-balanced.yaml --snapshotclass-files=pd-volumesnapshotclass.yaml \
-            --volumeattributesclass-files=hdb-volumeattributesclass.yaml \
             --storageclass-for-vac-file=sc-hdb.yaml \
             --kube-runtime-config=api/all=true \
             --deployment-strategy=${deployment_strategy} --test-version=${test_version} \
             --num-nodes=3 --image-type=${image_type} --use-kubetest2=${use_kubetest2}"
+
+if [[ -n "${volumeattributesclass_files}" ]]; then
+  base_cmd+=" --volumeattributesclass-files=${volumeattributesclass_files}"
+fi
 
 if [ "$use_gke_managed_driver" = false ]; then
   base_cmd="${base_cmd} --deploy-overlay-name=${overlay_name}"

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -102,7 +102,7 @@ func TestSanity(t *testing.T) {
 	}()
 
 	go func() {
-		gceDriver.Run(endpoint, 10000, false)
+		gceDriver.Run(endpoint, 10000, false /* enableOtelTracing */, nil /* metricsManager */)
 	}()
 
 	// TODO(#818): Fix failing tests and remove test skip flag.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Hyper disk multi-writer support is now in [compute/v1](https://pkg.go.dev/google.golang.org/api/compute/v1) but the persistent disk csi driver still calls [v0.beta](https://pkg.go.dev/google.golang.org/api/compute/v0.beta) which leads a error while creating a hyperdisk with multi-writer mode. Error:

```
Warning ProvisioningFailed 31m (x15 over 57m) pd.csi.storage.gke.io_wduan-1030a-g-vdnqh-master-0_dc46e9f6-1725-4f15-922c-99f0e281e102 failed to provision volume with StorageClass
"balanced-storage": rpc error: code = InvalidArgument desc = CreateVolume failed: rpc error: code = InvalidArgument desc = CreateVolume failed to create single zonal disk pvc-0b65d680-636b-46c6-876d-d3a6c412c3ef: failed to insert zonal disk: unknown Insert disk error:
googleapi: Error 400: Invalid value for field 'resource.multiWriter': 'true'.
Cannot specify the multi writer field for 'hyperdisk-balanced' disks,
please use access mode instead., invalid%!v(MISSING)
```

To fix this we will call the v1 API which accepts `accessMode = ReadWriteMany`. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1863

**Special notes for your reviewer**:
- Discussed this issue and the fix with Matthew
- Making this change only for disk types `hyperdisk*`, multi-writer support for other disk types is not the focus of this fix.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
