### PR TITLE
Update minCpuPlatform check when re-creating e2e test intsances

### DIFF
--- a/test/e2e/tests/setup_e2e_test.go
+++ b/test/e2e/tests/setup_e2e_test.go
@@ -43,8 +43,8 @@ var (
 	serviceAccount            = flag.String("service-account", "", "Service account to bring up instance with")
 	vmNamePrefix              = flag.String("vm-name-prefix", "gce-pd-csi-e2e", "VM name prefix")
 	architecture              = flag.String("arch", "amd64", "Architecture pd csi driver build on")
-	minCpuPlatform            = flag.String("min-cpu-platform", "rome", "Minimum CPU architecture")
-	mwMinCpuPlatform          = flag.String("min-cpu-platform-mw", "sapphirerapids", "Minimum CPU architecture for multiwriter tests")
+	minCpuPlatform            = flag.String("min-cpu-platform", "AMD Rome", "Minimum CPU architecture")
+	mwMinCpuPlatform          = flag.String("min-cpu-platform-mw", "Intel Sapphire Rapids", "Minimum CPU architecture for multiwriter tests")
 	zones                     = flag.String("zones", "us-east4-a,us-east4-c", "Zones to run tests in. If there are multiple zones, separate each by comma")
 	machineType               = flag.String("machine-type", "n2d-standard-4", "Type of machine to provision instance on")
 	imageURL                  = flag.String("image-url", "projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2404-lts-amd64", "OS image url to get image from")
@@ -56,7 +56,7 @@ var (
 	// Multi-writer is only supported on M3, C3, and N4
 	// https://cloud.google.com/compute/docs/disks/sharing-disks-between-vms#hd-multi-writer
 	hdMachineType    = flag.String("hyperdisk-machine-type", "c3-standard-4", "Type of machine to provision instance on")
-	hdMinCpuPlatform = flag.String("hyperdisk-min-cpu-platform", "sapphirerapids", "Minimum CPU architecture")
+	hdMinCpuPlatform = flag.String("hyperdisk-min-cpu-platform", "Intel Sapphire Rapids", "Minimum CPU architecture")
 
 	testContexts          = []*remote.TestContext{}
 	hyperdiskTestContexts = []*remote.TestContext{}

--- a/test/remote/instance.go
+++ b/test/remote/instance.go
@@ -86,23 +86,23 @@ func (i *InstanceInfo) GetLocalSSD() int64 {
 
 func machineTypeMismatch(curInst *compute.Instance, newInst *compute.Instance) bool {
 	if !strings.Contains(curInst.MachineType, newInst.MachineType) {
-		klog.Infof("Machine type mismatch")
+		klog.Infof("Machine type mismatch (current: %v, new: %v)", curInst.MachineType, newInst.MachineType)
 		return true
 	}
 	// Ideally we could compare to see if the new instance has a greater minCpuPlatfor
 	// For now we just check it was set and it's different.
 	if curInst.MinCpuPlatform != "" && curInst.MinCpuPlatform != newInst.MinCpuPlatform {
-		klog.Infof("CPU Platform mismatch")
+		klog.Infof("CPU Platform mismatch (current: %v, new: %v)", curInst.MinCpuPlatform, newInst.MinCpuPlatform)
 		return true
 	}
 	if (curInst.ConfidentialInstanceConfig != nil && newInst.ConfidentialInstanceConfig == nil) ||
 		(curInst.ConfidentialInstanceConfig == nil && newInst.ConfidentialInstanceConfig != nil) ||
 		(curInst.ConfidentialInstanceConfig != nil && newInst.ConfidentialInstanceConfig != nil && curInst.ConfidentialInstanceConfig.EnableConfidentialCompute != newInst.ConfidentialInstanceConfig.EnableConfidentialCompute) {
-		klog.Infof("Confidential compute mismatch")
+		klog.Infof("Confidential compute mismatch (current: %v, new: %v)", curInst.ConfidentialInstanceConfig, newInst.ConfidentialInstanceConfig)
 		return true
 	}
 	if curInst.SourceMachineImage != newInst.SourceMachineImage {
-		klog.Infof("Source Machine Mismatch")
+		klog.Infof("Source Machine Mismatch (current: %v, new: %v)", curInst.SourceMachineImage, newInst.SourceMachineImage)
 		return true
 	}
 	return false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This fixes an issue where subsequent e2e test runs delete and re-create instances, due to `minCpuPlatform` string mismatch

```
I0319 12:27:38.563310 1389961 instance.go:95] CPU Platform mismatch (current: AMD Rome, new: rome)
I0319 12:27:38.563346 1389961 instance.go:187] Instance machine type doesn't match the required one. Delete instance.
I0319 12:27:38.568171 1389961 instance.go:95] CPU Platform mismatch (current: Intel Sapphire Rapids, new: sapphirerapids)
I0319 12:27:38.568201 1389961 instance.go:187] Instance machine type doesn't match the required one. Delete instance.
I0319 12:27:38.592324 1389961 instance.go:95] CPU Platform mismatch (current: AMD Rome, new: rome)
I0319 12:27:38.592350 1389961 instance.go:187] Instance machine type doesn't match the required one. Delete instance.
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
