### PR TITLE
Add exception for dual-variable setting in utils.go for extended channel

### DIFF
--- a/test/k8s-integration/main.go
+++ b/test/k8s-integration/main.go
@@ -176,8 +176,10 @@ func main() {
 
 	if *deploymentStrat == "gke" {
 		ensureVariable(kubeVersion, false, "Cannot set kube-version when using deployment strategy 'gke'. Use gke-cluster-version.")
-		ensureExactlyOneVariableSet([]*string{gkeClusterVer, gkeReleaseChannel},
-			"For GKE cluster deployment, exactly one of 'gke-cluster-version' or 'gke-release-channel' must be set")
+		if *gkeReleaseChannel != "extended" {
+			ensureExactlyOneVariableSet([]*string{gkeClusterVer, gkeReleaseChannel},
+				"For GKE cluster deployment, exactly one of 'gke-cluster-version' or 'gke-release-channel' must be set")
+		}
 		ensureVariable(kubeFeatureGates, false, "Cannot set feature gates when using deployment strategy 'gke'.")
 		if len(*localK8sDir) == 0 {
 			ensureVariable(testVersion, true, "Must set either test-version or local k8s dir when using deployment strategy 'gke'.")


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:

Earlier #2045 did not also update the golang script, which had validation that needed an exception for extended channel.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
