### PR TITLE
Add validation for negative provisioned-throughput-on-create parameter

### DIFF
--- a/pkg/common/parameters.go
+++ b/pkg/common/parameters.go
@@ -201,6 +201,9 @@ func (pp *ParameterProcessor) ExtractAndDefaultParameters(parameters map[string]
 			if err != nil {
 				return p, fmt.Errorf("parameters contain invalid provisionedThroughputOnCreate parameter: %w", err)
 			}
+			if paramProvisionedThroughputOnCreate < 0 {
+				return p, fmt.Errorf("parameter provisionedThroughputOnCreate cannot be negative")
+			}
 			p.ProvisionedThroughputOnCreate = paramProvisionedThroughputOnCreate
 		case ParameterAvailabilityClass:
 			paramAvailabilityClass, err := ConvertStringToAvailabilityClass(v)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
If the StorageClass is of type hyperdisk-throughput and the parameter `provisioned-throughput-on-create` has a negative value, we don't include the negative value when calling the GCE API to provision the volume. Instead a sensible default is used injected by GCE API, leading to a confusing UX.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Using a negative value for provisioned-throughput-on-create parameter of hyperdisk-throughput type StorageClass will now lead to a failure when creating a new volume.
```
