### PR TITLE
Upgrade to resizer to v1.13.0

### DIFF
--- a/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
+++ b/deploy/kubernetes/images/prow-stable-sidecar-rc-master/image.yaml
@@ -23,7 +23,7 @@ metadata:
   name: imagetag-csi-resize-prow-rc
 imageTag:
   name: registry.k8s.io/sig-storage/csi-resizer
-  newTag: "v1.12.0"
+  newTag: "v1.13.2"
 ---
 apiVersion: builtin
 kind: ImageTagTransformer

--- a/deploy/kubernetes/images/stable-master/image.yaml
+++ b/deploy/kubernetes/images/stable-master/image.yaml
@@ -22,7 +22,7 @@ metadata:
   name: imagetag-csi-resizer
 imageTag:
   name: registry.k8s.io/sig-storage/csi-resizer
-  newTag: "v1.12.0"
+  newTag: "v1.13.2"
 ---
 
 apiVersion: builtin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind failing-test

**What this PR does / why we need it**:
Updates the image for external resizer to use the latest version, v1.13.0. This resolves tests failures related to the [verification of beta fields](https://github.com/kubernetes/kubernetes/commit/784c589a77a3fd67b1c1cd16bfccb4f2814bd6fe) not used in the previous version. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
