### PR TITLE
Remove VAC name from Driver name

### DIFF
--- a/test/k8s-integration/config/test-config-template.in
+++ b/test/k8s-integration/config/test-config-template.in
@@ -14,7 +14,7 @@ Timeouts:
   {{ end }}
 {{end}}
 DriverInfo:
-  Name: csi-gcepd-{{.StorageClass}}--{{.SnapshotClass}}--{{.VolumeAttributesClass}}
+  Name: csi-gcepd-{{.StorageClass}}--{{.SnapshotClass}}
   SupportedFsType:
   {{range .SupportedFsType}}  {{ . }}:
   {{end}}

--- a/test/k8s-integration/driver-config.go
+++ b/test/k8s-integration/driver-config.go
@@ -130,12 +130,8 @@ func generateDriverConfigFile(testParams *testParameters) (string, error) {
 	}
 
 	var absVacFilePath string
-	var vacName string
 	if testParams.volumeAttributesClassFile != "" {
 		absVacFilePath = filepath.Join(testParams.pkgDir, testConfigDir, testParams.volumeAttributesClassFile)
-		vacName = testParams.volumeAttributesClassFile[:strings.LastIndex(testParams.volumeAttributesClassFile, ".")]
-	} else {
-		vacName = "no-vac"
 	}
 
 	if !strings.Contains(testParams.storageClassFile, "sc-extreme") {
@@ -160,7 +156,6 @@ func generateDriverConfigFile(testParams *testParameters) (string, error) {
 		SnapshotClassFile:         absSnapshotClassFilePath,
 		SnapshotClass:             snapshotClassName,
 		VolumeAttributesClassFile: absVacFilePath,
-		VolumeAttributesClass:     vacName,
 		SupportedFsType:           fsTypes,
 		Capabilities:              caps,
 		MinimumVolumeSize:         minimumVolumeSize,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:
Some VAC tests are failing because of 
```
{  [FAILED] While creating new VolumeAttributesClass: VolumeAttributesClass.storage.k8s.io "volume-modify-4528-e2e-vac-invalidvqcvs" is invalid: driverName: Invalid value: "csi-gcepd-sc-hdb--no-vsc--hdb-volumeattributesclass-volume-modify-4528": name part must be no more than 63 characters
```

This just removes VAC name from driver name
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
