### PR TITLE
Enable autoupgrade when creating extended channel GKE clusters in CI

### DIFF
--- a/test/k8s-integration/cluster.go
+++ b/test/k8s-integration/cluster.go
@@ -219,8 +219,9 @@ func clusterUpGKE(gceZone, gceRegion string, numNodes int, numWindowsNodes int, 
 		cmdParams = append(cmdParams, "--cluster-version", *gkeClusterVer)
 	} else {
 		cmdParams = append(cmdParams, "--release-channel", *gkeReleaseChannel)
-		// release channel based GKE clusters require autorepair to be enabled.
+		// Release channel based GKE clusters require autorepair to be enabled.
 		cmdParams = append(cmdParams, "--enable-autorepair")
+		// Extended channel clusters require autoupgrade to be enabled.
 		cmdParams = append(cmdParams, "--enable-autoupgrade")
 	}
 

--- a/test/k8s-integration/cluster.go
+++ b/test/k8s-integration/cluster.go
@@ -221,8 +221,11 @@ func clusterUpGKE(gceZone, gceRegion string, numNodes int, numWindowsNodes int, 
 		cmdParams = append(cmdParams, "--release-channel", *gkeReleaseChannel)
 		// Release channel based GKE clusters require autorepair to be enabled.
 		cmdParams = append(cmdParams, "--enable-autorepair")
+
 		// Extended channel clusters require autoupgrade to be enabled.
-		cmdParams = append(cmdParams, "--enable-autoupgrade")
+		if *gkeReleaseChannel == "extended" {
+			cmdParams = append(cmdParams, "--enable-autoupgrade")
+		}
 	}
 
 	if isVariableSet(gkeNodeVersion) {

--- a/test/k8s-integration/cluster.go
+++ b/test/k8s-integration/cluster.go
@@ -221,6 +221,7 @@ func clusterUpGKE(gceZone, gceRegion string, numNodes int, numWindowsNodes int, 
 		cmdParams = append(cmdParams, "--release-channel", *gkeReleaseChannel)
 		// release channel based GKE clusters require autorepair to be enabled.
 		cmdParams = append(cmdParams, "--enable-autorepair")
+		cmdParams = append(cmdParams, "--enable-autoupgrade")
 	}
 
 	if isVariableSet(gkeNodeVersion) {

--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -51,7 +51,7 @@ var (
 	numNodes             = flag.Int("num-nodes", 0, "the number of nodes in the test cluster")
 	numWindowsNodes      = flag.Int("num-windows-nodes", 0, "the number of Windows nodes in the test cluster")
 	imageType            = flag.String("image-type", "cos_containerd", "the image type to use for the cluster")
-	gkeReleaseChannel    = flag.String("gke-release-channel", "", "GKE release channel to be used for cluster deploy. One of 'rapid', 'stable' or 'regular'")
+	gkeReleaseChannel    = flag.String("gke-release-channel", "", "GKE release channel to be used for cluster deploy. One of 'rapid', 'stable', 'regular' or 'extended'")
 	gkeTestClusterPrefix = flag.String("gke-cluster-prefix", "pdcsi", "Prefix of GKE cluster names. A random suffix will be appended to form the full name.")
 	gkeTestClusterName   = flag.String("gke-cluster-name", "", "Name of existing cluster")
 	gkeNodeVersion       = flag.String("gke-node-version", "", "GKE cluster worker node version")


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:

Managed tests are seeing failures on the Extended channel due to the lack of the `--enable-autoupgrade` flag during cluster creation.



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
