### PR TITLE
Dynamically build e2e test OS image from architecture

### DIFF
--- a/test/e2e/tests/setup_e2e_test.go
+++ b/test/e2e/tests/setup_e2e_test.go
@@ -36,14 +36,17 @@ import (
 )
 
 var (
-	project                   = flag.String("project", "", "Project to run tests in")
-	serviceAccount            = flag.String("service-account", "", "Service account to bring up instance with")
-	vmNamePrefix              = flag.String("vm-name-prefix", "gce-pd-csi-e2e", "VM name prefix")
-	architecture              = flag.String("arch", "amd64", "Architecture pd csi driver build on")
-	minCpuPlatform            = flag.String("min-cpu-platform", "AMD Milan", "Minimum CPU architecture")
-	zones                     = flag.String("zones", "us-east4-a,us-east4-c", "Zones to run tests in. If there are multiple zones, separate each by comma")
-	machineType               = flag.String("machine-type", "n2d-standard-2", "Type of machine to provision instance on")
-	imageURL                  = flag.String("image-url", "projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2404-lts-amd64", "OS image url to get image from")
+	project        = flag.String("project", "", "Project to run tests in")
+	serviceAccount = flag.String("service-account", "", "Service account to bring up instance with")
+	vmNamePrefix   = flag.String("vm-name-prefix", "gce-pd-csi-e2e", "VM name prefix")
+	architecture   = flag.String("arch", "amd64", "Architecture pd csi driver build on")
+	minCpuPlatform = flag.String("min-cpu-platform", "AMD Milan", "Minimum CPU architecture")
+	zones          = flag.String("zones", "us-east4-a,us-east4-c", "Zones to run tests in. If there are multiple zones, separate each by comma")
+	machineType    = flag.String("machine-type", "n2d-standard-2", "Type of machine to provision instance on")
+	// TODO: Remove presubmit is no longer setting --image-url
+	imageURL                  = flag.String("image-url", "", "[DEPRECATED] OS image url to get image from. Not actively used")
+	imageProject              = flag.String("image-project", "ubuntu-os-cloud", "OS image url to get image from")
+	imagePrefix               = flag.String("image-family-prefix", "ubuntu-minimal-2404-lts", "Image family prefix, to which \"-<arch>\" is appended")
 	runInProw                 = flag.Bool("run-in-prow", false, "If true, use a Boskos loaned project and special CI service accounts and ssh keys")
 	deleteInstances           = flag.Bool("delete-instances", false, "Delete the instances after tests run")
 	cloudtopHost              = flag.Bool("cloudtop-host", false, "The local host is cloudtop, a kind of googler machine with special requirements to access GCP")
@@ -137,6 +140,7 @@ func NewTestContext(zone string) *remote.TestContext {
 	nodeID := fmt.Sprintf("%s-%s", *vmNamePrefix, zone)
 	klog.Infof("Setting up node %s", nodeID)
 
+	imageURL := fmt.Sprintf("projects/%s/global/images/family/%s-%s", *imageProject, *imagePrefix, *architecture)
 	instanceConfig := remote.InstanceConfig{
 		Project:                   *project,
 		Architecture:              *architecture,
@@ -145,7 +149,7 @@ func NewTestContext(zone string) *remote.TestContext {
 		Name:                      nodeID,
 		MachineType:               *machineType,
 		ServiceAccount:            *serviceAccount,
-		ImageURL:                  *imageURL,
+		ImageURL:                  imageURL,
 		CloudtopHost:              *cloudtopHost,
 		EnableConfidentialCompute: *enableConfidentialCompute,
 		ComputeService:            computeService,

--- a/test/run-e2e-local.sh
+++ b/test/run-e2e-local.sh
@@ -16,4 +16,4 @@ if hostname | grep -q c.googlers.com ; then
   CLOUDTOP_HOST=--cloudtop-host
 fi
 
-ginkgo --v "test/e2e/tests" -- --project "${PROJECT}" --service-account "${IAM_NAME}" "${CLOUDTOP_HOST}" --v=6 --logtostderr $@
+ginkgo --v "test/e2e/tests" -- --project "${PROJECT}" --service-account "${IAM_NAME}" ${CLOUDTOP_HOST} --v=6 --logtostderr $@


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
To simplify running e2e tests on amd64/arm64, the OS image can be inferred from the `--architecture` flag. This simplifies presubmit configuration arguments like https://github.com/kubernetes/test-infra/pull/32214.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
