### PR TITLE
Adding additional checks for data cache watcher and reduceVolumeGroup

### DIFF
--- a/pkg/gce-pd-csi-driver/cache.go
+++ b/pkg/gce-pd-csi-driver/cache.go
@@ -453,6 +453,10 @@ func createVg(volumeGroupName string, raidedLocalSsds string) error {
 }
 
 func reduceVolumeGroup(volumeGroupName string, force bool) {
+	if !checkVgExists(volumeGroupName) {
+		klog.V(2).Infof("Volume group %v not found, no further action needed", volumeGroupName)
+		return
+	}
 	args := []string{
 		"--removemissing",
 		volumeGroupName,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Adding additional check for data cache:
- Run Data Cache watcher on a node if it is a data cache node.
- check for VG existence during reduceVolumeGroup so that it doesn't run vgreduce and produce unactionable errors on the (pantheon) logs.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Run Data Cache watcher on a node if it is a data cache node.
Check for VG existence during reduceVolumeGroup so that it doesn't run vgreduce and produce unactionable errors on the (pantheon) logs.
```
