### PR TITLE
Fix units for cache size while calculating chunk size for LVM

### DIFF
--- a/pkg/gce-pd-csi-driver/cache.go
+++ b/pkg/gce-pd-csi-driver/cache.go
@@ -210,7 +210,7 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 			req.GetPublishContext()[common.ContextDataCacheMode],
 			volumeGroupName + "/" + mainLvName,
 			"--chunksize",
-			chunkSize, // default unit is KiB
+			chunkSize,
 			"--force",
 			"-y",
 		}
@@ -563,7 +563,7 @@ func isCachingSetup(mainLvName string) (error, bool) {
 func fetchChunkSizeKiB(cacheSize string) (string, error) {
 	var chunkSize float64
 
-	cacheSizeInt, err := common.ConvertGiStringToInt64(cacheSize)
+	cacheSizeInt, err := strconv.ParseInt(cacheSize, 10, 64)
 	if err != nil {
 		return "0", err
 	}

--- a/pkg/gce-pd-csi-driver/cache_test.go
+++ b/pkg/gce-pd-csi-driver/cache_test.go
@@ -13,22 +13,22 @@ func TestFetchChunkSizeKiB(t *testing.T) {
 	}{
 		{
 			name:         "chunk size is in the allowed range",
-			cacheSize:    "500Gi",
+			cacheSize:    "500",
 			expChunkSize: "512KiB", //range defined in fetchChunkSizeKiB
 		},
 		{
 			name:         "chunk size is set to the range ceil",
-			cacheSize:    "30000000Gi",
+			cacheSize:    "30000000",
 			expChunkSize: "1048576KiB", //range defined in fetchChunkSizeKiB - max 1GiB
 		},
 		{
 			name:         "chunk size is set to the allowed range floor",
-			cacheSize:    "10Gi",
+			cacheSize:    "100",
 			expChunkSize: "160KiB", //range defined in fetchChunkSizeKiB - min 160 KiB
 		},
 		{
 			name:         "cacheSize set to KiB also sets the chunk size to range floor",
-			cacheSize:    "100Ki",
+			cacheSize:    "1",
 			expChunkSize: "160KiB", //range defined in fetchChunkSizeKiB - min 160 KiB
 		},
 		{

--- a/test/remote/client-wrappers.go
+++ b/test/remote/client-wrappers.go
@@ -56,7 +56,7 @@ const (
 	// Keys in the volume context.
 	contextForceAttach = "force-attach"
 
-	defaultLocalSsdCacheSize = "200Gi"
+	defaultLocalSsdCacheSize = "200"
 	defaultDataCacheMode     = common.DataCacheModeWriteThrough
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
 /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Currently the cache size unit isn't passed along with the cache size causing conversion issues downstream
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix unit calculation bug for cache size setup
```
