### PR TITLE
Use correct path in error message for udev tooling

### DIFF
--- a/pkg/deviceutils/device-utils.go
+++ b/pkg/deviceutils/device-utils.go
@@ -194,7 +194,7 @@ func ensureUdevToolExists(toolPath string) error {
 	if !exists {
 		// The driver should be containerized with the tool so maybe something is
 		// wrong with the build process
-		return fmt.Errorf("could not find tool at %q, unable to verify device paths", nvmeIdPath)
+		return fmt.Errorf("could not find tool at %q, unable to verify device paths", toolPath)
 	}
 	return nil
 }


### PR DESCRIPTION
/kind bug

The current error message uses the wrong path. #1853 would have fixed it, but it was not submitted for some reason.

```release-note
Use correct tool path in udev error message.
```

/assign @msau42 
