### PR TITLE
Skip rwop fsgroup tests when node version is below 1.32

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -744,6 +744,13 @@ func generateGKETestSkip(testParams *testParameters) string {
 	// Skip mount options test until we fix the invalid mount options for xfs.
 	skipString = skipString + "|csi-gcepd-sc-xfs.*provisioning.should.provision.storage.with.mount.options"
 
+	// Skip rwop test when node version is less than 1.32.  Test was added only
+	// in 1.32 and above, see tags in
+	// https://github.com/kubernetes/kubernetes/pull/128244.
+	if nodeVer != nil && nodeVer.lessThan(mustParseVersion("1.32.0")) {
+		skipString = skipString + "|rwop.pod.created.with.an.initial.fsgroup..new.pod.fsgroup.applied.to.volume.contents"
+	}
+
 	return skipString
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:

The `rwop` fsgroup tests [were added](https://github.com/kubernetes/kubernetes/pull/128244) only in k8s versions 1.32 and up.  Failures with node versions below that will not pass.

```release-note
None
```
