### PR TITLE
Convert E2E tests to running the PD CSI driver in a container instead of a binary directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,13 @@ else
 	$(warning gcp-pd-driver-windows only supports amd64.)
 endif
 
+build-container-local: init-buildx
+	$(DOCKER) buildx build --platform=linux --progress=plain \
+		-t local:local \
+		--build-arg BUILDPLATFORM=linux \
+		--build-arg STAGINGVERSION=local \
+		--load .
+
 build-container: require-GCE_PD_CSI_STAGING_IMAGE require-GCE_PD_CSI_STAGING_VERSION init-buildx
 	$(DOCKER) buildx build --platform=linux --progress=plain \
 		-t $(STAGINGIMAGE):$(STAGINGVERSION) \

--- a/pkg/deviceutils/device-utils.go
+++ b/pkg/deviceutils/device-utils.go
@@ -324,7 +324,8 @@ func filterAvailableNvmeDevFsPaths(devNvmePaths []string) []string {
 	return diskNvmePaths
 }
 
-func findAvailableDevFsPaths() ([]string, error) {
+// FindAvailableDevFsPaths returns a list of the paths of accessible devices.
+func FindAvailableDevFsPaths() ([]string, error) {
 	diskSDPaths, err := filepath.Glob(diskSDGlob)
 	if err != nil {
 		return nil, fmt.Errorf("failed to filepath.Glob(\"%s\"): %w", diskSDGlob, err)
@@ -340,7 +341,7 @@ func findAvailableDevFsPaths() ([]string, error) {
 
 func udevadmTriggerForDiskIfExists(deviceName string) error {
 	devFsPathToSerial := map[string]string{}
-	devFsPaths, err := findAvailableDevFsPaths()
+	devFsPaths, err := FindAvailableDevFsPaths()
 	if err != nil {
 		return err
 	}

--- a/test/e2e/tests/multi_zone_e2e_test.go
+++ b/test/e2e/tests/multi_zone_e2e_test.go
@@ -1089,8 +1089,7 @@ func testAttachAndMount(volID string, volName string, instance *remote.InstanceI
 
 	detach := func() {
 		// Detach Disk
-		err = client.ControllerUnpublishVolume(volID, instance.GetNodeID())
-		if err != nil {
+		if err := client.ControllerUnpublishVolume(volID, instance.GetNodeID()); err != nil {
 			klog.Errorf("Failed to detach disk: %v", err)
 		}
 	}
@@ -1110,13 +1109,11 @@ func testAttachAndMount(volID string, volName string, instance *remote.InstanceI
 
 	unstageAndDetach := func() {
 		// Unstage Disk
-		err = client.NodeUnstageVolume(volID, stageDir)
-		if err != nil {
+		if err := client.NodeUnstageVolume(volID, stageDir); err != nil {
 			klog.Errorf("Failed to unstage volume: %v", err)
 		}
 		fp := filepath.Join("/tmp/", volName)
-		err = testutils.RmAll(instance, fp)
-		if err != nil {
+		if err := testutils.RmAll(instance, fp); err != nil {
 			klog.Errorf("Failed to rm file path %s: %v", fp, err)
 		}
 
@@ -1139,8 +1136,7 @@ func testAttachAndMount(volID string, volName string, instance *remote.InstanceI
 
 	unpublish := func() {
 		// Unpublish Disk
-		err = client.NodeUnpublishVolume(volID, publishDir)
-		if err != nil {
+		if err := client.NodeUnpublishVolume(volID, publishDir); err != nil {
 			klog.Errorf("Failed to unpublish volume: %v", err)
 		}
 	}

--- a/test/e2e/tests/setup_e2e_test.go
+++ b/test/e2e/tests/setup_e2e_test.go
@@ -55,6 +55,7 @@ var (
 	computeAlphaService *computealpha.Service
 	computeBetaService  *computebeta.Service
 	kmsClient           *cloudkms.KeyManagementClient
+	archivePath         string
 )
 
 func init() {
@@ -98,6 +99,9 @@ var _ = BeforeSuite(func() {
 
 	klog.Infof("Running in project %v with service account %v", *project, *serviceAccount)
 
+	archivePath, err = testutils.BuildLocalImage()
+	Expect(err).To(BeNil())
+
 	for _, zone := range zones {
 		go func(curZone string) {
 			defer GinkgoRecover()
@@ -120,6 +124,9 @@ var _ = AfterSuite(func() {
 			tc.Instance.DeleteInstance()
 		}
 	}
+
+	err := testutils.RemoveLocalImage()
+	Expect(err).To(BeNil())
 })
 
 func notEmpty(v string) bool {
@@ -128,8 +135,9 @@ func notEmpty(v string) bool {
 
 func getDriverConfig() testutils.DriverConfig {
 	return testutils.DriverConfig{
-		ExtraFlags: slices.Filter(nil, strings.Split(*extraDriverFlags, ","), notEmpty),
-		Zones:      strings.Split(*zones, ","),
+		ExtraFlags:  slices.Filter(nil, strings.Split(*extraDriverFlags, ","), notEmpty),
+		Zones:       strings.Split(*zones, ","),
+		ArchivePath: archivePath,
 	}
 }
 

--- a/test/e2e/utils/setup-remote.sh
+++ b/test/e2e/utils/setup-remote.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+## Install Kubectl: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
+## Install Docker: https://docs.docker.com/engine/install/debian/
+sudo apt-get update
+sudo apt-get install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+  bookworm stable" | \
+  tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+
+sudo apt-get install -y uidmap docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin dbus-user-session slirp4netns docker-ce-rootless-extras
+
+# systemctl disable --now docker.service docker.socket
+# rm /var/run/docker.sock
+
+# touch /tmp/startup-configured.txt
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind cleanup

**What this PR does / why we need it**:

It converts the test code from running the PD CSI driver as a binary on GCE to running it as a container image. This increases test coverage to include our Dockerfile and its dependencies.

**Which issue(s) this PR fixes**:

Fixes b/261474293

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
