### PR TITLE
Mount error metrics branch

### DIFF
--- a/cmd/gce-pd-csi-driver/main.go
+++ b/cmd/gce-pd-csi-driver/main.go
@@ -155,13 +155,22 @@ func handle() {
 	}
 
 	var metricsManager *metrics.MetricsManager = nil
-	if *runControllerService && *httpEndpoint != "" {
+	runServiceWithMetrics := *runControllerService || *runNodeService
+	if runServiceWithMetrics && *httpEndpoint != "" {
 		mm := metrics.NewMetricsManager()
 		mm.InitializeHttpHandler(*httpEndpoint, *metricsPath)
-		mm.RegisterPDCSIMetric()
 
-		if metrics.IsGKEComponentVersionAvailable() {
-			mm.EmitGKEComponentVersion()
+		switch {
+		case *runControllerService:
+			mm.RegisterPDCSIMetric()
+			if metrics.IsGKEComponentVersionAvailable() {
+				mm.EmitGKEComponentVersion()
+			}
+		case *runNodeService:
+			if err := mm.EmmitProcessStartTime(); err != nil {
+				klog.Errorf("Failed to emit process start time: %v", err.Error())
+			}
+			mm.RegisterMountMetric()
 		}
 		metricsManager = &mm
 	}
@@ -255,6 +264,7 @@ func handle() {
 			EnableDeviceInUseCheck: *enableDeviceInUseCheck,
 			DeviceInUseTimeout:     *deviceInUseTimeout,
 			EnableDataCache:        *enableDataCacheFlag,
+			MetricsManager:         metricsManager,
 		}
 		nodeServer = driver.NewNodeServer(gceDriver, mounter, deviceUtils, meta, statter, nsArgs)
 		if *maxConcurrentFormatAndMount > 0 {

--- a/pkg/gce-pd-csi-driver/gce-pd-driver.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver.go
@@ -156,6 +156,7 @@ func NewNodeServer(gceDriver *GCEDriver, mounter *mount.SafeFormatAndMount, devi
 		enableDeviceInUseCheck: args.EnableDeviceInUseCheck,
 		deviceInUseErrors:      newDeviceErrMap(args.DeviceInUseTimeout),
 		EnableDataCache:        args.EnableDataCache,
+		metricsManager:         args.MetricsManager,
 	}
 }
 

--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/deviceutils"
 	metadataservice "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/metadata"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/metrics"
 	mountmanager "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/mount-manager"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/resizefs"
 )
@@ -71,6 +72,8 @@ type GCENodeServer struct {
 	// Embed UnimplementedNodeServer to ensure the driver returns Unimplemented for any
 	// new RPC methods that might be introduced in future versions of the spec.
 	csi.UnimplementedNodeServer
+
+	metricsManager *metrics.MetricsManager
 }
 
 type NodeServerArgs struct {
@@ -81,6 +84,8 @@ type NodeServerArgs struct {
 	DeviceInUseTimeout time.Duration
 
 	EnableDataCache bool
+
+	MetricsManager *metrics.MetricsManager
 }
 
 var _ csi.NodeServer = &GCENodeServer{}
@@ -405,6 +410,10 @@ func (ns *GCENodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStage
 				klog.V(4).Infof("NodeStageVolume succeeded with \"noload\" option on %v to %s", volumeID, stagingTargetPath)
 				return &csi.NodeStageVolumeResponse{}, nil
 			}
+		}
+
+		if ns.metricsManager != nil {
+			ns.metricsManager.RecordMountErrorMetric(err)
 		}
 		return nil, status.Error(codes.Internal,
 			fmt.Sprintf("Failed to format and mount device from (%q) to (%q) with fstype (%q) and options (%q): %v",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"k8s.io/component-base/metrics"
 	"k8s.io/klog/v2"
+	"k8s.io/mount-utils"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
 )
 
@@ -53,6 +54,15 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"driver_name", "method_name", "grpc_status_code", "disk_type", "enable_confidential_storage", "enable_storage_pools"})
+
+	mountErrorMetric = metrics.NewCounterVec(&metrics.CounterOpts{
+		Subsystem:      "node",
+		Name:           "mount_errors",
+		Help:           "Node server file system mounting errors",
+		StabilityLevel: metrics.ALPHA,
+	},
+		[]string{"error_type"},
+	)
 )
 
 type MetricsManager struct {
@@ -78,6 +88,10 @@ func (mm *MetricsManager) RegisterPDCSIMetric() {
 	mm.registry.MustRegister(pdcsiOperationErrorsMetric)
 }
 
+func (mm *MetricsManager) RegisterMountMetric() {
+	mm.registry.MustRegister(mountErrorMetric)
+}
+
 func (mm *MetricsManager) recordComponentVersionMetric() error {
 	v := getEnvVar(envGKEPDCSIVersion)
 	if v == "" {
@@ -99,6 +113,19 @@ func (mm *MetricsManager) RecordOperationErrorMetrics(
 	errCode := errorCodeLabelValue(operationErr)
 	pdcsiOperationErrorsMetric.WithLabelValues(pdcsiDriverName, fullMethodName, errCode, diskType, enableConfidentialStorage, enableStoragePools).Inc()
 	klog.Infof("Recorded PDCSI operation error code: %q", errCode)
+}
+
+func (mm *MetricsManager) RecordMountErrorMetric(err error) {
+	mntErr := &mount.MountError{}
+	if errors.As(err, mntErr) {
+		mountErrorMetric.WithLabelValues(string(mntErr.Type)).Inc()
+	}
+
+	klog.Infof("Recorded mount error type: %q", mntErr.Type)
+}
+
+func (mm *MetricsManager) EmmitProcessStartTime() error {
+	return metrics.RegisterProcessStartTime(mm.registry.Register)
 }
 
 func (mm *MetricsManager) EmitGKEComponentVersion() error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR adds metrics capability for the PDCSI node server. Metrics enable us to define SLO/Alerts for the node server. This PR specifically adds a metric for mount errors. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
adds metrics for node server including:
- 'process_start_time': start time of the container for use in metric scraping
- 'node_mount_errors': error types which occur during volume mounting
```
