### PR TITLE
Remove erroneous `if` in run-k8s-integration-ci.sh

### DIFF
--- a/test/run-k8s-integration-ci.sh
+++ b/test/run-k8s-integration-ci.sh
@@ -103,8 +103,6 @@ if [ "$deployment_strategy" = "gke" ]; then
   else
     base_cmd="${base_cmd} --gke-cluster-version=${gke_cluster_version}"
   fi
-fi
-
 else
   base_cmd="${base_cmd} --kube-version=${kube_version}"
 fi


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation


/kind failing-test


> /kind feature
> /kind flake

**What this PR does / why we need it**:

Fix a test bash error: `test/run-k8s-integration-ci.sh: line 108: syntax error near unexpected token `else'`

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
