### PR TITLE
feat: enable btrfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ FROM gke.gcr.io/debian-base:bookworm-v1.0.4-gke.3 AS debian
 
 # Install necessary dependencies
 # google_nvme_id script depends on the following packages: nvme-cli, xxd, bash
-RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs nvme-cli xxd bash kmod lvm2 mdadm
+RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs nvme-cli xxd bash kmod lvm2 mdadm btrfs-progs
 
 # Since we're leveraging apt to pull in dependencies, we use `gcr.io/distroless/base` because it includes glibc.
 FROM gcr.io/distroless/base-debian12 AS distroless-base
@@ -48,6 +48,7 @@ COPY --from=debian /etc/mke2fs.conf /etc/mke2fs.conf
 COPY --from=debian /lib/udev/scsi_id /lib/udev_containerized/scsi_id
 COPY --from=debian /bin/mount /bin/mount
 COPY --from=debian /bin/umount /bin/umount
+COPY --from=debian /bin/btrfs /bin/btrfs
 COPY --from=debian /sbin/blkid /sbin/blkid
 COPY --from=debian /sbin/blockdev /sbin/blockdev
 COPY --from=debian /sbin/dumpe2fs /sbin/dumpe2fs
@@ -131,6 +132,7 @@ COPY --from=debian /lib/${LIB_DIR_PREFIX}-linux-gnu/libselinux.so.1 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libnvme.so.1 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libsystemd.so.0 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libgpg-error.so.0 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/liblzo2.so.2 \
                    /lib/${LIB_DIR_PREFIX}-linux-gnu/libzstd.so.1 /lib/${LIB_DIR_PREFIX}-linux-gnu/
 
 COPY --from=debian /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libblkid.so.1 \

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ As part of the deployment process, the driver is deployed in a newly created nam
 
 Controller-level and node-level deployments will both have priorityClassName set, and the corresponding priority value is close to the maximum possible for user-created PriorityClasses.
 
+## Notes on filesystems
+
+As noted in [GCP PD documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/gce-pd-csi-driver), `ext4` and `xfs` are officially supported. `btrfs` support is experimental:
+- As of writing, Ubuntu VM images support btrfs, but [COS does not](https://cloud.google.com/container-optimized-os/docs/concepts/supported-filesystems).
+- Early testers have observed CSI driver OOMs when mounting larger (1TiB+) btrfs volumes under default memory constraints. The default constraint, as of writing, is 50MiB.
+
 ## Further Documentation
 
 [Local Development](docs/kubernetes/development.md)


### PR DESCRIPTION
This change is enough to provision and run a btrfs filesystems.

Tested workflows:
[x] provisioning (formatting)
[x] disk expansion

/kind feature

Fixes #2000

**What this PR does / why we need it**:

Enables formatting new PVCs using `btrfs` filesystem.

Mount options like `compress=zstd` work as expected.

**Does this PR introduce a user-facing change?**: YES
```release-note
ubuntu-only: specifying `fsType: btrfs` in the PVC definition now formats & mounts a btrfs filesystem. btrfs support is experimental.
```

Non-btrfs users are not impacted by this change.

It is [not explicitly supported in GCP docs](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/gce-pd-csi-driver), and it does not have to be, at least in the interim. This PR allows users easily experiment with the FS.

The integration tests are not updated to run btrfs, because as of writing [COS does not support btrfs](https://cloud.google.com/container-optimized-os/docs/concepts/supported-filesystems).