### PR TITLE
Update RAID logic and post-RAID validation to integrate Datacache support for GKE nodes

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -44,4 +44,11 @@ const (
 	ContexLocalSsdCacheSize = "local-ssd-cache-size"
 	// Node name for E2E tests
 	TestNode = "test-node-csi-e2e"
+
+	// Default LSSD count for datacache E2E tests
+	LocalSSDCountForDataCache = 2
+
+	// Node label for datacache
+	NodeLabelPrefix         = "cloud.google.com/%s"
+	DataCacheLssdCountLabel = "gke-data-cache-disk"
 )

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -48,7 +48,7 @@ const (
 	// Default LSSD count for datacache E2E tests
 	LocalSSDCountForDataCache = 2
 
-	// Node label for datacache
+	// Node label for Data Cache (only applicable to GKE nodes)
 	NodeLabelPrefix         = "cloud.google.com/%s"
 	DataCacheLssdCountLabel = "gke-data-cache-disk"
 )

--- a/pkg/gce-pd-csi-driver/cache.go
+++ b/pkg/gce-pd-csi-driver/cache.go
@@ -1,42 +1,57 @@
 package gceGCEDriver
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
-
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
 )
 
 const (
-	cacheSuffix        = "csi-fast"
-	mainLvSuffix       = "csi-main"
-	raidedLocalSsdName = "csi-driver-data-cache"
-	raidMode           = "0"
-	raidedLssdPrefix   = "/dev/md/"
+	cacheSuffix               = "csi-fast"
+	mainLvSuffix              = "csi-main"
+	raidedLocalSsdName        = "csi-driver-data-cache"
+	raidMode                  = "0"
+	initialRaidedLocalSsdPath = "/dev/md0"
 )
 
-var raidedLocalSsdPath = raidedLssdPrefix + raidedLocalSsdName
+func fetchRAIDedLocalSsdPath() (string, error) {
+	args := []string{
+		"--detail",
+		"--scan",
+	}
+	info, err := common.RunCommand("grep", []string{raidedLocalSsdName}, "mdadm", args...)
+	if err != nil || len(info) == 0 {
+		return "", fmt.Errorf("Error getting RAIDed device path for Datacache %v, output:%v ===============", err, string(info))
+	}
+	infoString := strings.TrimSpace(string(info))
+	infoSlice := strings.Split(infoString, " ")
+
+	// We want to get the second element in the array, which is the path to the RAIDed device
+	return infoSlice[1], nil
+}
 
 func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId string) (string, error) {
+
+	// The device path may have changed after rebooting, so we need to fetch the path again
+	raidedLocalSsdPath, err := fetchRAIDedLocalSsdPath()
+	if err != nil {
+		return "", err
+	}
+
 	volumeId := req.GetVolumeId()
 	volumeGroupName := getVolumeGroupName(nodeId)
 	mainDevicePath := "/dev/" + volumeGroupName + "/" + getLvName(mainLvSuffix, volumeId)
 	mainLvName := getLvName(mainLvSuffix, volumeId)
 	klog.V(2).Infof("Volume group available on node %v ", volumeGroupName)
-
-	info, err := common.RunCommand("grep", raidedLocalSsdName, "ls", raidedLssdPrefix)
-	if err != nil {
-		klog.Errorf("failed while listing raided devices, err: %v, output:%v", err, info)
-	}
-	infoString := strings.TrimSpace(string(info))
-	raidedLocalSsdPath = raidedLssdPrefix + infoString
-
 	vgExists := checkVgExists(volumeGroupName)
 	if vgExists {
 		// Clean up Volume Group before adding the PD
@@ -55,22 +70,24 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 		"-o",
 		"vg_name",
 	}
-	info, err = common.RunCommand("" /* pipedCmd */, "" /* pipedCmdArg */, "pvs", args...)
+	info, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "pvs", args...)
 	if err != nil {
 		klog.Errorf("errored while checking physical volume details %v: %s", err, info)
 		// On error info contains the error message which we cannot use for further steps
 		info = nil
 	}
 
-	infoString = strings.TrimSpace(strings.ReplaceAll(string(info), "\n", " "))
+	infoString := strings.TrimSpace(strings.ReplaceAll(string(info), "\n", " "))
 	infoString = strings.ReplaceAll(infoString, ".", "")
 	infoString = strings.ReplaceAll(infoString, "\"", "")
 	infoSlice := strings.Split(strings.TrimSpace(infoString), " ")
 	vgNameForPv := strings.TrimSpace(infoSlice[(len(infoSlice) - 1)])
+	klog.V(2).Infof("============================== Physical volume is part of Volume group: %v ==============================", vgNameForPv)
 	if vgNameForPv == volumeGroupName {
-		klog.V(2).Infof("Physical Volume(PV) already exists in the Volume Group %v", volumeGroupName)
+		klog.V(2).Infof("============================== Physical Volume(PV) already exists in the Volume Group ==============================")
 	} else if vgNameForPv != "VG" && vgNameForPv != "" {
-		info, err = common.RunCommand("" /* pipedCmd */, "" /* pipedCmdArg */, "vgchange", []string{"-an", vgNameForPv}...)
+
+		info, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgchange", []string{"-an", vgNameForPv}...)
 		if err != nil {
 			klog.Errorf("Errored while deactivating VG %v: err: %v: %s", vgNameForPv, err, info)
 		}
@@ -78,6 +95,7 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 		reduceVolumeGroup(vgNameForPv, false)
 		_, isCached := isCachingSetup(mainLvName)
 		// We will continue to uncache even if it errors to check caching as it is not a terminal issue.
+
 		if isCached {
 			// Uncache LV
 			args = []string{
@@ -86,20 +104,20 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 				"--force",
 				"-y", // force remove cache without flushing data
 			}
-			info, err = common.RunCommand("" /* pipedCmd */, "" /* pipedCmdArg */, "lvconvert", args...)
+			info, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvconvert", args...)
 			if err != nil {
 				return "", fmt.Errorf("errored while uncaching main LV. %v: %s", err, info)
 			}
 			// CLean up volume group to remove any dangling PV refrences
 			reduceVolumeGroup(vgNameForPv, false)
 		}
-		info, err = common.RunCommand("" /* pipedCmd */, "" /* pipedCmdArg */, "vgmerge", []string{volumeGroupName, vgNameForPv}...)
+		info, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgmerge", []string{volumeGroupName, vgNameForPv}...)
 		if err != nil {
 			return "", fmt.Errorf("Errored while merging the PV Volume group %s into %s %v: %s", vgNameForPv, volumeGroupName, err, info)
 		}
 
 	} else {
-		info, err := common.RunCommand("" /* pipedCmd */, "" /* pipedCmdArg */, "vgextend", []string{volumeGroupName, devicePath}...)
+		info, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgextend", []string{volumeGroupName, devicePath}...)
 		if err != nil {
 			return "", fmt.Errorf("Errored while extending Volume group to add PV %v, error: %v: %s", devicePath, err, info)
 		}
@@ -112,7 +130,7 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 		"-o",
 		"lv_name",
 	}
-	lvList, err := common.RunCommand("" /* pipedCmd */, "" /* pipedCmdArg */, "lvs", args...)
+	lvList, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvs", args...)
 	if err != nil {
 		return mainDevicePath, fmt.Errorf("Errored while checking logical volume for the device %s %w: %s", devicePath, err, info)
 	}
@@ -126,7 +144,7 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 			volumeGroupName,
 			devicePath,
 		}
-		info, err = common.RunCommand("" /* pipedCmd */, "" /* pipedCmdArg */, "lvcreate", args...)
+		info, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvcreate", args...)
 		if err != nil {
 			return mainDevicePath, fmt.Errorf("Errored setting up logical volume for the volume %s %w: %s", devicePath, err, info)
 		}
@@ -141,7 +159,7 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 		// Validate that cache is setup for required size
 		klog.V(2).Infof("Assuming valid data cache size and mode, resizing cache is not supported")
 	} else {
-		fastCacheSize := req.GetPublishContext()[common.ContexLocalSsdCacheSize]
+		fastCacheSize := req.GetPublishContext()[common.ContextDataCacheSize]
 		chunkSize := "960" // Cannot use default chunk size(64KiB) as it errors on maxChunksAllowed. Unit - KiB
 		args = []string{
 			"--yes",
@@ -153,7 +171,7 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 			volumeGroupName,
 			raidedLocalSsdPath,
 		}
-		info, err = common.RunCommand("" /* pipedCmd */, "" /* pipedCmdArg */, "lvcreate", args...)
+		info, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvcreate", args...)
 		if err != nil {
 			return mainDevicePath, fmt.Errorf("Errored while creating cache %w: %s", err, info)
 		}
@@ -174,14 +192,14 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 			"--force",
 			"-y",
 		}
-		info, err = common.RunCommand("" /* pipedCmd */, "" /* pipedCmdArg */, "lvconvert", args...)
+		info, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvconvert", args...)
 		if err != nil {
 			return mainDevicePath, fmt.Errorf("Errored while setting up caching for volume %s %w: %s", devicePath, err, info)
 		}
 	}
 
 	// activate all the LVs in the Volume group
-	info, err = common.RunCommand("" /* pipedCmd */, "" /* pipedCmdArg */, "vgchange", []string{"-ay", volumeGroupName}...)
+	info, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgchange", []string{"-ay", volumeGroupName}...)
 	if err != nil {
 		// The logical volumes would not be accessible if the group is not activated
 		return mainDevicePath, fmt.Errorf("Failed to activate volume group %v %v:%s", volumeGroupName, err, info)
@@ -189,9 +207,142 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 	return mainDevicePath, nil
 }
 
+func ValidateDataCacheConfig(dataCacheMode string, datacacheSize string, ctx context.Context, nodeName string) error {
+	if dataCacheMode != "" && datacacheSize != "" {
+		isAlreadyRaided, err := IsRaided()
+		if err != nil {
+			return fmt.Errorf("Local SSDs are not setup for caching; got error: %v", err)
+		}
+		if !isAlreadyRaided {
+			return fmt.Errorf("Local SSDs are not setup for caching")
+		}
+		return nil
+	}
+	klog.Infof("Data cache is not enabled for PVC")
+	return nil
+}
+
+func GetDataCacheCountFromNodeLabel(ctx context.Context, nodeName string) (int, error) {
+	if nodeName == common.TestNode {
+		return common.LocalSSDCountForDataCache, nil
+	}
+	cfg, err := rest.InClusterConfig()
+	// We want to capture API errors with node label fetching, so return -1
+	// in those cases instead of 0.
+	if err != nil {
+		return -1, err
+	}
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return -1, err
+	}
+	node, err := kubeClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		// We could retry, but this error will also crashloop the driver which may be as good a way to retry as any.
+		return -1, err
+	}
+	if val, found := node.GetLabels()[fmt.Sprintf(common.NodeLabelPrefix, common.DataCacheLssdCountLabel)]; found {
+		dataCacheCount, err := strconv.Atoi(val)
+		if err != nil {
+			return -1, fmt.Errorf("Error getting Datacache's LSSD count from node label: %v", err)
+		}
+		klog.Infof("Number of local SSDs requested for Datacache: %v", dataCacheCount)
+		return dataCacheCount, nil
+	}
+	return 0, fmt.Errorf("Cannot get Datacache's LSSD count from node label")
+}
+
+func FetchRaidedLssdCountForDatacache() (int, error) {
+	args := []string{
+		"--detail",
+		initialRaidedLocalSsdPath,
+	}
+	info, err := common.RunCommand("grep", []string{"Raid Devices"}, "mdadm", args...)
+	if err != nil {
+		return 0, fmt.Errorf("Error getting RAIDed devices for Datacache")
+	}
+	if len(info) != 0 {
+		raidedDeviceInfo := strings.Split(strings.TrimSpace(string(info)), ":")
+		// raidedDeviceInfo should be in "Raid Devices : X" format
+		raidedDeviceCount, _ := strconv.Atoi(strings.TrimSpace(raidedDeviceInfo[1]))
+		return raidedDeviceCount, nil
+	}
+	return 0, nil
+}
+
+func FetchRaidedLssds() ([]string, error) {
+	raidedLssdList := []string{}
+
+	args := []string{
+		"--detail",
+		"--scan",
+		"--export",
+	}
+
+	info, err := common.RunCommand("grep", []string{"/dev"}, "mdadm", args...)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching RAIDed LSSDs: %v; err:%v", info, err)
+	}
+
+	if len(info) != 0 {
+		infoList := strings.Split(strings.TrimSpace(string(info)), "\n")
+		for _, ssd := range infoList {
+			ssdInfo := strings.TrimSpace(ssd)
+			// SSD name comes after "=" on each output line (e.g. MD_DEVICE_dev_nvme3n1_DEV=/dev/nvme3n1)
+			ssdName := strings.Split(ssdInfo, "=")[1]
+			raidedLssdList = append(raidedLssdList, ssdName)
+		}
+	}
+
+	klog.V(2).Infof("Raided NVME list %v", raidedLssdList)
+
+	return raidedLssdList, nil
+}
+
+func FetchAllLssds() ([]string, error) {
+	diskList := []string{}
+
+	info, err := common.RunCommand("" /* pipedCmd */, nil /* pipeCmdArg */, "lsblk", []string{"-o", "NAME,MODEL", "-p", "-d", "-n"}...)
+	if err != nil {
+		return nil, fmt.Errorf("errored while fetching NVME disks info: %v; err:%v", info, err)
+	}
+	infoList := strings.Split(strings.TrimSpace(string(info)), "\n")
+	re, err := regexp.Compile("nvme_card([0-9]+)?$")
+	if err != nil {
+		klog.V(2).ErrorS(err, "Errored while compiling to check PD or LSSD")
+	}
+	for _, ssd := range infoList {
+		ssd = strings.TrimSpace(ssd)
+		if strings.HasPrefix(ssd, "/dev/nvme") {
+			ssdDetails := strings.Split(ssd, " ")
+			lssd := re.MatchString(ssdDetails[1])
+			if lssd {
+				diskList = append(diskList, strings.TrimSpace(ssdDetails[0]))
+			}
+		}
+	}
+
+	klog.V(2).Infof("NVME list %v", diskList)
+
+	return diskList, nil
+}
+
+func FetchLSSDsWihtEmptyMountPoint() ([]string, error) {
+	info, err := common.RunCommand("grep", []string{"-E", `^\S+\s*$`} /* pipeCmdArg */, "lsblk", []string{"-o", "NAME,MOUNTPOINT", "-pdn"}...)
+	if err != nil {
+		return nil, fmt.Errorf("Error while fetching disks with no mount point: %v; err:%v", info, err)
+	}
+	infoList := strings.Split(string(info), "\n")
+	diskList := []string{}
+	for _, ssd := range infoList {
+		diskList = append(diskList, strings.TrimSpace(ssd))
+	}
+	return diskList, nil
+}
+
 func checkVgExists(volumeGroupName string) bool {
 	args := []string{}
-	info, err := common.RunCommand("" /* pipedCmd */, "" /* pipedCmdArg */, "vgscan", args...)
+	info, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgscan", args...)
 	if err != nil {
 		klog.Errorf("Errored while checking if volume group exists %v: %s", err, info)
 		return false
@@ -212,7 +363,7 @@ func cleanupCache(volumeId string, nodeId string) error {
 		"-an",
 		"/dev/" + volumeGroupName + "/" + mainLvName,
 	}
-	info, err := common.RunCommand("" /* pipedCmd */, "" /* pipedCmdArg */, "lvchange", args...)
+	info, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvchange", args...)
 	if err != nil {
 		return fmt.Errorf("Failed to deactivate volume for uncaching %s %v: %s", volumeId, err, info)
 	}
@@ -221,7 +372,7 @@ func cleanupCache(volumeId string, nodeId string) error {
 		volumeGroupName + "/" + mainLvName,
 		"-y",
 	}
-	info, err = common.RunCommand("" /* pipedCmd */, "" /* pipedCmdArg */, "lvconvert", args...)
+	info, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvconvert", args...)
 	if err != nil {
 		return fmt.Errorf("Failed to uncache volume %s %w: %s", volumeId, err, info)
 	}
@@ -249,14 +400,14 @@ func createVg(volumeGroupName string, devicePath string, raidedLocalSsds string)
 		raidedLocalSsds,
 		"-v",
 	}
-	info, err := common.RunCommand("" /* pipedCmd */, "" /* pipedCmdArg */, "vgcreate", args...)
+	info, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgcreate", args...)
 	if err != nil {
 		return fmt.Errorf("Volume group creation failed %w: %s", err, info)
 	}
 	klog.Infof("Volume group creation succeeded for %v", volumeGroupName)
 
 	args = []string{}
-	info, err = common.RunCommand("" /* pipedCmd */, "" /* pipedCmdArg */, "vgscan", args...)
+	info, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgscan", args...)
 	if err != nil {
 		klog.Errorf("Failed to scan for volume group post creation, continuing: %v: %s", err, info)
 	}
@@ -271,75 +422,54 @@ func reduceVolumeGroup(volumeGroupName string, force bool) {
 	if force {
 		args = append(args, "--force")
 	}
-	info, err := common.RunCommand("" /* pipedCmd */, "" /* pipedCmdArg */, "vgreduce", args...)
+	info, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgreduce", args...)
 	if err != nil {
 		klog.Errorf("Errored while cleaning up volume group %v: %s", err, info)
 	}
 }
 
-func RaidLocalSsds() error {
-	isAlreadyRaided, err := isRaided()
-	if err != nil {
-		klog.V(2).Infof("Errored while scanning for available LocalSSDs err:%v; continuing Raiding", err)
-	} else if isAlreadyRaided {
-		klog.V(2).Infof("Local SSDs are already RAIDed, no further action needed here")
-		return nil
-	}
-	diskList := []string{}
-	info, err := common.RunCommand("" /* pipedCmd */, "" /* pipeCmdArg */, "lsblk", []string{"-o", "NAME,MODEL", "-p", "-d", "-n"}...)
-	if err != nil {
-		return fmt.Errorf("Failed to fetch LSSD info: %v; err:%v", info, err)
-	}
-	infoList := strings.Split(strings.TrimSpace(string(info)), "\n")
-	re, err := regexp.Compile("nvme_card([0-9]+)?$")
-	if err != nil {
-		return fmt.Errorf("Errored while compiling to check PD or LSSD %s", err)
-	}
-	for _, ssd := range infoList {
-		ssd = strings.TrimSpace(ssd)
-		if strings.HasPrefix(ssd, "/dev/nvme") {
-			ssdDetails := strings.Split(ssd, " ")
-			lssd := re.MatchString(ssdDetails[1])
-			if lssd {
-				diskList = append(diskList, strings.TrimSpace(ssdDetails[0]))
-			}
-		}
-	}
-	nvmeDiskCount := len(diskList)
-	if nvmeDiskCount == 0 {
-		return fmt.Errorf("No local SSDs found for raiding")
-	}
+func RaidLocalSsds(availableLssds []string) error {
 	args := []string{
 		"--create",
-		raidedLssdPrefix + raidedLocalSsdName,
+		initialRaidedLocalSsdPath,
+		"--name",
+		raidedLocalSsdName,
 		"-l" + raidMode,
 		// Force RAIDing as sometime it might fail for caution if there is just 1 LSSD present as 1 LSSD need not be RAIDed
 		"--force",
 		"-n",
-		strconv.Itoa(nvmeDiskCount),
+		strconv.Itoa(len(availableLssds)),
 	}
-	args = append(args, diskList...)
-	info, err = common.RunCommand("" /* pipedCmd */, "" /* pipeCmdArg */, "mdadm", args...)
+	args = append(args, availableLssds...)
+	info, err := common.RunCommand("" /* pipedCmd */, nil /* pipeCmdArg */, "mdadm", args...)
 	if err != nil {
 		return fmt.Errorf("errored while RAIDing LSSDs info: %v; err:%v", info, err)
 	}
 	// Validate if Raided successfully
-	isAlreadyRaided, err = isRaided()
+	isAlreadyRaided, err := IsRaided()
 	if err != nil {
 		klog.V(2).Infof("Errored while scanning for available raided LocalSSDs err:%v=", err)
 	}
 	if !isAlreadyRaided {
 		return fmt.Errorf("failed raiding, raided device not found on scanning")
 	}
+
+	raidedDataCacheCount, err := FetchRaidedLssdCountForDatacache()
+	if err != nil {
+		return err
+	}
+	if raidedDataCacheCount != len(availableLssds) {
+		return fmt.Errorf("Local SSDs reserved do not match the requested count")
+	}
 	return nil
 }
 
-func isRaided() (bool, error) {
+func IsRaided() (bool, error) {
 	args := []string{
 		"--detail",
 		"--scan",
 	}
-	info, err := common.RunCommand("" /* pipedCmd */, "" /* pipeCmdArg */, "mdadm", args...)
+	info, err := common.RunCommand("" /* pipedCmd */, nil /* pipeCmdArg */, "mdadm", args...)
 	if err != nil {
 		return false, fmt.Errorf("errored while scanning for raided LSSD %v: %s", err, info)
 	}
@@ -357,7 +487,7 @@ func isCachingSetup(mainLvName string) (error, bool) {
 		"-o",
 		"pool_lv",
 	}
-	poolName, err := common.RunCommand("" /* pipedCmd */, "" /* pipeCmdArg */, "lvs", args...)
+	poolName, err := common.RunCommand("" /* pipedCmd */, nil /* pipeCmdArg */, "lvs", args...)
 	if err != nil {
 		return fmt.Errorf("Failed to check if caching is setup %w", err), false
 	}

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -1063,7 +1063,7 @@ func (gceCS *GCEControllerServer) executeControllerPublishVolume(ctx context.Con
 	if gceCS.enableDataCache && req.GetVolumeContext() != nil {
 		if req.GetVolumeContext()[common.ContextDataCacheSize] != "" {
 			pubVolResp.PublishContext = map[string]string{}
-			pubVolResp.PublishContext[common.ContexLocalSsdCacheSize] = req.GetVolumeContext()[common.ContextDataCacheSize]
+			pubVolResp.PublishContext[common.ContextDataCacheSize] = req.GetVolumeContext()[common.ContextDataCacheSize]
 			pubVolResp.PublishContext[common.ContextDataCacheMode] = req.GetVolumeContext()[common.ContextDataCacheMode]
 		}
 	}

--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -347,7 +347,7 @@ func (ns *GCENodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStage
 		}
 		configError := ValidateDataCacheConfig(req.GetPublishContext()[common.ContextDataCacheMode], req.GetPublishContext()[common.ContextDataCacheSize], ctx, nodeId)
 		if configError != nil {
-			return nil, status.Error(codes.Internal, fmt.Sprintf("Error validate configuration for Datacache: %v", err.Error()))
+			return nil, status.Error(codes.Internal, fmt.Sprintf("Error validate configuration for Data Cache: %v", err.Error()))
 		}
 		devicePath, err = setupCaching(devFsPath, req, nodeId)
 		if err != nil {

--- a/test/e2e/tests/setup_e2e_test.go
+++ b/test/e2e/tests/setup_e2e_test.go
@@ -33,6 +33,7 @@ import (
 	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/strings/slices"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
 	testutils "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/test/e2e/utils"
 	remote "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/test/remote"
 )
@@ -64,8 +65,6 @@ var (
 	computeBetaService    *computebeta.Service
 	kmsClient             *cloudkms.KeyManagementClient
 )
-
-const localSSDCount int64 = 2
 
 func init() {
 	klog.InitFlags(flag.CommandLine)
@@ -194,7 +193,7 @@ func NewTestContext(zone, minCpuPlatform, machineType string, instanceNumber str
 		CloudtopHost:              *cloudtopHost,
 		EnableConfidentialCompute: *enableConfidentialCompute,
 		ComputeService:            computeService,
-		LocalSSDCount:             localSSDCount,
+		LocalSSDCount:             common.LocalSSDCountForDataCache,
 	}
 
 	if machineType == *hdMachineType {

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -71,8 +71,11 @@ func GCEClientAndDriverSetup(instance *remote.InstanceInfo, driverConfig DriverC
 		"--allow-hdha-provisioning",
 		"--device-in-use-timeout=10s", // Set lower than the usual value to expedite tests
 		fmt.Sprintf("--fallback-requisite-zones=%s", strings.Join(driverConfig.Zones, ",")),
-		"--enable-data-cache",
-		fmt.Sprintf("--node-name=%s", utilcommon.TestNode),
+	}
+
+	if instance.GetLocalSSD() > 0 {
+		extra_flags = append(extra_flags, "--enable-data-cache")
+		extra_flags = append(extra_flags, fmt.Sprintf("--node-name=%s", utilcommon.TestNode))
 	}
 	extra_flags = append(extra_flags, fmt.Sprintf("--compute-endpoint=%s", driverConfig.ComputeEndpoint))
 	extra_flags = append(extra_flags, driverConfig.ExtraFlags...)

--- a/test/remote/client-wrappers.go
+++ b/test/remote/client-wrappers.go
@@ -54,12 +54,7 @@ var (
 
 const (
 	// Keys in the volume context.
-	contextForceAttach   = "force-attach"
-	contextDataCacheSize = "data-cache-size"
-	contextDataCacheMode = "data-cache-mode"
-
-	// Keys in the publish context
-	contexLocalSsdCacheSize = "local-ssd-cache-size"
+	contextForceAttach = "force-attach"
 
 	defaultLocalSsdCacheSize = "200Gi"
 	defaultDataCacheMode     = common.DataCacheModeWriteThrough
@@ -203,8 +198,8 @@ func (c *CsiClient) NodeStageBlockVolume(volId, stageDir string, setupDataCache 
 func (c *CsiClient) NodeStageVolume(volId string, stageDir string, volumeCap *csipb.VolumeCapability, setupDataCache bool) error {
 	publishContext := map[string]string{}
 	if setupDataCache {
-		publishContext[contexLocalSsdCacheSize] = defaultLocalSsdCacheSize
-		publishContext[contextDataCacheMode] = defaultDataCacheMode
+		publishContext[common.ContextDataCacheSize] = defaultLocalSsdCacheSize
+		publishContext[common.ContextDataCacheMode] = defaultDataCacheMode
 	}
 	nodeStageReq := &csipb.NodeStageVolumeRequest{
 		VolumeId:          volId,

--- a/test/remote/instance.go
+++ b/test/remote/instance.go
@@ -80,6 +80,10 @@ func (i *InstanceInfo) GetNodeID() string {
 	return common.CreateNodeID(i.cfg.Project, i.cfg.Zone, i.cfg.Name)
 }
 
+func (i *InstanceInfo) GetLocalSSD() int64 {
+	return i.cfg.LocalSSDCount
+}
+
 func machineTypeMismatch(curInst *compute.Instance, newInst *compute.Instance) bool {
 	if !strings.Contains(curInst.MachineType, newInst.MachineType) {
 		klog.Infof("Machine type mismatch")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
Update RAIDing logic to fetch requested local SSD count for Datacache from GKE node label, set up  RAIDing for Datacache with the corresponding local SSD number, and validate RAID-ing config afterwards.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Update RAID logic and post-RAID validation to integrate Data Cache support for GKE nodes
```
