### PR TITLE
Add support for HdHA disk provisioning

### DIFF
--- a/cmd/gce-pd-csi-driver/main.go
+++ b/cmd/gce-pd-csi-driver/main.go
@@ -72,6 +72,7 @@ var (
 	formatAndMountTimeout       = flag.Duration("format-and-mount-timeout", 1*time.Minute, "The maximum duration of a format and mount operation before another such operation will be started. Used only if --serialize-format-and-mount")
 	fallbackRequisiteZonesFlag  = flag.String("fallback-requisite-zones", "", "Comma separated list of requisite zones that will be used if there are not sufficient zones present in requisite topologies when provisioning a disk")
 	enableStoragePoolsFlag      = flag.Bool("enable-storage-pools", false, "If set to true, the CSI Driver will allow volumes to be provisioned in Storage Pools")
+	enableHdHAFlag              = flag.Bool("allow-hdha-provisioning", false, "If set to true, will allow the driver to provision Hyperdisk-balanced High Availability disks")
 
 	multiZoneVolumeHandleDiskTypesFlag = flag.String("multi-zone-volume-handle-disk-types", "", "Comma separated list of allowed disk types that can use the multi-zone volumeHandle. Used only if --multi-zone-volume-handle-enable")
 	multiZoneVolumeHandleEnableFlag    = flag.Bool("multi-zone-volume-handle-enable", false, "If set to true, the multi-zone volumeHandle feature will be enabled")
@@ -222,7 +223,7 @@ func handle() {
 		}
 		initialBackoffDuration := time.Duration(*errorBackoffInitialDurationMs) * time.Millisecond
 		maxBackoffDuration := time.Duration(*errorBackoffMaxDurationMs) * time.Millisecond
-		controllerServer = driver.NewControllerServer(gceDriver, cloudProvider, initialBackoffDuration, maxBackoffDuration, fallbackRequisiteZones, *enableStoragePoolsFlag, multiZoneVolumeHandleConfig, listVolumesConfig, provisionableDisksConfig)
+		controllerServer = driver.NewControllerServer(gceDriver, cloudProvider, initialBackoffDuration, maxBackoffDuration, fallbackRequisiteZones, *enableStoragePoolsFlag, multiZoneVolumeHandleConfig, listVolumesConfig, provisionableDisksConfig, *enableHdHAFlag)
 	} else if *cloudConfigFilePath != "" {
 		klog.Warningf("controller service is disabled but cloud config given - it has no effect")
 	}

--- a/pkg/common/parameters.go
+++ b/pkg/common/parameters.go
@@ -34,6 +34,7 @@ const (
 	ParameterKeyStoragePools                  = "storage-pools"
 	ParameterKeyResourceTags                  = "resource-tags"
 	ParameterKeyEnableMultiZoneProvisioning   = "enable-multi-zone-provisioning"
+	ParameterHdHADiskType                     = "hyperdisk-balanced-high-availability"
 
 	// Parameters for VolumeSnapshotClass
 	ParameterKeyStorageLocations = "storage-locations"
@@ -108,6 +109,10 @@ type DiskParameters struct {
 	MultiZoneProvisioning bool
 }
 
+func (dp *DiskParameters) IsRegional() bool {
+	return dp.ReplicationType == "regional-pd" || dp.DiskType == ParameterHdHADiskType
+}
+
 // SnapshotParameters contains normalized and defaulted parameters for snapshots
 type SnapshotParameters struct {
 	StorageLocations []string
@@ -129,6 +134,7 @@ type ParameterProcessor struct {
 	DriverName         string
 	EnableStoragePools bool
 	EnableMultiZone    bool
+	EnableHdHA         bool
 }
 
 type ModifyVolumeParameters struct {
@@ -167,6 +173,9 @@ func (pp *ParameterProcessor) ExtractAndDefaultParameters(parameters map[string]
 		case ParameterKeyType:
 			if v != "" {
 				p.DiskType = strings.ToLower(v)
+				if !pp.EnableHdHA && p.DiskType == ParameterHdHADiskType {
+					return p, fmt.Errorf("parameters contain invalid disk type %s", ParameterHdHADiskType)
+				}
 			}
 		case ParameterKeyReplicationType:
 			if v != "" {

--- a/pkg/common/parameters_test.go
+++ b/pkg/common/parameters_test.go
@@ -30,6 +30,7 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 		labels             map[string]string
 		enableStoragePools bool
 		enableMultiZone    bool
+		enableHdHA         bool
 		extraTags          map[string]string
 		expectParams       DiskParameters
 		expectErr          bool
@@ -395,6 +396,23 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 			parameters: map[string]string{ParameterKeyType: "hyperdisk-ml", ParameterKeyEnableMultiZoneProvisioning: "true"},
 			expectErr:  true,
 		},
+		{
+			name:       "disk parameters, hdha disabled",
+			parameters: map[string]string{ParameterKeyType: "hyperdisk-balanced-high-availability"},
+			expectErr:  true,
+		},
+		{
+			name:       "disk parameters, hdha enabled",
+			parameters: map[string]string{ParameterKeyType: "hyperdisk-balanced-high-availability"},
+			enableHdHA: true,
+			expectParams: DiskParameters{
+				DiskType:        "hyperdisk-balanced-high-availability",
+				ReplicationType: "none",
+				Tags:            map[string]string{},
+				ResourceTags:    map[string]string{},
+				Labels:          map[string]string{},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -403,6 +421,7 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 				DriverName:         "testDriver",
 				EnableStoragePools: tc.enableStoragePools,
 				EnableMultiZone:    tc.enableMultiZone,
+				EnableHdHA:         tc.enableHdHA,
 			}
 			p, err := pp.ExtractAndDefaultParameters(tc.parameters, tc.labels, tc.extraTags)
 			if gotErr := err != nil; gotErr != tc.expectErr {

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -1409,7 +1409,7 @@ func TestIsUserMultiAttachError(t *testing.T) {
 		},
 	}
 	for _, test := range cases {
-		code, err := isUserMultiAttachError(fmt.Errorf(test.errorString))
+		code, err := isUserMultiAttachError(fmt.Errorf("%v", test.errorString))
 		if test.expectCode {
 			if err != nil || code != test.expectedCode {
 				t.Errorf("Failed with non-nil error %v or bad code %v: %s", err, code, test.errorString)

--- a/pkg/gce-cloud-provider/compute/cloud-disk.go
+++ b/pkg/gce-cloud-provider/compute/cloud-disk.go
@@ -166,6 +166,17 @@ func (d *CloudDisk) GetZone() string {
 	}
 }
 
+func (d *CloudDisk) GetRegion() string {
+	switch {
+	case d.disk != nil:
+		return d.disk.Region
+	case d.betaDisk != nil:
+		return d.betaDisk.Region
+	default:
+		return ""
+	}
+}
+
 func (d *CloudDisk) GetSnapshotId() string {
 	switch {
 	case d.disk != nil:

--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -79,6 +79,10 @@ func CreateFakeCloudProvider(project, zone string, cloudDisks []*CloudDisk) (*Fa
 		mockDiskStatus: "READY",
 	}
 	for _, d := range cloudDisks {
+		if d.LocationType() == meta.Regional {
+			fcp.disks[meta.RegionalKey(d.GetName(), d.GetRegion()).String()] = d
+			continue
+		}
 		diskZone := d.GetZone()
 		if diskZone == "" {
 			diskZone = zone

--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -423,8 +423,8 @@ func ValidateDiskParameters(disk *CloudDisk, params common.DiskParameters) error
 	}
 
 	locationType := disk.LocationType()
-	if (params.ReplicationType == "none" && locationType != meta.Zonal) || (params.ReplicationType == "regional-pd" && locationType != meta.Regional) {
-		return fmt.Errorf("actual disk replication type %v did not match expected param %s", locationType, params.ReplicationType)
+	if (params.ReplicationType == "none" && locationType != meta.Zonal) || (params.IsRegional() && locationType != meta.Regional) {
+		return fmt.Errorf("actual replication type %v did not match expected param %s and %s", locationType, params.ReplicationType, params.DiskType)
 	}
 
 	if !KmsKeyEqual(

--- a/pkg/gce-cloud-provider/compute/gce.go
+++ b/pkg/gce-cloud-provider/compute/gce.go
@@ -101,6 +101,8 @@ type CloudProvider struct {
 	tagsRateLimiter *rate.Limiter
 
 	listInstancesConfig ListInstancesConfig
+
+	enableHdHA bool
 }
 
 var _ GCECompute = &CloudProvider{}

--- a/pkg/gce-pd-csi-driver/gce-pd-driver.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver.go
@@ -156,7 +156,7 @@ func NewNodeServer(gceDriver *GCEDriver, mounter *mount.SafeFormatAndMount, devi
 	}
 }
 
-func NewControllerServer(gceDriver *GCEDriver, cloudProvider gce.GCECompute, errorBackoffInitialDuration, errorBackoffMaxDuration time.Duration, fallbackRequisiteZones []string, enableStoragePools bool, multiZoneVolumeHandleConfig MultiZoneVolumeHandleConfig, listVolumesConfig ListVolumesConfig, provisionableDisksConfig ProvisionableDisksConfig) *GCEControllerServer {
+func NewControllerServer(gceDriver *GCEDriver, cloudProvider gce.GCECompute, errorBackoffInitialDuration, errorBackoffMaxDuration time.Duration, fallbackRequisiteZones []string, enableStoragePools bool, multiZoneVolumeHandleConfig MultiZoneVolumeHandleConfig, listVolumesConfig ListVolumesConfig, provisionableDisksConfig ProvisionableDisksConfig, enableHdHA bool) *GCEControllerServer {
 	return &GCEControllerServer{
 		Driver:                      gceDriver,
 		CloudProvider:               cloudProvider,
@@ -168,6 +168,7 @@ func NewControllerServer(gceDriver *GCEDriver, cloudProvider gce.GCECompute, err
 		multiZoneVolumeHandleConfig: multiZoneVolumeHandleConfig,
 		listVolumesConfig:           listVolumesConfig,
 		provisionableDisksConfig:    provisionableDisksConfig,
+		enableHdHA:                  enableHdHA,
 	}
 }
 

--- a/pkg/gce-pd-csi-driver/gce-pd-driver_test.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver_test.go
@@ -54,7 +54,7 @@ func controllerServerForTest(cloudProvider gce.GCECompute) *GCEControllerServer 
 		SupportsThroughputChange: []string{"hyperdisk-balanced", "hyperdisk-throughput", "hyperdisk-ml"},
 	}
 
-	return NewControllerServer(gceDriver, cloudProvider, errorBackoffInitialDuration, errorBackoffMaxDuration, fallbackRequisiteZones, enableStoragePools, multiZoneVolumeHandleConfig, listVolumesConfig, provisionableDisksConfig)
+	return NewControllerServer(gceDriver, cloudProvider, errorBackoffInitialDuration, errorBackoffMaxDuration, fallbackRequisiteZones, enableStoragePools, multiZoneVolumeHandleConfig, listVolumesConfig, provisionableDisksConfig, true /* enableHdHA */)
 }
 
 func initGCEDriverWithCloudProvider(t *testing.T, cloudProvider gce.GCECompute) *GCEDriver {

--- a/pkg/gce-pd-csi-driver/utils.go
+++ b/pkg/gce-pd-csi-driver/utils.go
@@ -156,8 +156,8 @@ func validateStoragePools(req *csi.CreateVolumeRequest, params common.DiskParame
 		return fmt.Errorf("invalid disk-type: %q. storage pools only support hyperdisk-balanced or hyperdisk-throughput", params.DiskType)
 	}
 
-	if params.ReplicationType == replicationTypeRegionalPD {
-		return fmt.Errorf("storage pools do not support regional PD")
+	if params.IsRegional() {
+		return fmt.Errorf("storage pools do not support regional disks")
 	}
 
 	if useVolumeCloning(req) {

--- a/pkg/gce-pd-csi-driver/utils_test.go
+++ b/pkg/gce-pd-csi-driver/utils_test.go
@@ -297,11 +297,12 @@ func TestGetReadOnlyFromCapabilities(t *testing.T) {
 
 func TestValidateStoragePools(t *testing.T) {
 	testCases := []struct {
-		name    string
-		req     *csi.CreateVolumeRequest
-		params  common.DiskParameters
-		project string
-		expErr  error
+		name       string
+		req        *csi.CreateVolumeRequest
+		params     common.DiskParameters
+		project    string
+		expErr     error
+		enableHdHA bool
 	}{
 		{
 			name: "success with storage pools not enabled",
@@ -396,7 +397,58 @@ func TestValidateStoragePools(t *testing.T) {
 				},
 			},
 			project: "test-project",
-			expErr:  fmt.Errorf("storage pools do not support regional PD"),
+			expErr:  fmt.Errorf("storage pools do not support regional disks"),
+		},
+		{
+			name: "fail storage pools with HdHA, even when HdHA is allowed",
+			req: &csi.CreateVolumeRequest{
+				Name: "test-name",
+			},
+			params: common.DiskParameters{
+				DiskType: "hyperdisk-balanced-high-availability",
+				StoragePools: []common.StoragePool{
+					{
+						Project:      "test-project",
+						Zone:         "us-central1-a",
+						Name:         "storagePool-1",
+						ResourceName: "projects/test-project/zones/us-central1-a/storagePools/storagePool-1",
+					},
+					{
+						Project:      "test-project",
+						Zone:         "us-central1-b",
+						Name:         "storagePool-2",
+						ResourceName: "projects/test-project/zones/us-central1-a/storagePools/storagePool-1",
+					},
+				},
+			},
+			project:    "test-project",
+			expErr:     fmt.Errorf("invalid disk-type: \"hyperdisk-balanced-high-availability\". storage pools only support hyperdisk-balanced or hyperdisk-throughput"),
+			enableHdHA: true,
+		},
+		{
+			name: "fail storage pools with HdHA when HdHA is not allowed",
+			req: &csi.CreateVolumeRequest{
+				Name: "test-name",
+			},
+			params: common.DiskParameters{
+				DiskType: "hyperdisk-balanced-high-availability",
+				StoragePools: []common.StoragePool{
+					{
+						Project:      "test-project",
+						Zone:         "us-central1-a",
+						Name:         "storagePool-1",
+						ResourceName: "projects/test-project/zones/us-central1-a/storagePools/storagePool-1",
+					},
+					{
+						Project:      "test-project",
+						Zone:         "us-central1-b",
+						Name:         "storagePool-2",
+						ResourceName: "projects/test-project/zones/us-central1-a/storagePools/storagePool-1",
+					},
+				},
+			},
+			project: "test-project",
+			expErr:  fmt.Errorf("invalid disk-type: \"hyperdisk-balanced-high-availability\". storage pools only support hyperdisk-balanced or hyperdisk-throughput"),
 		},
 		{
 			name: "fail storage pools with disk clones",

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -64,6 +64,7 @@ const (
 	hdxDiskType                               = "hyperdisk-extreme"
 	hdtDiskType                               = "hyperdisk-throughput"
 	hdmlDiskType                              = "hyperdisk-ml"
+	hdhaDiskType                              = "hyperdisk-balanced-high-availability"
 	provisionedIOPSOnCreate                   = "12345"
 	provisionedIOPSOnCreateInt                = int64(12345)
 	provisionedIOPSOnCreateDefaultInt         = int64(100000)

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -68,6 +68,7 @@ func GCEClientAndDriverSetup(instance *remote.InstanceInfo, driverConfig DriverC
 		"--use-instance-api-to-list-volumes-published-nodes",
 		"--supports-dynamic-iops-provisioning=hyperdisk-balanced,hyperdisk-extreme",
 		"--supports-dynamic-throughput-provisioning=hyperdisk-balanced,hyperdisk-throughput,hyperdisk-ml",
+		"--allow-hdha-provisioning",
 		fmt.Sprintf("--fallback-requisite-zones=%s", strings.Join(driverConfig.Zones, ",")),
 	}
 	extra_flags = append(extra_flags, fmt.Sprintf("--compute-endpoint=%s", driverConfig.ComputeEndpoint))

--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -5,7 +5,7 @@ set -x
 
 readonly PKGDIR=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 
-TIMEOUT=30m
+TIMEOUT=40m
 if [ "$RUN_CONTROLLER_MODIFY_VOLUME_TESTS" = true ]; then
     TIMEOUT=45m
 fi

--- a/test/sanity/sanity_test.go
+++ b/test/sanity/sanity_test.go
@@ -75,7 +75,7 @@ func TestSanity(t *testing.T) {
 
 	//Initialize GCE Driver
 	identityServer := driver.NewIdentityServer(gceDriver)
-	controllerServer := driver.NewControllerServer(gceDriver, cloudProvider, 0, 5*time.Minute, fallbackRequisiteZones, enableStoragePools, multiZoneVolumeHandleConfig, listVolumesConfig, provisionableDisksConfig)
+	controllerServer := driver.NewControllerServer(gceDriver, cloudProvider, 0, 5*time.Minute, fallbackRequisiteZones, enableStoragePools, multiZoneVolumeHandleConfig, listVolumesConfig, provisionableDisksConfig, true)
 	fakeStatter := mountmanager.NewFakeStatterWithOptions(mounter, mountmanager.FakeStatterOptions{IsBlock: false})
 	nodeServer := driver.NewNodeServer(gceDriver, mounter, deviceUtils, metadataservice.NewFakeService(), fakeStatter)
 	err = gceDriver.SetupGCEDriver(driverName, vendorVersion, extraLabels, nil, identityServer, controllerServer, nodeServer)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:

This PR adds support for the PDCSI driver to provision Hyperdisk-balanced High Availability (HdHA) disks. This allows users to use the latest generation of regional disks from GCE. The feature is gated behind flag `allow-hdha-provisioning`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes b/391964605

**Special notes for your reviewer**:

One potential gap I observe is that we have to return the raw GCE error if users call `ControllerPublishVolume` on a HdHA disk in read only mode, because we cannot determine the disk type without actually fetching the disk. I think this is mostly fine since the GCE error is pretty clear (" Error 400: The disk cannot be attached with READ_ONLY mode."), but please let me know if I should add some more explicit error message.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add support for provisioning Hyperdisk-balanced High Availability disks.
```
