### PR TITLE
When using the extended channel, also specify the cluster version

### DIFF
--- a/test/run-k8s-integration-ci.sh
+++ b/test/run-k8s-integration-ci.sh
@@ -93,11 +93,18 @@ else
 fi
 
 if [ "$deployment_strategy" = "gke" ]; then
-  if [ "$gke_release_channel" ]; then
+  # To leverage old cluster versions, we need set both the release channel and
+  # the cluster version.
+  if [ "$gke_release_channel" = "extended" ]; then
+    base_cmd="${base_cmd} --gke-release-channel=${gke_release_channel}"
+    base_cmd="${base_cmd} --gke-cluster-version=${gke_cluster_version}"
+  elif [ -n "$gke_release_channel" ]; then
     base_cmd="${base_cmd} --gke-release-channel=${gke_release_channel}"
   else
     base_cmd="${base_cmd} --gke-cluster-version=${gke_cluster_version}"
   fi
+fi
+
 else
   base_cmd="${base_cmd} --kube-version=${kube_version}"
 fi


### PR DESCRIPTION
<**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:

When running CI for the `extended` channel, we intended to specify both the release channel _and_ the version of the cluster.  However, the CI test script was choosing only one of the two depending on the setting of the release channel.

This PR adds a special case of for `extended`, where both the release channel and the cluster version are passed to the test automation.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
