### PR TITLE
[metrics] Fix panic during metrics manager startup

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -39,11 +39,6 @@ const (
 )
 
 var (
-	gkeComponentVersion        *metrics.GaugeVec
-	pdcsiOperationErrorsMetric *metrics.CounterVec
-)
-
-func initMetrics() {
 	// This metric is exposed only from the controller driver component when GKE_PDCSI_VERSION env variable is set.
 	gkeComponentVersion = metrics.NewGaugeVec(&metrics.GaugeOpts{
 		Name: "component_version",
@@ -58,7 +53,7 @@ func initMetrics() {
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"driver_name", "method_name", "grpc_status_code", "disk_type", "enable_confidential_storage", "enable_storage_pools"})
-}
+)
 
 type MetricsManager struct {
 	registry metrics.KubeRegistry

--- a/pkg/metrics/metrics_test_util.go
+++ b/pkg/metrics/metrics_test_util.go
@@ -19,5 +19,6 @@ package metrics
 // Test-only method used for resetting metric counts.
 func (mm *MetricsManager) ResetMetrics() {
 	// Re-initialize metrics
-	initMetrics()
+	gkeComponentVersion.Reset()
+	pdcsiOperationErrorsMetric.Reset()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This fixes a regression introduced in #1876 where the driver would start panicking on startup if `--http-endpoint` was specified. This was caused by the metrics not being initialized anymore during startup. The proposed fix involves using the `Reset` methods of the metrics object instead of trying to redefine them each time they need to be reset.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1894

Tested the PR by building an image and making sure it did not panic:
```
$ docker buildx build --platform "linux/amd64" --tag gcp-pd-csi-driver:test --build-arg=BUILDPLATFORM=linux --build-arg=STAGINGVERSION=v1.15.3 -f Dockerfile --load .
...
$ docker run -it gcp-pd-csi-driver:test --http-endpoint=localhost:8080
I1218 13:22:38.273351       1 main.go:114] Operating compute environment set to: production and computeEndpoint is set to: <nil>
I1218 13:22:38.274410       1 main.go:123] Sys info: NumCPU: 20 MAXPROC: 1
W1218 13:22:38.274885       1 metrics.go:143] "GKE_PDCSI_VERSION" env not set
I1218 13:22:38.280217       1 metrics.go:133] Metric server listening at "localhost:8080"
W1218 13:22:38.286433       1 gce.go:203] GOOGLE_APPLICATION_CREDENTIALS env var not set
F1218 13:22:38.286477       1 main.go:221] Failed to get cloud provider: google: could not find default credentials. See https://cloud.google.com/docs/authentication/external/set-up-adc for more information

```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed panic issue during startup when using the --http-endpoint flag
```
