### PR TITLE
fix outdated metadata error in watcher

### DIFF
--- a/pkg/gce-pd-csi-driver/cache.go
+++ b/pkg/gce-pd-csi-driver/cache.go
@@ -641,6 +641,14 @@ func watchDiskDetaches(watcher *fsnotify.Watcher, nodeName string, errorCh chan 
 		case event := <-watcher.Events:
 			// In case of an event i.e. creation or deletion of any new PV, we update the VG metadata.
 			// This might include some non-LVM changes, no harm in updating metadata multiple times.
+			args := []string{
+				"--updatemetadata",
+				getVolumeGroupName(nodeName),
+			}
+			_, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgck", args...)
+			if err != nil {
+				klog.Errorf("Error updating volume group's metadata: %v", err)
+			}
 			reduceVolumeGroup(getVolumeGroupName(nodeName), true)
 			klog.V(2).Infof("disk attach/detach event %#v\n", event)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
We saw outdated metadata errors with volume groupsduring concurrent  PVC detaching/provisioning operations with Guitar tests like the following, which ultimately caused an error during cache setup.
```
WARNING: ignoring metadata seqno 7 on /dev/sdb for seqno 9 on /dev/md127 for VG csi-vg-x84b7gt4   WARNING: Inconsistent metadata found for VG csi-vg-x84b7gt4   See vgck --updatemetadata to correct inconsistency   WARNING: outdated PV /dev/sdb seqno 7 has been removed in current VG csi-vg-x84b7gt4 seqno 9   See vgck --updatemetadata to clear outdated metadata
```
This PR updates the Data Cache's watcher to run 'vcgk --updatemetada <VGName>' to avoid this error.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix outdated metadata error in watcher for Data Cache
```
