### PR TITLE
Don't overwrite libc in distroless debian base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,6 @@ COPY --from=debian /lib/${LIB_DIR_PREFIX}-linux-gnu/libselinux.so.1 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/liblzma.so.5 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libreadline.so.8 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libz.so.1 \
-                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libc.so.6 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/liburcu.so.8 \ 
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libcap.so.2 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libcrypto.so.3 \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
In our Dockerfile, we copy over some libraries from `gke.gcr.io/debian-base:bookworm-` to a `gcr.io/distroless/base-debian12` base. Currently this overwrites `libc.so.6`, which already exists in  `gcr.io/distroless/base-debian12`. This can lead to ABI incompatibilities between `ld-linux` (which is in base-debian) and the overwritten libc library. At the moment the ARM64 Docker image is broken when running applications that depend on `libc`. The following error can be seen:

```
docker run --entrypoint /bin/bash -it  bd99abeb3efc --
/bin/bash: error while loading shared libraries: __kernel_gettimeofday: invalid mode for dlopen(): Invalid argument
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1882

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix shared library loading runtime error
```
