### PR TITLE
Copy kubernetes test binaries to _rundir, instead of _artifacts when running integration test on k8s master branch

### DIFF
--- a/test/k8s-integration/driver.go
+++ b/test/k8s-integration/driver.go
@@ -27,19 +27,17 @@ func installDriver(testParams *testParameters, stagingImage, deployOverlayName s
 
 		// Edit ci kustomization to use given image tag
 		overlayDir := getOverlayDir(testParams.pkgDir, deployOverlayName)
-		err = os.Chdir(overlayDir)
-		if err != nil {
-			return fmt.Errorf("failed to change to overlay directory: %s, err: %v", out, err.Error())
-		}
 
 		// TODO (#138): in a local environment this is going to modify the actual kustomize files.
 		// maybe a copy should be made instead
-		out, err = exec.Command(
+		kustomizeCommand := exec.Command(
 			filepath.Join(testParams.pkgDir, "bin", "kustomize"),
 			"edit",
 			"set",
 			"image",
-			fmt.Sprintf("%s=%s:%s", pdImagePlaceholder, stagingImage, testParams.stagingVersion)).CombinedOutput()
+			fmt.Sprintf("%s=%s:%s", pdImagePlaceholder, stagingImage, testParams.stagingVersion))
+		kustomizeCommand.Dir = overlayDir
+		out, err = kustomizeCommand.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("failed to edit kustomize: %s, err: %v", out, err.Error())
 		}

--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -867,16 +867,11 @@ func runTestsWithConfig(testParams *testParameters, testConfigArg, reportPrefix 
 			// path sent to kubetest2 through its --artifacts path
 
 			// pkg/_artifacts is the default value that kubetests uses for --artifacts
-			kubernetesTestBinariesPath := filepath.Join(testParams.pkgDir, "_artifacts")
-			if kubetestDumpDir != "" {
-				// a custom artifacts dir was set
-				kubernetesTestBinariesPath = kubetestDumpDir
-			}
+			kubernetesTestBinariesPath := filepath.Join(testParams.pkgDir, "_rundir")
 			kubernetesTestBinariesPath = filepath.Join(kubernetesTestBinariesPath, runID)
 
 			klog.Infof("Copying kubernetes binaries to path=%s to run the tests", kubernetesTestBinariesPath)
-			err := copyKubernetesTestBinaries(testParams.k8sSourceDir, kubernetesTestBinariesPath)
-			if err != nil {
+			if err := copyKubernetesTestBinaries(testParams.k8sSourceDir, kubernetesTestBinariesPath); err != nil {
 				return fmt.Errorf("failed to copy the kubernetes test binaries, err=%v", err.Error())
 			}
 			kubeTest2Args = append(kubeTest2Args, "--use-built-binaries")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
/kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: The OSS Prow testgrid is currently failing, due to `kubectl` and other binaries not being found by `ginkgo`. This was a result of #1911 which updated the `kubetest2` version. In order to fix, the test binaries need to be copied to `_rundir/$KUBETEST2_RUN_ID`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
