### PR TITLE
Update 1.17 changelog based on Releases page, make placeholder 1.18

### DIFF
--- a/CHANGELOG/CHANGELOG-1.17.md
+++ b/CHANGELOG/CHANGELOG-1.17.md
@@ -1,3 +1,49 @@
+# v1.17.12 - Changelog since v1.17.11
+- [Bump up golang.org version to 0.39](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/2071)
+
+# v1.17.11 - Changelog since v1.17.10
+- [Remove no-op Watcher logs for GKE Data Cache in 1.17 release branch](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/2069)
+
+# v1.17.10 - Changelog since v1.17.9
+- [Fix hyperdisk attach limits](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/2060)
+- [Fix Hyperdisk Resize That Requires Iops/Throughput Adjustment](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/2061)
+
+# v1.17.9 - Changelog since v1.17.8
+- [Relax volumeContentSource restriction for ROX multi-zone dynamic volume creation](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/2036)
+
+# v1.17.8 - Changelog since v1.17.7
+- [Automated cherry pick of #2037: update cache logic to calculate chunk size based on total](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/2039)
+
+# v1.17.7 - Changelog since v1.17.6
+- [Add Attach Limit for Hyperdisk + Gen4 VMs](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/2021)
+- [Add pageToken response check to ListSnapshots gRPC API](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/2020)
+- [fix outdated metadata error in watcher](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/2029)
+
+# v1.17.6 - Changelog since v1.17.5
+- [Use strings.Fields for whitespace splitting to fix issues with strings.Split in case of multiple consecutive spaces](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/2008)
+- [Fix units for cache size while calculating chunk size for LVM](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/2012)
+- [Map insufficient free space error during cache creating to InvalidArgument error](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/2011)
+
+# v1.17.5 - Changelog since v1.17.4
+- [Add handling for TPC to GetRegionFromZones](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1998)
+
+# v1.17.4 - Changelog since v1.17.3
+- [Update changelog and test image to release-v1.17.1](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1971)
+- [Fix CVE-2025-22870](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1991)
+- [Pass performance parameters when creating regional disks.](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1992)
+- [Fix logic bug while checking available LSSDs for RAIDing for Data Cache](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1994)
+- [Add exponential backoff retries for getting Node from API server logic](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1995)
+
+# v1.17.3 - Changelog since v1.17.2
+- [Bump the onsi group across 1 directory with 2 updates](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1924)
+- [Adding additional checks for data cache watcher and reduceVolumeGroup](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1966)
+- [Fix build issues for Windows image](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1953)
+- [Bump golang from 1.23.0 to 1.24.0](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1943)
+- [Bump the golang-x group across 1 directory with 10 updates](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1963)
+- [Fix CVE-2022-1996](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1967)
+- [Pass performance parameters when creating regional disks](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1989)
+- [Update change log and docs for release v1.17.1 to master](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1973)
+
 # v1.17.2 - Changelog since v1.17.1
 - [Fixed CVE-2022-1996](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1977)
 

--- a/CHANGELOG/CHANGELOG-1.18.md
+++ b/CHANGELOG/CHANGELOG-1.18.md
@@ -1,0 +1,2 @@
+# v1.18.0 - Changelog since v1.17.12
+To be filled in via a copy of the automatically generated release notes once the v1.18.0 tag is created. (TODO: julianKatz@)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug


/kind cleanup


> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Brings changelogs up to date for 1.17 (10 releases were missed).  Creates a placeholder file for 1.18.  I could compile that one manually but I'm going to get one for free (I think) when I generate the v1.18.0 tag.  If not, I can come back and make it manually.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
