### PR TITLE
fix VAC tests now that VAC file is always set

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -814,13 +814,9 @@ func runTestsWithConfig(testParams *testParameters, testConfigArg, reportPrefix 
 		focuses = append(focuses, "VolumeSnapshotDataSource")
 	}
 
-	// If testParams.volumeAttributesClassFile is empty, then VAC tests will be automatically skipped. Otherwise confirm
-	// the right tests are run.
-	if testParams.volumeAttributesClassFile != "" && strings.Contains(skip, "VolumeAttributesClass") {
-		return fmt.Errorf("VolumeAttributesClass file %s specified, but VolumeAttributesClass tests are skipped: %s", testParams.volumeAttributesClassFile, skip)
-	}
-	if testParams.volumeAttributesClassFile != "" {
-		// If there is a VolumeAttributesClass file, run VAC tests
+	// testParams.volumeAttributesClassFile is always set, so rely on test skip to determine if VAC tests should
+	// be run.
+	if testParams.volumeAttributesClassFile != "" && !strings.Contains(skip, "VolumeAttributesClass") {
 		focuses = append(focuses, "VolumeAttributesClass")
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:
We now always set volume attributes class file after https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1889. This causes all VAC tests with GKE version < 1.31 to fail with `F0113 13:43:21.841754    8775 main.go:228] Failed to run integration test: runCSITests failed: VolumeAttributesClass file hdb-volumeattributesclass.yaml specified, but VolumeAttributesClass tests are skipped: \[Disruptive\]|\[Serial\]|VolumeAttributesClass|csi-gcepd-sc-xfs.*provisioning.should.provision.storage.with.mount.options`. 

Now we only rely on test skip. 


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
