### PR TITLE
Update ./hack/verify-docker-deps.sh script to validate dependencies on build platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,20 +73,24 @@ build-and-push-multi-arch-debug: build-and-push-container-linux-debug build-and-
 push-container: build-container
 
 # Used by hack/verify-docker-deps.sh, not used for building artifacts
-validate-container-linux-amd64: init-buildx
-	$(DOCKER) buildx build --platform=linux/amd64 \
-		-t validation_linux_amd64 \
-		--target validation-image \
-		--build-arg BUILDPLATFORM=linux \
-		--build-arg STAGINGVERSION=$(STAGINGVERSION) .
+validate-container-linux-amd64: build-and-load-container-linux-amd64
+	./hack/print-missing-deps.sh $(STAGINGIMAGE):$(STAGINGVERSION)_linux_amd64
 
 # Used by hack/verify-docker-deps.sh, not used for building artifacts
-validate-container-linux-arm64: init-buildx
-	$(DOCKER) buildx build --platform=linux/arm64 \
-		-t validation_linux_arm64 \
-		--target validation-image \
-		--build-arg BUILDPLATFORM=linux \
-		--build-arg STAGINGVERSION=$(STAGINGVERSION) .
+validate-container-linux-arm64: build-and-load-container-linux-arm64
+	./hack/print-missing-deps.sh $(STAGINGIMAGE):$(STAGINGVERSION)_linux_arm64
+
+validate-container-linux: validate-container-linux-amd64 validate-container-linux-arm64
+
+build-and-load-container-linux-amd64: require-GCE_PD_CSI_STAGING_IMAGE init-buildx
+	$(DOCKER) buildx build --platform=linux/amd64 \
+		-t $(STAGINGIMAGE):$(STAGINGVERSION)_linux_amd64 \
+		--build-arg STAGINGVERSION=$(STAGINGVERSION) --load .
+
+build-and-load-container-linux-arm64: require-GCE_PD_CSI_STAGING_IMAGE init-buildx
+	$(DOCKER) buildx build --file=Dockerfile --platform=linux/arm64 \
+		-t $(STAGINGIMAGE):$(STAGINGVERSION)_linux_arm64 \
+		--build-arg STAGINGVERSION=$(STAGINGVERSION) --load .
 
 build-and-push-container-linux-amd64: require-GCE_PD_CSI_STAGING_IMAGE init-buildx
 	$(DOCKER) buildx build --platform=linux/amd64 \

--- a/hack/verify-docker-deps.sh
+++ b/hack/verify-docker-deps.sh
@@ -22,4 +22,5 @@ echo "Verifying Docker Image Dependencies"
 
 PKG_ROOT=$(git rev-parse --show-toplevel)
 
-make -C "${PKG_ROOT}" validate-container-linux-amd64 validate-container-linux-arm64
+export GCE_PD_CSI_STAGING_IMAGE=validation-image
+make -C "${PKG_ROOT}" validate-container-linux


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Verify presubmit is currently failing (due to running on QEMU using target platform). This changes from using `ldd` on the target platform to using `readelf` on executables from the target image to validate dependencies exist in the base image.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
