### PR TITLE
Fix Gen4 Custom VM Cases

### DIFF
--- a/pkg/gce-pd-csi-driver/node_test.go
+++ b/pkg/gce-pd-csi-driver/node_test.go
@@ -289,14 +289,30 @@ func TestNodeGetVolumeLimits(t *testing.T) {
 			expVolumeLimit: 31,
 		},
 		{
+			name:           "n4-micro", // This type does not exist, but testing edge cases
+			machineType:    "n4-micro",
+			expVolumeLimit: volumeLimitBig,
+			expectError:    true,
+		},
+		{
 			name:           "n4-highcpu-4",
 			machineType:    "n4-highcpu-4",
 			expVolumeLimit: 15,
 		},
 		{
+			name:           "n4-custom-8-12345-ext",
+			machineType:    "n4-custom-8-12345-ext",
+			expVolumeLimit: 23,
+		},
+		{
+			name:           "n4-custom-16-12345",
+			machineType:    "n4-custom-16-12345",
+			expVolumeLimit: 31,
+		},
+		{
 			name:           "invalid gen4 machine type",
 			machineType:    "n4-highcpu-4xyz",
-			expVolumeLimit: volumeLimitSmall,
+			expVolumeLimit: volumeLimitBig,
 			expectError:    true,
 		},
 		{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Custom VM naming does not follow the current string handling, it returns an error in NodeGetInfo and breaks customers.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Fix Gen4 Custom VM Cases
```
