### PR TITLE
btrfs recalim on kernel v5.19+: use bg_reclaim_threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,13 @@ Controller-level and node-level deployments will both have priorityClassName set
 
 As noted in [GCP PD documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/gce-pd-csi-driver), `ext4` and `xfs` are officially supported. `btrfs` support is experimental:
 - As of writing, Ubuntu VM images support btrfs, but [COS does not](https://cloud.google.com/container-optimized-os/docs/concepts/supported-filesystems).
-- Early testers have observed CSI driver OOMs when mounting larger (1TiB+) btrfs volumes under default memory constraints. The default constraint, as of writing, is 50MiB.
+
+`btrfs` filesystem accepts two "special" mount options:
+
+- `btrfs-data-bg_reclaim_threshold`
+- `btrfs-metadata-bg_reclaim_threshold`
+
+Which writes to `/sys/fs/btrfs/FS-UUID/allocation/{,meta}data/bg_reclaim_threshold`, as documented [in btrfs docs](https://btrfs.readthedocs.io/en/latest/ch-sysfs.html#uuid-allocations-data-metadata-system).
 
 ## Further Documentation
 

--- a/cmd/gce-pd-csi-driver/main.go
+++ b/cmd/gce-pd-csi-driver/main.go
@@ -265,6 +265,7 @@ func handle() {
 			DeviceInUseTimeout:       *deviceInUseTimeout,
 			EnableDataCache:          *enableDataCacheFlag,
 			DataCacheEnabledNodePool: isDataCacheEnabledNodePool,
+			SysfsPath:                "/sys",
 		}
 		nodeServer = driver.NewNodeServer(gceDriver, mounter, deviceUtils, meta, statter, nsArgs)
 

--- a/pkg/gce-pd-csi-driver/gce-pd-driver.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver.go
@@ -157,6 +157,7 @@ func NewNodeServer(gceDriver *GCEDriver, mounter *mount.SafeFormatAndMount, devi
 		deviceInUseErrors:        newDeviceErrMap(args.DeviceInUseTimeout),
 		EnableDataCache:          args.EnableDataCache,
 		DataCacheEnabledNodePool: args.DataCacheEnabledNodePool,
+		SysfsPath:                args.SysfsPath,
 	}
 }
 

--- a/pkg/gce-pd-csi-driver/utils.go
+++ b/pkg/gce-pd-csi-driver/utils.go
@@ -311,6 +311,14 @@ func collectMountOptions(fsType string, mntFlags []string) []string {
 			// passed directly as an option to the mount command.
 			continue
 		}
+
+		if btrfsReclaimDataRegex.FindString(opt) != "" {
+			continue
+		}
+		if btrfsReclaimMetadataRegex.FindString(opt) != "" {
+			continue
+		}
+
 		options = append(options, opt)
 	}
 


### PR DESCRIPTION
Add a sysfs knob `btrfs-allocation-{,meta}data-bg_reclaim_threshold`, which will do the equivalent of:

```
echo VALUE > /sys/fs/btrfs/FS-UUID/allocation/data/bg_reclaim_threshold
```

Or, in case of metadata, equivalently:

```
echo VALUE > /sys/fs/btrfs/FS-UUID/allocation/metadata/bg_reclaim_threshold
```

Where VALUE is a number between `0` and `99` inclusive.

Adding it as a "special" mount option, similarly to `read_ahead_kb`, as that's quite convenient.

Some resources about `bg_reclaim_threshold` and more broadly balancing of the btrfs filesystem:

- https://btrfs.readthedocs.io/en/latest/Administration.html#uuid-allocations-data-metadata-system
- https://web.git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=18bb8bbf13c1839b43c9e09e76d397b753989af2
- https://lwn.net/Articles/978826/ Linux v6.11+, this may obsolete `bg_reclaim_threshold`.

Author's interpretation
-----------------------

The higher the reclaim threshold, the more accurately btrfs will show unused space (`Device Unallocated` row of `btrfs filesystem usage`) at the expense of sometimes needlessly moving data around. The lower the threshold, the less rebalancing, the less accurate metrics of the remaining space.

The author of this commit prefers more IO in order to see more accurate `Device Unallocated` metrics, and therefore sets
`btrfs-allocation-data-bg_reclaim_threshold=90`.


**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

More control to the operator to manage btrfs free space tracking.

**Which issue(s) this PR fixes**:

Fixes #2088

**Does this PR introduce a user-facing change?**:
```release-note
`btrfs` filesystems gain special mount options `btrfs-allocation-(data|metadata)-bg_reclaim_threshold`. The driver will write the provided value to `/sys/fs/btrfs/FS-UUID/allocation/(data|metadata)/bg_reclaim_threshold` respectively.
```