### PR TITLE
Refactor metric defer() statements to gRPC metric interceptor

### DIFF
--- a/cmd/gce-pd-csi-driver/main.go
+++ b/cmd/gce-pd-csi-driver/main.go
@@ -143,6 +143,7 @@ func handle() {
 		}()
 	}
 
+	var metricsManager *metrics.MetricsManager = nil
 	if *runControllerService && *httpEndpoint != "" {
 		mm := metrics.NewMetricsManager()
 		mm.InitializeHttpHandler(*httpEndpoint, *metricsPath)
@@ -151,6 +152,7 @@ func handle() {
 		if metrics.IsGKEComponentVersionAvailable() {
 			mm.EmitGKEComponentVersion()
 		}
+		metricsManager = &mm
 	}
 
 	if len(*extraVolumeLabelsStr) > 0 && !*runControllerService {
@@ -261,7 +263,7 @@ func handle() {
 	gce.WaitForOpBackoff.Steps = *waitForOpBackoffSteps
 	gce.WaitForOpBackoff.Cap = *waitForOpBackoffCap
 
-	gceDriver.Run(*endpoint, *grpcLogCharCap, *enableOtelTracing)
+	gceDriver.Run(*endpoint, *grpcLogCharCap, *enableOtelTracing, metricsManager)
 }
 
 func notEmpty(v string) bool {

--- a/pkg/gce-pd-csi-driver/gce-pd-driver.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/deviceutils"
 	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute"
 	metadataservice "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/metadata"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/metrics"
 	mountmanager "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/mount-manager"
 )
 
@@ -170,12 +171,12 @@ func NewControllerServer(gceDriver *GCEDriver, cloudProvider gce.GCECompute, err
 	}
 }
 
-func (gceDriver *GCEDriver) Run(endpoint string, grpcLogCharCap int, enableOtelTracing bool) {
+func (gceDriver *GCEDriver) Run(endpoint string, grpcLogCharCap int, enableOtelTracing bool, metricsManager *metrics.MetricsManager) {
 	maxLogChar = grpcLogCharCap
 
 	klog.V(4).Infof("Driver: %v", gceDriver.name)
 	//Start the nonblocking GRPC
-	s := NewNonBlockingGRPCServer(enableOtelTracing)
+	s := NewNonBlockingGRPCServer(enableOtelTracing, metricsManager)
 	// TODO(#34): Only start specific servers based on a flag.
 	// In the future have this only run specific combinations of servers depending on which version this is.
 	// The schema for that was in util. basically it was just s.start but with some nil servers.

--- a/pkg/gce-pd-csi-driver/gce-pd-driver_test.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver_test.go
@@ -41,8 +41,7 @@ func initBlockingGCEDriver(t *testing.T, cloudDisks []*gce.CloudDisk, readyToExe
 	return initGCEDriverWithCloudProvider(t, fakeBlockingBlockProvider)
 }
 
-func initGCEDriverWithCloudProvider(t *testing.T, cloudProvider gce.GCECompute) *GCEDriver {
-	vendorVersion := "test-vendor"
+func controllerServerForTest(cloudProvider gce.GCECompute) *GCEControllerServer {
 	gceDriver := GetGCEDriver()
 	errorBackoffInitialDuration := 200 * time.Millisecond
 	errorBackoffMaxDuration := 5 * time.Minute
@@ -55,7 +54,13 @@ func initGCEDriverWithCloudProvider(t *testing.T, cloudProvider gce.GCECompute) 
 		SupportsThroughputChange: []string{"hyperdisk-balanced", "hyperdisk-throughput", "hyperdisk-ml"},
 	}
 
-	controllerServer := NewControllerServer(gceDriver, cloudProvider, errorBackoffInitialDuration, errorBackoffMaxDuration, fallbackRequisiteZones, enableStoragePools, multiZoneVolumeHandleConfig, listVolumesConfig, provisionableDisksConfig)
+	return NewControllerServer(gceDriver, cloudProvider, errorBackoffInitialDuration, errorBackoffMaxDuration, fallbackRequisiteZones, enableStoragePools, multiZoneVolumeHandleConfig, listVolumesConfig, provisionableDisksConfig)
+}
+
+func initGCEDriverWithCloudProvider(t *testing.T, cloudProvider gce.GCECompute) *GCEDriver {
+	vendorVersion := "test-vendor"
+	gceDriver := GetGCEDriver()
+	controllerServer := controllerServerForTest(cloudProvider)
 	err := gceDriver.SetupGCEDriver(driver, vendorVersion, nil, nil, nil, controllerServer, nil)
 	if err != nil {
 		t.Fatalf("Failed to setup GCE Driver: %v", err)

--- a/pkg/gce-pd-csi-driver/server_test.go
+++ b/pkg/gce-pd-csi-driver/server_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package gceGCEDriver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	csipb "github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
+	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/metrics"
+)
+
+func createSocketFile() (string, func(), error) {
+	tmpDir, err := os.MkdirTemp("", "socket-dir")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create temporary socket directory: %v", err)
+	}
+	cleanup := func() {
+		os.RemoveAll(tmpDir)
+	}
+	socketFile := fmt.Sprintf("%s/test.sock", tmpDir)
+	return socketFile, cleanup, nil
+}
+
+func createServerClient(mm *metrics.MetricsManager, socketFile string, seedDisks []*gce.CloudDisk) (*grpc.ClientConn, error) {
+	socketEndpoint := fmt.Sprintf("unix:%s", socketFile)
+	file, err := os.Create(socketFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary socket file: %v", err)
+	}
+	file.Close()
+
+	metricsPath := "/metrics"
+	metricEndpoint := "localhost:0" // random port
+	mm.InitializeHttpHandler(metricEndpoint, metricsPath)
+	mm.RegisterPDCSIMetric()
+
+	server := NewNonBlockingGRPCServer(false /* enableOtelTracing */, mm)
+	gceDriver := GetGCEDriver()
+	identityServer := NewIdentityServer(gceDriver)
+	fakeCloudProvider, err := gce.CreateFakeCloudProvider(project, zone, seedDisks)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create fake cloud provider: %v", err)
+	}
+	controllerServer := controllerServerForTest(fakeCloudProvider)
+	if err := gceDriver.SetupGCEDriver(driver, "test-vendor", nil, nil, identityServer, controllerServer, nil); err != nil {
+		return nil, fmt.Errorf("failed to setup GCE Driver: %v", err)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create volume %v", err)
+	}
+	server.Start(socketEndpoint, gceDriver.ids, gceDriver.cs, gceDriver.ns)
+
+	conn, err := grpc.Dial(
+		socketEndpoint,
+		grpc.WithInsecure(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client connection")
+	}
+	return conn, nil
+}
+
+func TestServerCreateVolumeMetric(t *testing.T) {
+	mm := metrics.NewMetricsManager()
+	mm.ResetMetrics()
+	socketFile, cleanup, err := createSocketFile()
+	if err != nil {
+		t.Fatalf("Failed to create socket file: %v", err)
+	}
+	defer cleanup()
+	conn, err := createServerClient(&mm, socketFile, nil)
+	if err != nil {
+		t.Fatalf("Failed to create server client: %v", err)
+	}
+	controllerClient := csipb.NewControllerClient(conn)
+	req := &csi.CreateVolumeRequest{
+		Name:               name,
+		CapacityRange:      stdCapRange,
+		VolumeCapabilities: stdVolCaps,
+		Parameters: map[string]string{
+			common.ParameterKeyType: "pd-balanced",
+		},
+	}
+	resp, err := controllerClient.CreateVolume(context.Background(), req)
+
+	if err != nil {
+		t.Fatalf("CreateVolume returned unexpected error: %v", err)
+	}
+
+	wantName := "projects/test-project/zones/country-region-zone/disks/test-name"
+	if resp.Volume.GetVolumeId() != wantName {
+		t.Fatalf("Response name expected: %v, got: %v", wantName, resp.Volume.GetVolumeId())
+	}
+
+	reg := mm.GetRegistry()
+	metrics, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gailed to gather metrics: %v", err)
+	}
+	if len(metrics) != 1 {
+		t.Fatalf("Expected 1 metric, got %d", len(metrics))
+	}
+	gotMetric := fmt.Sprint(metrics[0])
+	wantMetric := `name:"csidriver_operation_errors" help:"[ALPHA] CSI server side error metrics" type:COUNTER metric:<label:<name:"disk_type" value:"pd-balanced" > label:<name:"driver_name" value:"pd.csi.storage.gke.io" > label:<name:"enable_confidential_storage" value:"false" > label:<name:"enable_storage_pools" value:"false" > label:<name:"grpc_status_code" value:"OK" > label:<name:"method_name" value:"/csi.v1.Controller/CreateVolume" > counter:<value:1 > > `
+	if gotMetric != wantMetric {
+		t.Fatalf("Metric mismatch: \ngot: %v\nwant: %v", gotMetric, wantMetric)
+	}
+}
+
+func TestServerValidateVolumeCapabilitiesMetric(t *testing.T) {
+	mm := metrics.NewMetricsManager()
+	mm.ResetMetrics()
+	seedDisks := []*gce.CloudDisk{
+		createZonalCloudDisk(name),
+	}
+	socketFile, cleanup, err := createSocketFile()
+	if err != nil {
+		t.Fatalf("Failed to create socket file: %v", err)
+	}
+	defer cleanup()
+	conn, err := createServerClient(&mm, socketFile, seedDisks)
+	if err != nil {
+		t.Fatalf("Failed to create server client: %v", err)
+	}
+	controllerClient := csipb.NewControllerClient(conn)
+	req := &csi.ValidateVolumeCapabilitiesRequest{
+		VolumeId:           fmt.Sprintf("projects/%s/zones/%s/disks/%s", project, zone, name),
+		VolumeCapabilities: stdVolCaps,
+	}
+	resp, err := controllerClient.ValidateVolumeCapabilities(context.Background(), req)
+
+	if err != nil {
+		t.Fatalf("CreateVolume returned unexpected error: %v", err)
+	}
+
+	if resp.Confirmed != nil {
+		t.Fatalf("Expected not nil response, got: %v", resp)
+	}
+
+	reg := mm.GetRegistry()
+	metrics, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gailed to gather metrics: %v", err)
+	}
+	if len(metrics) != 1 {
+		t.Fatalf("Expected 1 metric, got %d", len(metrics))
+	}
+	gotMetric := fmt.Sprint(metrics[0])
+	wantMetric := `name:"csidriver_operation_errors" help:"[ALPHA] CSI server side error metrics" type:COUNTER metric:<label:<name:"disk_type" value:"" > label:<name:"driver_name" value:"pd.csi.storage.gke.io" > label:<name:"enable_confidential_storage" value:"false" > label:<name:"enable_storage_pools" value:"false" > label:<name:"grpc_status_code" value:"OK" > label:<name:"method_name" value:"/csi.v1.Controller/ValidateVolumeCapabilities" > counter:<value:1 > > `
+	if gotMetric != wantMetric {
+		t.Fatalf("Metric mismatch: \ngot: %v\nwant: %v", gotMetric, wantMetric)
+	}
+}
+
+func TestServerGetPluginInfoMetric(t *testing.T) {
+	mm := metrics.NewMetricsManager()
+	mm.ResetMetrics()
+	socketFile, cleanup, err := createSocketFile()
+	if err != nil {
+		t.Fatalf("Failed to create socket file: %v", err)
+	}
+	defer cleanup()
+	conn, err := createServerClient(&mm, socketFile, nil)
+	if err != nil {
+		t.Fatalf("Failed to create server client: %v", err)
+	}
+	idClient := csipb.NewIdentityClient(conn)
+	resp, err := idClient.GetPluginInfo(context.Background(), &csi.GetPluginInfoRequest{})
+	if err != nil {
+		t.Fatalf("GetPluginInfo returned unexpected error: %v", err)
+	}
+
+	if resp.GetName() != driver {
+		t.Fatalf("Response name expected: %v, got: %v", driver, resp.GetName())
+	}
+
+	reg := mm.GetRegistry()
+	metrics, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gailed to gather metrics: %v", err)
+	}
+	if len(metrics) != 1 {
+		t.Fatalf("Expected 1 metric, got %d", len(metrics))
+	}
+	gotMetric := fmt.Sprint(metrics[0])
+	wantMetric := `name:"csidriver_operation_errors" help:"[ALPHA] CSI server side error metrics" type:COUNTER metric:<label:<name:"disk_type" value:"unknownDiskType" > label:<name:"driver_name" value:"pd.csi.storage.gke.io" > label:<name:"enable_confidential_storage" value:"unknownConfidentialMode" > label:<name:"enable_storage_pools" value:"unknownStoragePools" > label:<name:"grpc_status_code" value:"OK" > label:<name:"method_name" value:"/csi.v1.Identity/GetPluginInfo" > counter:<value:1 > > `
+	if gotMetric != wantMetric {
+		t.Fatalf("Metric mismatch: \ngot: %v\nwant: %v", gotMetric, wantMetric)
+	}
+}

--- a/pkg/metrics/interceptor.go
+++ b/pkg/metrics/interceptor.go
@@ -1,0 +1,23 @@
+package metrics
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+type MetricInterceptor struct {
+	MetricsManager *MetricsManager
+}
+
+func (m *MetricInterceptor) unaryInterceptorInternal(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	requestMetadata := newRequestMetadata()
+	newCtx := context.WithValue(ctx, requestMetadataKey, requestMetadata)
+	result, err := handler(newCtx, req)
+	m.MetricsManager.RecordOperationErrorMetrics(info.FullMethod, err, requestMetadata.diskType, requestMetadata.enableConfidentialStorage, requestMetadata.enableStoragePools)
+	return result, err
+}
+
+func (m *MetricInterceptor) UnaryInterceptor() grpc.UnaryServerInterceptor {
+	return m.unaryInterceptorInternal
+}

--- a/pkg/metrics/metadata.go
+++ b/pkg/metrics/metadata.go
@@ -1,0 +1,55 @@
+package metrics
+
+import (
+	"context"
+	"strconv"
+
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
+	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute"
+)
+
+const (
+	// envGKEPDCSIVersion is an environment variable set in the PDCSI controller manifest
+	// with the current version of the GKE component.
+	requestMetadataKey = "requestMetadata"
+)
+
+// RequestMetadata represents metadata about a gRPC CSI request
+type RequestMetadata struct {
+	diskType                  string
+	enableConfidentialStorage string
+	enableStoragePools        string
+}
+
+func newRequestMetadata() *RequestMetadata {
+	return &RequestMetadata{
+		diskType:                  DefaultDiskTypeForMetric,
+		enableConfidentialStorage: DefaultEnableConfidentialCompute,
+		enableStoragePools:        DefaultEnableStoragePools,
+	}
+}
+
+// MetadataFromContext returns a mutable from a request context
+func MetadataFromContext(ctx context.Context) *RequestMetadata {
+	requestMetadata, _ := ctx.Value(requestMetadataKey).(*RequestMetadata)
+	return requestMetadata
+}
+
+func UpdateRequestMetadataFromParams(ctx context.Context, params common.DiskParameters) {
+	metadata := MetadataFromContext(ctx)
+	if metadata != nil {
+		metadata.diskType = params.DiskType
+		metadata.enableConfidentialStorage = strconv.FormatBool(params.EnableConfidentialCompute)
+		hasStoragePools := len(params.StoragePools) > 0
+		metadata.enableStoragePools = strconv.FormatBool(hasStoragePools)
+	}
+}
+
+func UpdateRequestMetadataFromDisk(ctx context.Context, disk *gce.CloudDisk) {
+	metadata := MetadataFromContext(ctx)
+	if metadata != nil && disk != nil {
+		metadata.diskType = disk.GetPDType()
+		metadata.enableConfidentialStorage = strconv.FormatBool(disk.GetEnableConfidentialCompute())
+		metadata.enableStoragePools = strconv.FormatBool(disk.GetEnableStoragePools())
+	}
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -99,15 +99,18 @@ func TestGetMetricParameters(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Logf("Running test: %v", tc.name)
-		diskType, confidentialCompute, enableStoragePools := GetMetricParameters(tc.disk)
-		if confidentialCompute != tc.expectedEnableConfidentialCompute {
-			t.Fatalf("Got confidentialCompute value %q expected %q", confidentialCompute, tc.expectedEnableConfidentialCompute)
+		ctx := context.TODO()
+		requestMetadata := newRequestMetadata()
+		newCtx := context.WithValue(ctx, requestMetadataKey, requestMetadata)
+		UpdateRequestMetadataFromDisk(newCtx, tc.disk)
+		if requestMetadata.enableConfidentialStorage != tc.expectedEnableConfidentialCompute {
+			t.Fatalf("Got confidentialCompute value %q expected %q", requestMetadata.enableConfidentialStorage, tc.expectedEnableConfidentialCompute)
 		}
-		if diskType != tc.expectedDiskType {
-			t.Fatalf("Got diskType value %q expected %q", diskType, tc.expectedDiskType)
+		if requestMetadata.diskType != tc.expectedDiskType {
+			t.Fatalf("Got diskType value %q expected %q", requestMetadata.enableConfidentialStorage, tc.expectedDiskType)
 		}
-		if enableStoragePools != tc.expectedEnableStoragePools {
-			t.Fatalf("Got enableStoragePools value %q expected %q", enableStoragePools, tc.expectedEnableStoragePools)
+		if requestMetadata.enableStoragePools != tc.expectedEnableStoragePools {
+			t.Fatalf("Got enableStoragePools value %q expected %q", requestMetadata.enableStoragePools, tc.expectedEnableStoragePools)
 		}
 	}
 }

--- a/pkg/metrics/metrics_test_util.go
+++ b/pkg/metrics/metrics_test_util.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+// Test-only method used for resetting metric counts.
+func (mm *MetricsManager) ResetMetrics() {
+	// Re-initialize metrics
+	initMetrics()
+}

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -102,7 +102,7 @@ func TestSanity(t *testing.T) {
 	}()
 
 	go func() {
-		gceDriver.Run(endpoint, 10000, false)
+		gceDriver.Run(endpoint, 10000, false /* enableOtelTracing */, nil /* metricsManager */)
 	}()
 
 	// TODO(#818): Fix failing tests and remove test skip flag.


### PR DESCRIPTION
Migrate metric defer() statements to gRPC metric interceptor. This allows for more accurate error code reporting of the internal `operation_errors` metric when gRPC handling functionality is refactored

> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Currently the ControllerServer reports error metrics through a `defer()` function pattern. This captures the output of captured variables when the function returns. If captured references are not updated (eg: a statement is refactored, and the `err` variable is not updated), the error code reported may not be accurate. This can result in poor error classification when this metric is used for reporting (as all error codes may be classified as `INTERNAL`).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Improved field accuracy for `csidriver/operation_errors` metric.
```
