### PR TITLE
Revert "Require VACs to use SI units"

### DIFF
--- a/examples/kubernetes/demo-vol-create.yaml
+++ b/examples/kubernetes/demo-vol-create.yaml
@@ -16,7 +16,7 @@ metadata:
 driverName: pd.csi.storage.gke.io
 parameters:
   iops: "3000"
-  throughput: "150Mi"
+  throughput: "150"
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: VolumeAttributesClass
@@ -25,7 +25,7 @@ metadata:
 driverName: pd.csi.storage.gke.io
 parameters:
   iops: "3013"
-  throughput: "151Mi"
+  throughput: "151"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/pkg/common/parameters.go
+++ b/pkg/common/parameters.go
@@ -343,7 +343,7 @@ func ExtractModifyVolumeParameters(parameters map[string]string) (ModifyVolumePa
 			}
 			modifyVolumeParams.IOPS = &iops
 		case "throughput":
-			throughput, err := ConvertMiStringToInt64(value)
+			throughput, err := ConvertStringToInt64(value)
 			if err != nil {
 				return ModifyVolumeParameters{}, fmt.Errorf("parameters contain invalid throughput parameter: %w", err)
 			}

--- a/pkg/common/parameters_test.go
+++ b/pkg/common/parameters_test.go
@@ -485,7 +485,7 @@ func TestSnapshotParameters(t *testing.T) {
 func TestExtractModifyVolumeParameters(t *testing.T) {
 	parameters := map[string]string{
 		"iops":       "1000",
-		"throughput": "500Mi",
+		"throughput": "500",
 	}
 
 	iops := int64(1000)

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -1789,7 +1789,7 @@ func TestCreateVolumeWithVolumeAttributeClassParameters(t *testing.T) {
 						},
 					},
 				},
-				MutableParameters: map[string]string{"iops": "20000", "throughput": "600Mi"},
+				MutableParameters: map[string]string{"iops": "20000", "throughput": "600"},
 			},
 			expIops:       20000,
 			expThroughput: 600,
@@ -1822,7 +1822,7 @@ func TestCreateVolumeWithVolumeAttributeClassParameters(t *testing.T) {
 						},
 					},
 				},
-				MutableParameters: map[string]string{"iops": "20000", "throughput": "600Mi"},
+				MutableParameters: map[string]string{"iops": "20000", "throughput": "600"},
 			},
 			expIops:       0,
 			expThroughput: 0,
@@ -1890,7 +1890,7 @@ func TestVolumeModifyOperation(t *testing.T) {
 			name: "Update volume with valid parameters",
 			req: &csi.ControllerModifyVolumeRequest{
 				VolumeId:          testVolumeID,
-				MutableParameters: map[string]string{"iops": "20000", "throughput": "600Mi"},
+				MutableParameters: map[string]string{"iops": "20000", "throughput": "600"},
 			},
 			diskType: "hyperdisk-balanced",
 			params: &common.DiskParameters{
@@ -1906,7 +1906,7 @@ func TestVolumeModifyOperation(t *testing.T) {
 			name: "Update volume with invalid parameters",
 			req: &csi.ControllerModifyVolumeRequest{
 				VolumeId:          testVolumeID,
-				MutableParameters: map[string]string{"iops": "0", "throughput": "0Mi"},
+				MutableParameters: map[string]string{"iops": "0", "throughput": "0"},
 			},
 			diskType: "hyperdisk-balanced",
 			params: &common.DiskParameters{
@@ -1922,7 +1922,7 @@ func TestVolumeModifyOperation(t *testing.T) {
 			name: "Update volume with valid parameters but invalid disk type",
 			req: &csi.ControllerModifyVolumeRequest{
 				VolumeId:          testVolumeID,
-				MutableParameters: map[string]string{"iops": "20000", "throughput": "600Mi"},
+				MutableParameters: map[string]string{"iops": "20000", "throughput": "600"},
 			},
 			diskType: "pd-ssd",
 			params: &common.DiskParameters{
@@ -2053,7 +2053,7 @@ func TestVolumeModifyErrorHandling(t *testing.T) {
 				},
 			},
 			modifyReq: &csi.ControllerModifyVolumeRequest{
-				MutableParameters: map[string]string{"iops": "3001", "throughput": "151Mi"},
+				MutableParameters: map[string]string{"iops": "3001", "throughput": "151"},
 			},
 			modifyVolumeErrors: map[*meta.Key]error{
 				meta.ZonalKey(name, "us-central1-a"): &googleapi.Error{
@@ -2089,7 +2089,7 @@ func TestVolumeModifyErrorHandling(t *testing.T) {
 				},
 			},
 			modifyReq: &csi.ControllerModifyVolumeRequest{
-				MutableParameters: map[string]string{"iops": "10000", "throughput": "2400Mi"},
+				MutableParameters: map[string]string{"iops": "10000", "throughput": "2400"},
 			},
 			modifyVolumeErrors: map[*meta.Key]error{
 				meta.ZonalKey(name, "us-central1-a"): &googleapi.Error{Code: int(codes.InvalidArgument), Message: "InvalidArgument"},

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -1622,7 +1622,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 			stringPtr(provisionedIOPSOnCreateHdb),
 			stringPtr(provisionedThroughputOnCreateHdb),
 			stringPtr("3013"),
-			stringPtr("181Mi"),
+			stringPtr("181"),
 		),
 		Entry(
 			"for hyperdisk-extreme",
@@ -1640,7 +1640,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 			nil,
 			stringPtr(provisionedThroughputOnCreate),
 			nil,
-			stringPtr("70Mi"),
+			stringPtr("70"),
 		),
 	)
 })

--- a/test/k8s-integration/config/hdb-volumeattributesclass.yaml
+++ b/test/k8s-integration/config/hdb-volumeattributesclass.yaml
@@ -5,4 +5,4 @@ metadata:
 driverName: pd.csi.storage.gke.io
 parameters:
   iops: "3600"
-  throughput: "290Mi"
+  throughput: "290"


### PR DESCRIPTION
Reverts kubernetes-sigs/gcp-compute-persistent-disk-csi-driver#1875