### PR TITLE
Cherrypick #1919

### DIFF
--- a/pkg/common/parameters.go
+++ b/pkg/common/parameters.go
@@ -22,6 +22,9 @@ import (
 )
 
 const (
+	// Disk Params
+	ParameterAccessMode						  = "access-mode"
+
 	// Parameters for StorageClass
 	ParameterKeyType                          = "type"
 	ParameterKeyReplicationType               = "replication-type"
@@ -157,7 +160,6 @@ func (pp *ParameterProcessor) ExtractAndDefaultParameters(parameters map[string]
 		Tags:                 make(map[string]string), // Default
 		Labels:               make(map[string]string), // Default
 		ResourceTags:         make(map[string]string), // Default
-		AccessMode:           "READ_WRITE_SINGLE",     // Default
 	}
 
 	for k, v := range extraVolumeLabels {
@@ -265,6 +267,10 @@ func (pp *ParameterProcessor) ExtractAndDefaultParameters(parameters map[string]
 			p.MultiZoneProvisioning = paramEnableMultiZoneProvisioning
 			if paramEnableMultiZoneProvisioning {
 				p.Labels[MultiZoneLabel] = "true"
+			}
+		case ParameterAccessMode:
+			if v != "" {
+				p.AccessMode = v
 			}
 		default:
 			return p, fmt.Errorf("parameters contains invalid option %q", k)

--- a/pkg/common/parameters.go
+++ b/pkg/common/parameters.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// Disk Params
-	ParameterAccessMode						  = "access-mode"
+	ParameterAccessMode = "access-mode"
 
 	// Parameters for StorageClass
 	ParameterKeyType                          = "type"

--- a/pkg/common/parameters.go
+++ b/pkg/common/parameters.go
@@ -107,6 +107,9 @@ type DiskParameters struct {
 	// Values: {bool}
 	// Default: false
 	MultiZoneProvisioning bool
+	// Values: READ_WRITE_SINGLE, READ_ONLY_MANY, READ_WRITE_MANY
+	// Default: READ_WRITE_SINGLE
+	AccessMode string
 }
 
 func (dp *DiskParameters) IsRegional() bool {
@@ -154,6 +157,7 @@ func (pp *ParameterProcessor) ExtractAndDefaultParameters(parameters map[string]
 		Tags:                 make(map[string]string), // Default
 		Labels:               make(map[string]string), // Default
 		ResourceTags:         make(map[string]string), // Default
+		AccessMode:           "READ_WRITE_SINGLE",     // Default
 	}
 
 	for k, v := range extraVolumeLabels {

--- a/pkg/gce-cloud-provider/compute/cloud-disk.go
+++ b/pkg/gce-cloud-provider/compute/cloud-disk.go
@@ -224,6 +224,17 @@ func (d *CloudDisk) GetKMSKeyName() string {
 	return ""
 }
 
+func (d *CloudDisk) GetMultiWriter() bool {
+	switch {
+	case d.disk != nil:
+		return false
+	case d.betaDisk != nil:
+		return d.betaDisk.MultiWriter
+	default:
+		return false
+	}
+}
+
 func (d *CloudDisk) GetEnableConfidentialCompute() bool {
 	switch {
 	case d.disk != nil:

--- a/pkg/gce-cloud-provider/compute/cloud-disk.go
+++ b/pkg/gce-cloud-provider/compute/cloud-disk.go
@@ -228,6 +228,8 @@ func (d *CloudDisk) GetMultiWriter() bool {
 	switch {
 	case d.disk != nil:
 		return false
+	case d.disk != nil && d.disk.AccessMode == "READ_WRITE_MANY":
+		return true
 	case d.betaDisk != nil:
 		return d.betaDisk.MultiWriter
 	default:

--- a/pkg/gce-cloud-provider/compute/cloud-disk.go
+++ b/pkg/gce-cloud-provider/compute/cloud-disk.go
@@ -224,19 +224,6 @@ func (d *CloudDisk) GetKMSKeyName() string {
 	return ""
 }
 
-func (d *CloudDisk) GetMultiWriter() bool {
-	switch {
-	case d.disk != nil:
-		return false
-	case d.disk != nil && d.disk.AccessMode == "READ_WRITE_MANY":
-		return true
-	case d.betaDisk != nil:
-		return d.betaDisk.MultiWriter
-	default:
-		return false
-	}
-}
-
 func (d *CloudDisk) GetEnableConfidentialCompute() bool {
 	switch {
 	case d.disk != nil:

--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -217,7 +217,7 @@ func (cloud *FakeCloudProvider) ValidateExistingDisk(ctx context.Context, resp *
 	}
 
 	// We are assuming here that a multiWriter disk could be used as non-multiWriter
-	if multiWriter && !resp.GetMultiWriter() {
+	if multiWriter {
 		return fmt.Errorf("disk already exists with incompatible capability. Need MultiWriter. Got non-MultiWriter")
 	}
 

--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -216,11 +216,6 @@ func (cloud *FakeCloudProvider) ValidateExistingDisk(ctx context.Context, resp *
 			params.DiskType, respType[len(respType)-1])
 	}
 
-	// We are assuming here that a multiWriter disk could be used as non-multiWriter
-	if multiWriter {
-		return fmt.Errorf("disk already exists with incompatible capability. Need MultiWriter. Got non-MultiWriter")
-	}
-
 	klog.V(4).Infof("Compatible disk already exists")
 	return ValidateDiskParameters(resp, params)
 }

--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -216,6 +216,10 @@ func (cloud *FakeCloudProvider) ValidateExistingDisk(ctx context.Context, resp *
 			params.DiskType, respType[len(respType)-1])
 	}
 
+	// We are assuming here that a multiWriter disk could be used as non-multiWriter
+	if multiWriter && !resp.GetMultiWriter() {
+		return fmt.Errorf("disk already exists with incompatible capability. Need MultiWriter. Got non-MultiWriter")
+	}
 	klog.V(4).Infof("Compatible disk already exists")
 	return ValidateDiskParameters(resp, params)
 }

--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -188,7 +188,7 @@ func (cloud *FakeCloudProvider) ListSnapshots(ctx context.Context, filter string
 }
 
 // Disk Methods
-func (cloud *FakeCloudProvider) GetDisk(ctx context.Context, project string, volKey *meta.Key, api GCEAPIVersion) (*CloudDisk, error) {
+func (cloud *FakeCloudProvider) GetDisk(ctx context.Context, project string, volKey *meta.Key) (*CloudDisk, error) {
 	disk, ok := cloud.disks[volKey.String()]
 	if !ok {
 		return nil, notFoundError()

--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -808,7 +808,6 @@ func (cloud *CloudProvider) insertZonalDisk(
 
 	diskToCreate.AccessMode = accessMode
 	var insertOp *computebeta.Operation
-	diskToCreate.MultiWriter = multiWriter
 	insertOp, err = cloud.betaService.Disks.Insert(project, volKey.Zone, diskToCreate).Context(ctx).Do()
 	if insertOp != nil {
 		opName = insertOp.Name

--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -395,6 +395,11 @@ func (cloud *CloudProvider) ValidateExistingDisk(ctx context.Context, resp *Clou
 			reqBytes, common.GbToBytes(resp.GetSizeGb()), limBytes)
 	}
 
+	// We are assuming here that a multiWriter disk could be used as non-multiWriter
+	if multiWriter && !resp.GetMultiWriter() {
+		return fmt.Errorf("disk already exists with incompatible capability. Need MultiWriter. Got non-MultiWriter")
+	}
+
 	return ValidateDiskParameters(resp, params)
 }
 

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -2440,10 +2440,6 @@ func createRegionalDisk(ctx context.Context, cloudProvider gce.GCECompute, name 
 		return nil, fmt.Errorf("failed to insert regional disk: %w", err)
 	}
 
-	gceAPIVersion := gce.GCEAPIVersionV1
-	if multiWriter {
-		gceAPIVersion = gce.GCEAPIVersionBeta
-	}
 	// failed to GetDisk, however the Disk may already be created, the error code should be non-Final
 	disk, err := cloudProvider.GetDisk(ctx, project, meta.RegionalKey(name, region))
 	if err != nil {
@@ -2463,10 +2459,6 @@ func createSingleZoneDisk(ctx context.Context, cloudProvider gce.GCECompute, nam
 		return nil, fmt.Errorf("failed to insert zonal disk: %w", err)
 	}
 
-	gceAPIVersion := gce.GCEAPIVersionV1
-	if multiWriter {
-		gceAPIVersion = gce.GCEAPIVersionBeta
-	}
 	// failed to GetDisk, however the Disk may already be created, the error code should be non-Final
 	disk, err := cloudProvider.GetDisk(ctx, project, meta.ZonalKey(name, diskZone))
 	if err != nil {

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -598,7 +598,7 @@ func (gceCS *GCEControllerServer) createSingleDisk(ctx context.Context, req *csi
 	capBytes, _ := getRequestCapacity(capacityRange)
 	multiWriter, _ := getMultiWriterFromCapabilities(req.GetVolumeCapabilities())
 	readonly, _ := getReadOnlyFromCapabilities(req.GetVolumeCapabilities())
-	accessMode := ""
+	accessMode := params.AccessMode
 	if readonly && slices.Contains(disksWithModifiableAccessMode, params.DiskType) {
 		accessMode = gceReadOnlyManyAccessMode
 	}

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -604,7 +604,7 @@ func (gceCS *GCEControllerServer) createSingleDisk(ctx context.Context, req *csi
 	}
 
 	// Validate if disk already exists
-	existingDisk, err := gceCS.CloudProvider.GetDisk(ctx, gceCS.CloudProvider.GetDefaultProject(), volKey, getGCEApiVersion(multiWriter))
+	existingDisk, err := gceCS.CloudProvider.GetDisk(ctx, gceCS.CloudProvider.GetDefaultProject(), volKey)
 	if err != nil {
 		if !gce.IsGCEError(err, "notFound") {
 			// failed to GetDisk, however the Disk may already be created, the error code should be non-Final
@@ -659,7 +659,7 @@ func (gceCS *GCEControllerServer) createSingleDisk(ctx context.Context, req *csi
 			}
 
 			// Verify that the volume in VolumeContentSource exists.
-			diskFromSourceVolume, err := gceCS.CloudProvider.GetDisk(ctx, project, sourceVolKey, getGCEApiVersion(multiWriter))
+			diskFromSourceVolume, err := gceCS.CloudProvider.GetDisk(ctx, project, sourceVolKey)
 			if err != nil {
 				if gce.IsGCEError(err, "notFound") {
 					return nil, status.Errorf(codes.NotFound, "CreateVolume source volume %s does not exist", volumeContentSourceVolumeID)
@@ -788,7 +788,7 @@ func (gceCS *GCEControllerServer) ControllerModifyVolume(ctx context.Context, re
 	}
 	klog.V(4).Infof("Modify Volume Parameters for %s: %v", volumeID, volumeModifyParams)
 
-	existingDisk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey, gce.GCEAPIVersionBeta)
+	existingDisk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey)
 	metrics.UpdateRequestMetadataFromDisk(ctx, existingDisk)
 
 	if err != nil {
@@ -884,7 +884,7 @@ func (gceCS *GCEControllerServer) deleteMultiZoneDisk(ctx context.Context, req *
 			Region: volKey.Region,
 			Zone:   zone,
 		}
-		disk, _ := gceCS.CloudProvider.GetDisk(ctx, project, zonalVolKey, gce.GCEAPIVersionV1)
+		disk, _ := gceCS.CloudProvider.GetDisk(ctx, project, zonalVolKey)
 		// TODO: Consolidate the parameters here, rather than taking the last.
 		metrics.UpdateRequestMetadataFromDisk(ctx, disk)
 		err := gceCS.CloudProvider.DeleteDisk(ctx, project, zonalVolKey)
@@ -917,7 +917,7 @@ func (gceCS *GCEControllerServer) deleteSingleDeviceDisk(ctx context.Context, re
 		return nil, status.Errorf(codes.Aborted, common.VolumeOperationAlreadyExistsFmt, volumeID)
 	}
 	defer gceCS.volumeLocks.Release(volumeID)
-	disk, _ := gceCS.CloudProvider.GetDisk(ctx, project, volKey, gce.GCEAPIVersionV1)
+	disk, _ := gceCS.CloudProvider.GetDisk(ctx, project, volKey)
 	metrics.UpdateRequestMetadataFromDisk(ctx, disk)
 	err = gceCS.CloudProvider.DeleteDisk(ctx, project, volKey)
 	if err != nil {
@@ -1086,7 +1086,7 @@ func (gceCS *GCEControllerServer) executeControllerPublishVolume(ctx context.Con
 		return nil, status.Errorf(codes.Aborted, common.VolumeOperationAlreadyExistsFmt, lockingVolumeID), nil
 	}
 	defer gceCS.volumeLocks.Release(lockingVolumeID)
-	disk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey, gce.GCEAPIVersionV1)
+	disk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey)
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
 			return nil, status.Errorf(codes.NotFound, "Could not find disk %v: %v", volKey.String(), err.Error()), disk
@@ -1232,7 +1232,7 @@ func (gceCS *GCEControllerServer) executeControllerUnpublishVolume(ctx context.C
 		return nil, status.Errorf(codes.Aborted, common.VolumeOperationAlreadyExistsFmt, lockingVolumeID), nil
 	}
 	defer gceCS.volumeLocks.Release(lockingVolumeID)
-	diskToUnpublish, _ := gceCS.CloudProvider.GetDisk(ctx, project, volKey, gce.GCEAPIVersionV1)
+	diskToUnpublish, _ := gceCS.CloudProvider.GetDisk(ctx, project, volKey)
 	instance, err := gceCS.CloudProvider.GetInstanceOrError(ctx, instanceZone, instanceName)
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
@@ -1300,7 +1300,7 @@ func (gceCS *GCEControllerServer) ValidateVolumeCapabilities(ctx context.Context
 	}
 	defer gceCS.volumeLocks.Release(volumeID)
 
-	disk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey, gce.GCEAPIVersionV1)
+	disk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey)
 	metrics.UpdateRequestMetadataFromDisk(ctx, disk)
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
@@ -1541,7 +1541,7 @@ func (gceCS *GCEControllerServer) CreateSnapshot(ctx context.Context, req *csi.C
 	defer gceCS.volumeLocks.Release(volumeID)
 
 	// Check if volume exists
-	disk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey, gce.GCEAPIVersionV1)
+	disk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey)
 	metrics.UpdateRequestMetadataFromDisk(ctx, disk)
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
@@ -1890,7 +1890,7 @@ func (gceCS *GCEControllerServer) ControllerExpandVolume(ctx context.Context, re
 		return nil, status.Errorf(codes.InvalidArgument, "ControllerExpandVolume is not supported with the multi-zone PVC volumeHandle feature. Please re-create the volume %v from source if you want a larger size", volumeID)
 	}
 
-	sourceDisk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey, gce.GCEAPIVersionV1)
+	sourceDisk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey)
 	metrics.UpdateRequestMetadataFromDisk(ctx, sourceDisk)
 	resizedGb, err := gceCS.CloudProvider.ResizeDisk(ctx, project, volKey, reqBytes)
 
@@ -2445,7 +2445,7 @@ func createRegionalDisk(ctx context.Context, cloudProvider gce.GCECompute, name 
 		gceAPIVersion = gce.GCEAPIVersionBeta
 	}
 	// failed to GetDisk, however the Disk may already be created, the error code should be non-Final
-	disk, err := cloudProvider.GetDisk(ctx, project, meta.RegionalKey(name, region), gceAPIVersion)
+	disk, err := cloudProvider.GetDisk(ctx, project, meta.RegionalKey(name, region))
 	if err != nil {
 		return nil, common.NewTemporaryError(codes.Unavailable, fmt.Errorf("failed to get disk after creating regional disk: %w", err))
 	}
@@ -2468,7 +2468,7 @@ func createSingleZoneDisk(ctx context.Context, cloudProvider gce.GCECompute, nam
 		gceAPIVersion = gce.GCEAPIVersionBeta
 	}
 	// failed to GetDisk, however the Disk may already be created, the error code should be non-Final
-	disk, err := cloudProvider.GetDisk(ctx, project, meta.ZonalKey(name, diskZone), gceAPIVersion)
+	disk, err := cloudProvider.GetDisk(ctx, project, meta.ZonalKey(name, diskZone))
 	if err != nil {
 		return nil, common.NewTemporaryError(codes.Unavailable, fmt.Errorf("failed to get disk after creating zonal disk: %w", err))
 	}

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -1878,7 +1878,7 @@ func TestMultiZoneVolumeCreationErrHandling(t *testing.T) {
 		}
 
 		for _, volKey := range tc.wantDisks {
-			disk, err := fcp.GetDisk(context.Background(), project, volKey, gce.GCEAPIVersionV1)
+			disk, err := fcp.GetDisk(context.Background(), project, volKey)
 			if err != nil {
 				t.Errorf("Unexpected err fetching disk %v: %v", volKey, err)
 			}

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -1702,7 +1702,7 @@ func TestMultiZoneVolumeCreation(t *testing.T) {
 
 		for _, zone := range tc.expZones {
 			volumeKey := meta.ZonalKey(name, zone)
-			disk, err := fcp.GetDisk(context.Background(), project, volumeKey, gce.GCEAPIVersionBeta)
+			disk, err := fcp.GetDisk(context.Background(), project, volumeKey)
 			if err != nil {
 				t.Fatalf("Get Disk failed for created disk with error: %v", err)
 			}
@@ -1996,7 +1996,7 @@ func TestCreateVolumeWithVolumeAttributeClassParameters(t *testing.T) {
 			t.Fatalf("Failed to convert volume id to key: %v", err)
 		}
 
-		disk, err := fcp.GetDisk(context.Background(), project, volumeKey, gce.GCEAPIVersionBeta)
+		disk, err := fcp.GetDisk(context.Background(), project, volumeKey)
 
 		if err != nil {
 			t.Fatalf("Failed to get disk: %v", err)
@@ -2101,7 +2101,7 @@ func TestVolumeModifyOperation(t *testing.T) {
 			}
 		}
 
-		modifiedVol, err := fcp.GetDisk(context.Background(), project, volKey, gce.GCEAPIVersionBeta)
+		modifiedVol, err := fcp.GetDisk(context.Background(), project, volKey)
 
 		if err != nil {
 			t.Errorf("Failed to get volume: %v", err)
@@ -5378,7 +5378,7 @@ func TestCreateConfidentialVolume(t *testing.T) {
 
 			volumeId := resp.GetVolume().VolumeId
 			project, volumeKey, err := common.VolumeIDToKey(volumeId)
-			createdDisk, err := fcp.GetDisk(context.Background(), project, volumeKey, gce.GCEAPIVersionBeta)
+			createdDisk, err := fcp.GetDisk(context.Background(), project, volumeKey)
 			if err != nil {
 				t.Fatalf("Get Disk failed for created disk with error: %v", err)
 			}

--- a/test/e2e/tests/setup_e2e_test.go
+++ b/test/e2e/tests/setup_e2e_test.go
@@ -36,13 +36,17 @@ import (
 )
 
 var (
-	project                   = flag.String("project", "", "Project to run tests in")
-	serviceAccount            = flag.String("service-account", "", "Service account to bring up instance with")
-	vmNamePrefix              = flag.String("vm-name-prefix", "gce-pd-csi-e2e", "VM name prefix")
-	architecture              = flag.String("arch", "amd64", "Architecture pd csi driver build on")
-	minCpuPlatform            = flag.String("min-cpu-platform", "AMD Milan", "Minimum CPU architecture")
-	zones                     = flag.String("zones", "us-east4-a,us-east4-c", "Zones to run tests in. If there are multiple zones, separate each by comma")
-	machineType               = flag.String("machine-type", "n2d-standard-2", "Type of machine to provision instance on")
+	project          = flag.String("project", "", "Project to run tests in")
+	serviceAccount   = flag.String("service-account", "", "Service account to bring up instance with")
+	vmNamePrefix     = flag.String("vm-name-prefix", "gce-pd-csi-e2e", "VM name prefix")
+	architecture     = flag.String("arch", "amd64", "Architecture pd csi driver build on")
+	minCpuPlatform   = flag.String("min-cpu-platform", "rome", "Minimum CPU architecture")
+	mwMinCpuPlatform = flag.String("min-cpu-platform-mw", "sapphirerapids", "Minimum CPU architecture for multiwriter tests")
+	zones            = flag.String("zones", "us-east4-a,us-east4-c", "Zones to run tests in. If there are multiple zones, separate each by comma")
+	machineType      = flag.String("machine-type", "n2d-standard-4", "Type of machine to provision instance on")
+	// Multi-writer is only supported on M3, C3, and N4
+	// https://cloud.google.com/compute/docs/disks/sharing-disks-between-vms#hd-multi-writer
+	mwMachineType             = flag.String("mw-machine-type", "c3-standard-4", "Type of machine to provision instance for multiwriter tests")
 	imageURL                  = flag.String("image-url", "projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2404-lts-amd64", "OS image url to get image from")
 	runInProw                 = flag.Bool("run-in-prow", false, "If true, use a Boskos loaned project and special CI service accounts and ssh keys")
 	deleteInstances           = flag.Bool("delete-instances", false, "Delete the instances after tests run")
@@ -54,6 +58,7 @@ var (
 
 	testContexts          = []*remote.TestContext{}
 	hyperdiskTestContexts = []*remote.TestContext{}
+	multiWriterTestContexts = []*remote.TestContext{}
 	computeService        *compute.Service
 	computeAlphaService   *computealpha.Service
 	computeBetaService    *computebeta.Service
@@ -73,9 +78,13 @@ func TestE2E(t *testing.T) {
 var _ = BeforeSuite(func() {
 	var err error
 	tcc := make(chan *remote.TestContext)
-	hdtcc := make(chan *remote.TestContext)
 	defer close(tcc)
+
+	hdtcc := make(chan *remote.TestContext)
 	defer close(hdtcc)
+
+	mwTcc := make(chan *remote.TestContext)
+	defer close(mwTcc)
 
 	zones := strings.Split(*zones, ",")
 
@@ -112,11 +121,16 @@ var _ = BeforeSuite(func() {
 			defer GinkgoRecover()
 			hdtcc <- NewTestContext(curZone, *hdMinCpuPlatform, *hdMachineType)
 		}(zone)
+		go func(curZone string) {
+			mwTcc <- NewTestContext(curZone, *mwMinCpuPlatform, *mwMachineType)
+		}(zone)
 	}
 
 	for i := 0; i < len(zones); i++ {
 		tc := <-tcc
 		testContexts = append(testContexts, tc)
+		mwTc := <-mwTcc
+		multiWriterTestContexts = append(multiWriterTestContexts, mwTc)
 		klog.Infof("Added TestContext for node %s", tc.Instance.GetName())
 		tc = <-hdtcc
 		hyperdiskTestContexts = append(hyperdiskTestContexts, tc)
@@ -130,6 +144,13 @@ var _ = AfterSuite(func() {
 		Expect(err).To(BeNil(), "Teardown Driver and Client failed with error")
 		if *deleteInstances {
 			tc.Instance.DeleteInstance()
+		}
+	}
+	for _, mwTc := range multiWriterTestContexts {
+		err := remote.TeardownDriverAndClient(mwTc)
+		Expect(err).To(BeNil(), "Multiwriter Teardown Driver and Client failed with error")
+		if *deleteInstances {
+			mwTc.Instance.DeleteInstance()
 		}
 	}
 })
@@ -200,4 +221,9 @@ func getRandomTestContext() *remote.TestContext {
 	Expect(testContexts).ToNot(BeEmpty())
 	rn := rand.Intn(len(testContexts))
 	return testContexts[rn]
+}
+func getRandomMwTestContext() *remote.TestContext {
+	Expect(multiWriterTestContexts).ToNot(BeEmpty())
+	rn := rand.Intn(len(multiWriterTestContexts))
+	return multiWriterTestContexts[rn]
 }

--- a/test/e2e/tests/setup_e2e_test.go
+++ b/test/e2e/tests/setup_e2e_test.go
@@ -36,33 +36,32 @@ import (
 )
 
 var (
-	project          = flag.String("project", "", "Project to run tests in")
-	serviceAccount   = flag.String("service-account", "", "Service account to bring up instance with")
-	vmNamePrefix     = flag.String("vm-name-prefix", "gce-pd-csi-e2e", "VM name prefix")
-	architecture     = flag.String("arch", "amd64", "Architecture pd csi driver build on")
-	minCpuPlatform   = flag.String("min-cpu-platform", "rome", "Minimum CPU architecture")
-	mwMinCpuPlatform = flag.String("min-cpu-platform-mw", "sapphirerapids", "Minimum CPU architecture for multiwriter tests")
-	zones            = flag.String("zones", "us-east4-a,us-east4-c", "Zones to run tests in. If there are multiple zones, separate each by comma")
-	machineType      = flag.String("machine-type", "n2d-standard-4", "Type of machine to provision instance on")
-	// Multi-writer is only supported on M3, C3, and N4
-	// https://cloud.google.com/compute/docs/disks/sharing-disks-between-vms#hd-multi-writer
-	mwMachineType             = flag.String("mw-machine-type", "c3-standard-4", "Type of machine to provision instance for multiwriter tests")
+	project                   = flag.String("project", "", "Project to run tests in")
+	serviceAccount            = flag.String("service-account", "", "Service account to bring up instance with")
+	vmNamePrefix              = flag.String("vm-name-prefix", "gce-pd-csi-e2e", "VM name prefix")
+	architecture              = flag.String("arch", "amd64", "Architecture pd csi driver build on")
+	minCpuPlatform            = flag.String("min-cpu-platform", "rome", "Minimum CPU architecture")
+	mwMinCpuPlatform          = flag.String("min-cpu-platform-mw", "sapphirerapids", "Minimum CPU architecture for multiwriter tests")
+	zones                     = flag.String("zones", "us-east4-a,us-east4-c", "Zones to run tests in. If there are multiple zones, separate each by comma")
+	machineType               = flag.String("machine-type", "n2d-standard-4", "Type of machine to provision instance on")
 	imageURL                  = flag.String("image-url", "projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2404-lts-amd64", "OS image url to get image from")
 	runInProw                 = flag.Bool("run-in-prow", false, "If true, use a Boskos loaned project and special CI service accounts and ssh keys")
 	deleteInstances           = flag.Bool("delete-instances", false, "Delete the instances after tests run")
 	cloudtopHost              = flag.Bool("cloudtop-host", false, "The local host is cloudtop, a kind of googler machine with special requirements to access GCP")
 	extraDriverFlags          = flag.String("extra-driver-flags", "", "Extra flags to pass to the driver")
 	enableConfidentialCompute = flag.Bool("enable-confidential-compute", false, "Create VMs with confidential compute mode. This uses NVMe devices")
-	hdMachineType             = flag.String("hyperdisk-machine-type", "c3-standard-4", "Type of machine to provision instance on")
-	hdMinCpuPlatform          = flag.String("hyperdisk-min-cpu-platform", "sapphirerapids", "Minimum CPU architecture")
+	// Multi-writer is only supported on M3, C3, and N4
+	// https://cloud.google.com/compute/docs/disks/sharing-disks-between-vms#hd-multi-writer
+	hdMachineType    = flag.String("hyperdisk-machine-type", "c3-standard-4", "Type of machine to provision instance on")
+	hdMinCpuPlatform = flag.String("hyperdisk-min-cpu-platform", "sapphirerapids", "Minimum CPU architecture")
 
-	testContexts          = []*remote.TestContext{}
-	hyperdiskTestContexts = []*remote.TestContext{}
+	testContexts            = []*remote.TestContext{}
+	hyperdiskTestContexts   = []*remote.TestContext{}
 	multiWriterTestContexts = []*remote.TestContext{}
-	computeService        *compute.Service
-	computeAlphaService   *computealpha.Service
-	computeBetaService    *computebeta.Service
-	kmsClient             *cloudkms.KeyManagementClient
+	computeService          *compute.Service
+	computeAlphaService     *computealpha.Service
+	computeBetaService      *computebeta.Service
+	kmsClient               *cloudkms.KeyManagementClient
 )
 
 func init() {
@@ -122,6 +121,7 @@ var _ = BeforeSuite(func() {
 			hdtcc <- NewTestContext(curZone, *hdMinCpuPlatform, *hdMachineType)
 		}(zone)
 		go func(curZone string) {
+			defer GinkgoRecover()
 			mwTcc <- NewTestContext(curZone, *mwMinCpuPlatform, *mwMachineType)
 		}(zone)
 	}
@@ -129,8 +129,6 @@ var _ = BeforeSuite(func() {
 	for i := 0; i < len(zones); i++ {
 		tc := <-tcc
 		testContexts = append(testContexts, tc)
-		mwTc := <-mwTcc
-		multiWriterTestContexts = append(multiWriterTestContexts, mwTc)
 		klog.Infof("Added TestContext for node %s", tc.Instance.GetName())
 		tc = <-hdtcc
 		hyperdiskTestContexts = append(hyperdiskTestContexts, tc)
@@ -146,7 +144,7 @@ var _ = AfterSuite(func() {
 			tc.Instance.DeleteInstance()
 		}
 	}
-	for _, mwTc := range multiWriterTestContexts {
+	for _, mwTc := range hyperdiskTestContexts {
 		err := remote.TeardownDriverAndClient(mwTc)
 		Expect(err).To(BeNil(), "Multiwriter Teardown Driver and Client failed with error")
 		if *deleteInstances {
@@ -223,7 +221,7 @@ func getRandomTestContext() *remote.TestContext {
 	return testContexts[rn]
 }
 func getRandomMwTestContext() *remote.TestContext {
-	Expect(multiWriterTestContexts).ToNot(BeEmpty())
-	rn := rand.Intn(len(multiWriterTestContexts))
-	return multiWriterTestContexts[rn]
+	Expect(hyperdiskTestContexts).ToNot(BeEmpty())
+	rn := rand.Intn(len(hyperdiskTestContexts))
+	return hyperdiskTestContexts[rn]
 }

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -1785,7 +1785,8 @@ func deleteVolumeOrError(client *remote.CsiClient, volID string) {
 func createAndValidateUniqueZonalMultiWriterDisk(client *remote.CsiClient, project, zone string, diskType string) (string, string) {
 	// Create Disk
 	disk := typeToDisk[diskType]
-		disk.params.AccessMode = "READ_WRITE_MANY"
+
+	disk.params[common.ParameterAccessMode] = "READ_WRITE_MANY"
 
 	volName := testNamePrefix + string(uuid.NewUUID())
 	volume, err := client.CreateVolumeWithCaps(volName, disk.params, defaultMwSizeGb,

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -905,8 +905,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		Expect(err).To(BeNil(), "Failed to go through volume lifecycle")
 	})
 
-	// Pending while multi-writer feature is in Alpha
-	PIt("Should create and delete multi-writer disk", func() {
+	It("Should create and delete multi-writer disk", func() {
 		Expect(testContexts).ToNot(BeEmpty())
 		testContext := getRandomTestContext()
 
@@ -917,7 +916,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		zone := "us-east1-a"
 
 		// Create and Validate Disk
-		volName, volID := createAndValidateUniqueZonalMultiWriterDisk(client, p, zone, standardDiskType)
+		volName, volID := createAndValidateUniqueZonalMultiWriterDisk(client, p, zone, hdbDiskType)
 
 		defer func() {
 			// Delete Disk
@@ -930,8 +929,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		}()
 	})
 
-	// Pending while multi-writer feature is in Alpha
-	PIt("Should complete entire disk lifecycle with multi-writer disk", func() {
+	It("Should complete entire disk lifecycle with multi-writer disk", func() {
 		testContext := getRandomTestContext()
 
 		p, z, _ := testContext.Instance.GetIdentity()
@@ -939,7 +937,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		instance := testContext.Instance
 
 		// Create and Validate Disk
-		volName, volID := createAndValidateUniqueZonalMultiWriterDisk(client, p, z, standardDiskType)
+		volName, volID := createAndValidateUniqueZonalMultiWriterDisk(client, p, z, hdbDiskType)
 
 		defer func() {
 			// Delete Disk
@@ -1787,6 +1785,8 @@ func deleteVolumeOrError(client *remote.CsiClient, volID string) {
 func createAndValidateUniqueZonalMultiWriterDisk(client *remote.CsiClient, project, zone string, diskType string) (string, string) {
 	// Create Disk
 	disk := typeToDisk[diskType]
+		disk.params.AccessMode = "READ_WRITE_MANY"
+
 	volName := testNamePrefix + string(uuid.NewUUID())
 	volume, err := client.CreateVolumeWithCaps(volName, disk.params, defaultMwSizeGb,
 		&csi.TopologyRequirement{

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -283,7 +283,6 @@ var _ = Describe("GCE PD CSI Driver", func() {
 			Expect(err).To(BeNil(), "Could not find disk in correct zone")
 		}
 	})
-
 	// TODO(hime): Enable this test once all release branches contain the fix from PR#1708.
 	// It("Should return InvalidArgument when disk size exceeds limit", func() {
 	// 	// If this returns a different error code (like Unknown), the error wrapping logic in #1708 has regressed.

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -80,7 +80,6 @@ const (
 )
 
 var _ = Describe("GCE PD CSI Driver", func() {
-
 	It("Should get reasonable volume limits from nodes with NodeGetInfo", func() {
 		testContext := getRandomTestContext()
 		resp, err := testContext.Client.NodeGetInfo()
@@ -284,6 +283,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 			Expect(err).To(BeNil(), "Could not find disk in correct zone")
 		}
 	})
+
 	// TODO(hime): Enable this test once all release branches contain the fix from PR#1708.
 	// It("Should return InvalidArgument when disk size exceeds limit", func() {
 	// 	// If this returns a different error code (like Unknown), the error wrapping logic in #1708 has regressed.
@@ -907,16 +907,12 @@ var _ = Describe("GCE PD CSI Driver", func() {
 
 	It("Should create and delete multi-writer disk", func() {
 		Expect(testContexts).ToNot(BeEmpty())
-		testContext := getRandomTestContext()
+		testContext := getRandomMwTestContext()
 
-		p, _, _ := testContext.Instance.GetIdentity()
+		p, z, _ := testContext.Instance.GetIdentity()
 		client := testContext.Client
-
-		// Hardcode to us-east1-a while feature is in alpha
-		zone := "us-east1-a"
-
 		// Create and Validate Disk
-		volName, volID := createAndValidateUniqueZonalMultiWriterDisk(client, p, zone, hdbDiskType)
+		volName, volID := createAndValidateUniqueZonalMultiWriterDisk(client, p, z, hdbDiskType)
 
 		defer func() {
 			// Delete Disk
@@ -924,13 +920,13 @@ var _ = Describe("GCE PD CSI Driver", func() {
 			Expect(err).To(BeNil(), "DeleteVolume failed")
 
 			// Validate Disk Deleted
-			_, err = computeAlphaService.Disks.Get(p, zone, volName).Do()
+			_, err = computeService.Disks.Get(p, z, volName).Do()
 			Expect(gce.IsGCEError(err, "notFound")).To(BeTrue(), "Expected disk to not be found")
 		}()
 	})
 
 	It("Should complete entire disk lifecycle with multi-writer disk", func() {
-		testContext := getRandomTestContext()
+		testContext := getRandomMwTestContext()
 
 		p, z, _ := testContext.Instance.GetIdentity()
 		client := testContext.Client
@@ -1787,7 +1783,6 @@ func createAndValidateUniqueZonalMultiWriterDisk(client *remote.CsiClient, proje
 	disk := typeToDisk[diskType]
 
 	disk.params[common.ParameterAccessMode] = "READ_WRITE_MANY"
-
 	volName := testNamePrefix + string(uuid.NewUUID())
 	volume, err := client.CreateVolumeWithCaps(volName, disk.params, defaultMwSizeGb,
 		&csi.TopologyRequirement{
@@ -1815,11 +1810,8 @@ func createAndValidateUniqueZonalMultiWriterDisk(client *remote.CsiClient, proje
 	Expect(cloudDisk.Status).To(Equal(readyState))
 	Expect(cloudDisk.SizeGb).To(Equal(defaultMwSizeGb))
 	Expect(cloudDisk.Name).To(Equal(volName))
+	Expect(cloudDisk.AccessMode).To(Equal("READ_WRITE_MANY"))
 	disk.validate(cloudDisk)
-
-	alphaDisk, err := computeAlphaService.Disks.Get(project, zone, volName).Do()
-	Expect(err).To(BeNil(), "Failed to get cloud disk using alpha API")
-	Expect(alphaDisk.MultiWriter).To(Equal(true))
 
 	return volName, volume.VolumeId
 }


### PR DESCRIPTION
Cherrypick of #1919

/kind feature

```release-note
This PR introduces READ_WRITE_MANY AccessMode also know as Multi-writer support for hyperdisks. Refer [here](https://cloud.google.com/compute/docs/disks/sharing-disks-between-vms#hd-multi-writer) for details about the multi-writer mode support, disk and machine types that support it.

Users can enable this mode by setting `access-mode: "READ_WRITE_MANY"` for the corresponding disk section to attach it in multi-writer mode.
```
