### PR TITLE
Pass performance parameters when creating regional disks.

### DIFF
--- a/test/e2e/tests/multi_zone_e2e_test.go
+++ b/test/e2e/tests/multi_zone_e2e_test.go
@@ -1064,8 +1064,11 @@ var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 
 		// Create Disk
 		volName := testNamePrefix + string(uuid.NewUUID())
+		wantIOPs, wantThroughput := int64(7000), int64(250)
 		volume, err := controllerClient.CreateVolume(volName, map[string]string{
-			common.ParameterKeyType: common.DiskTypeHdHA,
+			common.ParameterKeyType:                          common.DiskTypeHdHA,
+			common.ParameterKeyProvisionedIOPSOnCreate:       strconv.FormatInt(wantIOPs, 10),
+			common.ParameterKeyProvisionedThroughputOnCreate: strconv.FormatInt(wantThroughput, 10) + "Mi",
 		}, defaultRepdSizeGb, &csi.TopologyRequirement{
 			Requisite: []*csi.Topology{
 				{
@@ -1086,6 +1089,8 @@ var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 		Expect(cloudDisk.SizeGb).To(Equal(defaultRepdSizeGb))
 		Expect(cloudDisk.Name).To(Equal(volName))
 		Expect(len(cloudDisk.ReplicaZones)).To(Equal(2))
+		Expect(cloudDisk.ProvisionedIops).To(Equal(wantIOPs))
+		Expect(cloudDisk.ProvisionedThroughput).To(Equal(wantThroughput))
 		zonesSet := sets.NewString(zones...)
 		for _, replicaZone := range cloudDisk.ReplicaZones {
 			tokens := strings.Split(replicaZone, "/")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
We found a bug during bugbash that performance parameters are not passed to `insertRegionalDisks`. I decided to consolidate the two variants of the function (`insertZonalDisks` and `insertRegionalDisks`), because they share almost the same logic except some non-applicable parameters (e.g. storage pool) and differences on the GCE interface. I believe that this will prevent future slips similar to this bug.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes b/402880628

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
