### PR TITLE
Remove make from verify-all in order to reduce presubmit flakes

### DIFF
--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -23,5 +23,3 @@ PKG_ROOT=$(git rev-parse --show-toplevel)
 "${PKG_ROOT}/hack/verify-gofmt.sh"
 "${PKG_ROOT}/hack/verify-govet.sh"
 "${PKG_ROOT}/hack/verify-docker-deps.sh"
-
-make -C "${PKG_ROOT}" all


### PR DESCRIPTION
/kind cleanup
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```

/assign @amacaskill 