### PR TITLE
changes to support hyperdisk multi-writer mode

### DIFF
--- a/pkg/common/parameters.go
+++ b/pkg/common/parameters.go
@@ -106,6 +106,9 @@ type DiskParameters struct {
 	// Values: {bool}
 	// Default: false
 	MultiZoneProvisioning bool
+	// Values: READ_WRITE_SINGLE, READ_ONLY_MANY, READ_WRITE_MANY
+	// Default: READ_WRITE_SINGLE
+	AccessMode string
 }
 
 // SnapshotParameters contains normalized and defaulted parameters for snapshots
@@ -148,6 +151,7 @@ func (pp *ParameterProcessor) ExtractAndDefaultParameters(parameters map[string]
 		Tags:                 make(map[string]string), // Default
 		Labels:               make(map[string]string), // Default
 		ResourceTags:         make(map[string]string), // Default
+		AccessMode:           "READ_WRITE_SINGLE",     // Default
 	}
 
 	for k, v := range extraVolumeLabels {

--- a/pkg/common/parameters.go
+++ b/pkg/common/parameters.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// Disk Params
-	ParameterAccessMode						  = "access-mode"
+	ParameterAccessMode = "access-mode"
 
 	// Parameters for StorageClass
 	ParameterKeyType                          = "type"

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -1409,7 +1409,7 @@ func TestIsUserMultiAttachError(t *testing.T) {
 		},
 	}
 	for _, test := range cases {
-		code, err := isUserMultiAttachError(fmt.Errorf(test.errorString))
+		code, err := isUserMultiAttachError(fmt.Errorf("%s", test.errorString))
 		if test.expectCode {
 			if err != nil || code != test.expectedCode {
 				t.Errorf("Failed with non-nil error %v or bad code %v: %s", err, code, test.errorString)

--- a/pkg/gce-cloud-provider/compute/cloud-disk.go
+++ b/pkg/gce-cloud-provider/compute/cloud-disk.go
@@ -217,6 +217,8 @@ func (d *CloudDisk) GetMultiWriter() bool {
 	switch {
 	case d.disk != nil:
 		return false
+	case d.disk != nil && d.disk.AccessMode == "READ_WRITE_MANY":
+		return true
 	case d.betaDisk != nil:
 		return d.betaDisk.MultiWriter
 	default:

--- a/pkg/gce-cloud-provider/compute/cloud-disk.go
+++ b/pkg/gce-cloud-provider/compute/cloud-disk.go
@@ -213,19 +213,6 @@ func (d *CloudDisk) GetKMSKeyName() string {
 	return ""
 }
 
-func (d *CloudDisk) GetMultiWriter() bool {
-	switch {
-	case d.disk != nil:
-		return false
-	case d.disk != nil && d.disk.AccessMode == "READ_WRITE_MANY":
-		return true
-	case d.betaDisk != nil:
-		return d.betaDisk.MultiWriter
-	default:
-		return false
-	}
-}
-
 func (d *CloudDisk) GetEnableConfidentialCompute() bool {
 	switch {
 	case d.disk != nil:

--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -212,11 +212,6 @@ func (cloud *FakeCloudProvider) ValidateExistingDisk(ctx context.Context, resp *
 			params.DiskType, respType[len(respType)-1])
 	}
 
-	// We are assuming here that a multiWriter disk could be used as non-multiWriter
-	if multiWriter {
-		return fmt.Errorf("disk already exists with incompatible capability. Need MultiWriter. Got non-MultiWriter")
-	}
-
 	klog.V(4).Infof("Compatible disk already exists")
 	return ValidateDiskParameters(resp, params)
 }

--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -184,7 +184,7 @@ func (cloud *FakeCloudProvider) ListSnapshots(ctx context.Context, filter string
 }
 
 // Disk Methods
-func (cloud *FakeCloudProvider) GetDisk(ctx context.Context, project string, volKey *meta.Key, api GCEAPIVersion) (*CloudDisk, error) {
+func (cloud *FakeCloudProvider) GetDisk(ctx context.Context, project string, volKey *meta.Key) (*CloudDisk, error) {
 	disk, ok := cloud.disks[volKey.String()]
 	if !ok {
 		return nil, notFoundError()

--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -213,7 +213,7 @@ func (cloud *FakeCloudProvider) ValidateExistingDisk(ctx context.Context, resp *
 	}
 
 	// We are assuming here that a multiWriter disk could be used as non-multiWriter
-	if multiWriter && !resp.GetMultiWriter() {
+	if multiWriter {
 		return fmt.Errorf("disk already exists with incompatible capability. Need MultiWriter. Got non-MultiWriter")
 	}
 

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -2432,10 +2432,6 @@ func createRegionalDisk(ctx context.Context, cloudProvider gce.GCECompute, name 
 		return nil, fmt.Errorf("failed to insert regional disk: %w", err)
 	}
 
-	gceAPIVersion := gce.GCEAPIVersionV1
-	if multiWriter {
-		gceAPIVersion = gce.GCEAPIVersionBeta
-	}
 	// failed to GetDisk, however the Disk may already be created, the error code should be non-Final
 	disk, err := cloudProvider.GetDisk(ctx, project, meta.RegionalKey(name, region))
 	if err != nil {
@@ -2455,10 +2451,6 @@ func createSingleZoneDisk(ctx context.Context, cloudProvider gce.GCECompute, nam
 		return nil, fmt.Errorf("failed to insert zonal disk: %w", err)
 	}
 
-	gceAPIVersion := gce.GCEAPIVersionV1
-	if multiWriter {
-		gceAPIVersion = gce.GCEAPIVersionBeta
-	}
 	// failed to GetDisk, however the Disk may already be created, the error code should be non-Final
 	disk, err := cloudProvider.GetDisk(ctx, project, meta.ZonalKey(name, diskZone))
 	if err != nil {

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -596,7 +596,7 @@ func (gceCS *GCEControllerServer) createSingleDisk(ctx context.Context, req *csi
 	capBytes, _ := getRequestCapacity(capacityRange)
 	multiWriter, _ := getMultiWriterFromCapabilities(req.GetVolumeCapabilities())
 	readonly, _ := getReadOnlyFromCapabilities(req.GetVolumeCapabilities())
-	accessMode := ""
+	accessMode := params.AccessMode
 	if readonly && slices.Contains(disksWithModifiableAccessMode, params.DiskType) {
 		accessMode = readOnlyManyAccessMode
 	}

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -1741,7 +1741,7 @@ func TestMultiZoneVolumeCreationErrHandling(t *testing.T) {
 		}
 
 		for _, volKey := range tc.wantDisks {
-			disk, err := fcp.GetDisk(context.Background(), project, volKey, gce.GCEAPIVersionV1)
+			disk, err := fcp.GetDisk(context.Background(), project, volKey)
 			if err != nil {
 				t.Errorf("Unexpected err fetching disk %v: %v", volKey, err)
 			}

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -1565,7 +1565,7 @@ func TestMultiZoneVolumeCreation(t *testing.T) {
 
 		for _, zone := range tc.expZones {
 			volumeKey := meta.ZonalKey(name, zone)
-			disk, err := fcp.GetDisk(context.Background(), project, volumeKey, gce.GCEAPIVersionBeta)
+			disk, err := fcp.GetDisk(context.Background(), project, volumeKey)
 			if err != nil {
 				t.Fatalf("Get Disk failed for created disk with error: %v", err)
 			}
@@ -1859,7 +1859,7 @@ func TestCreateVolumeWithVolumeAttributeClassParameters(t *testing.T) {
 			t.Fatalf("Failed to convert volume id to key: %v", err)
 		}
 
-		disk, err := fcp.GetDisk(context.Background(), project, volumeKey, gce.GCEAPIVersionBeta)
+		disk, err := fcp.GetDisk(context.Background(), project, volumeKey)
 
 		if err != nil {
 			t.Fatalf("Failed to get disk: %v", err)
@@ -1964,7 +1964,7 @@ func TestVolumeModifyOperation(t *testing.T) {
 			}
 		}
 
-		modifiedVol, err := fcp.GetDisk(context.Background(), project, volKey, gce.GCEAPIVersionBeta)
+		modifiedVol, err := fcp.GetDisk(context.Background(), project, volKey)
 
 		if err != nil {
 			t.Errorf("Failed to get volume: %v", err)
@@ -5241,7 +5241,7 @@ func TestCreateConfidentialVolume(t *testing.T) {
 
 			volumeId := resp.GetVolume().VolumeId
 			project, volumeKey, err := common.VolumeIDToKey(volumeId)
-			createdDisk, err := fcp.GetDisk(context.Background(), project, volumeKey, gce.GCEAPIVersionBeta)
+			createdDisk, err := fcp.GetDisk(context.Background(), project, volumeKey)
 			if err != nil {
 				t.Fatalf("Get Disk failed for created disk with error: %v", err)
 			}

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -904,8 +904,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		Expect(err).To(BeNil(), "Failed to go through volume lifecycle")
 	})
 
-	// Pending while multi-writer feature is in Alpha
-	PIt("Should create and delete multi-writer disk", func() {
+	It("Should create and delete multi-writer disk", func() {
 		Expect(testContexts).ToNot(BeEmpty())
 		testContext := getRandomTestContext()
 
@@ -916,7 +915,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		zone := "us-east1-a"
 
 		// Create and Validate Disk
-		volName, volID := createAndValidateUniqueZonalMultiWriterDisk(client, p, zone, standardDiskType)
+		volName, volID := createAndValidateUniqueZonalMultiWriterDisk(client, p, zone, hdbDiskType)
 
 		defer func() {
 			// Delete Disk
@@ -929,8 +928,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		}()
 	})
 
-	// Pending while multi-writer feature is in Alpha
-	PIt("Should complete entire disk lifecycle with multi-writer disk", func() {
+	It("Should complete entire disk lifecycle with multi-writer disk", func() {
 		testContext := getRandomTestContext()
 
 		p, z, _ := testContext.Instance.GetIdentity()
@@ -938,7 +936,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		instance := testContext.Instance
 
 		// Create and Validate Disk
-		volName, volID := createAndValidateUniqueZonalMultiWriterDisk(client, p, z, standardDiskType)
+		volName, volID := createAndValidateUniqueZonalMultiWriterDisk(client, p, z, hdbDiskType)
 
 		defer func() {
 			// Delete Disk
@@ -1710,6 +1708,8 @@ func deleteVolumeOrError(client *remote.CsiClient, volID string) {
 func createAndValidateUniqueZonalMultiWriterDisk(client *remote.CsiClient, project, zone string, diskType string) (string, string) {
 	// Create Disk
 	disk := typeToDisk[diskType]
+		disk.params.AccessMode = "READ_WRITE_MANY"
+
 	volName := testNamePrefix + string(uuid.NewUUID())
 	volume, err := client.CreateVolumeWithCaps(volName, disk.params, defaultMwSizeGb,
 		&csi.TopologyRequirement{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Hyper disk multi-writer support is now in [compute/v1](https://pkg.go.dev/google.golang.org/api/compute/v1) but the persistent disk csi driver still calls [v0.beta](https://pkg.go.dev/google.golang.org/api/compute/v0.beta) which leads a error while creating a hyperdisk with multi-writer mode.

Error:
```
Warning ProvisioningFailed 31m (x15 over 57m) pd.csi.storage.gke.io_wduan-1030a-g-vdnqh-master-0_dc46e9f6-1725-4f15-922c-99f0e281e102 failed to provision volume with StorageClass
"balanced-storage": rpc error: code = InvalidArgument desc = CreateVolume failed: rpc error: code = InvalidArgument desc = CreateVolume failed to create single zonal disk pvc-0b65d680-636b-46c6-876d-d3a6c412c3ef: failed to insert zonal disk: unknown Insert disk error:
googleapi: Error 400: Invalid value for field 'resource.multiWriter': 'true'.
Cannot specify the multi writer field for 'hyperdisk-balanced' disks,
please use access mode instead., invalid%!v(MISSING)
```

To fix this here are the changes done:
1. Add AccessMode param to [DiskParameters struct](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/96338cae8f2a0f04d68f21af525556fb1a5fcc5e/pkg/common/parameters.go#L73)
2. Initialize the AccessMode field to the input value in ExtractAndDefaultParameters(). We do not have an explicit default - that will be decided by the PD layer depending on disk type.
3. The parameter is read by controller in [createVolumeInternal()](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/96338cae8f2a0f04d68f21af525556fb1a5fcc5e/pkg/gce-pd-csi-driver/controller.go#L307)
4. The accessMode before calling createSingleZoneDisk() and createRegionalDisk() is currently set to "", the change fixes [createsingledisk()](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/96338cae8f2a0f04d68f21af525556fb1a5fcc5e/pkg/gce-pd-csi-driver/controller.go#L599) to read from the parameter passed by the user.
5. [insertZonalDisk()](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/master/pkg/gce-cloud-provider/compute/gce-compute.go#L764) currently calls beta APIs when multi-writer is set, the fix is to use v1 API instead.
6. [insertRegionalDisk()](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/master/pkg/gce-cloud-provider/compute/gce-compute.go#L636C29-L636C47)  currently calls beta APIs when multi-writer is set, the fix is to use v1 API instead.
7. Enable the [multiwriter e2e tests](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/c29a4ee145ad4cdf45306a96924c505f48a82d2b/test/e2e/tests/single_zone_e2e_test.go#L907) to test creation and lifecycle of multi-writer disks.
8. Delete stale comments about hyperdisk and multi-writer support

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1863 

**Special notes for your reviewer**:
- This issue and the fix proposal has been discussed with Matthew and Hung

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```
This PR introduces READ_WRITE_MANY AccessMode also know as Multi-writer support for hyperdisks. Refer [here](https://cloud.google.com/compute/docs/disks/sharing-disks-between-vms#hd-multi-writer) for details about the multi-writer mode support, disk and machine types that support it.

Users can enable this mode by setting `access-mode: "READ_WRITE_MANY"` for the corresponding disk section to attach it in multi-writer mode.
```
