### PR TITLE
default data cache enabled to false

### DIFF
--- a/cmd/gce-pd-csi-driver/main.go
+++ b/cmd/gce-pd-csi-driver/main.go
@@ -270,7 +270,7 @@ func handle() {
 		if err != nil {
 			klog.Fatalf("Failed to set up metadata service: %v", err.Error())
 		}
-		isDataCacheEnabledNodePool, err := isDataCacheEnabledNodePool(ctx, *nodeName)
+		isDataCacheEnabledNodePool, err := driver.IsDataCacheEnabledNodePool(ctx, *nodeName, *enableDataCacheFlag)
 		if err != nil {
 			klog.Fatalf("Failed to get node info from API server: %v", err.Error())
 		}
@@ -379,17 +379,6 @@ func urlFlag(target **url.URL, name string, usage string) {
 		klog.Errorf("Error parsing endpoint compute endpoint %v", err)
 		return err
 	})
-}
-
-func isDataCacheEnabledNodePool(ctx context.Context, nodeName string) (bool, error) {
-	if !*enableDataCacheFlag {
-		return false, nil
-	}
-	if len(nodeName) > 0 && nodeName != common.TestNode { // disregard logic below when E2E testing.
-		dataCacheLSSDCount, err := driver.GetDataCacheCountFromNodeLabel(ctx, nodeName)
-		return dataCacheLSSDCount != 0, err
-	}
-	return true, nil
 }
 
 func fetchLssdsForRaiding(lssdCount int) ([]string, error) {

--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -613,7 +613,7 @@ func (ns *GCENodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUns
 
 	// The NodeUnstageVolume does not have any volume or publish context, we need to get the info from LVM locally
 	// Check if cache group cache-{volumeID} exist in LVM
-	if ns.EnableDataCache {
+	if ns.EnableDataCache && ns.DataCacheEnabledNodePool {
 		nodeId := ns.MetadataService.GetName()
 		err := cleanupCache(volumeID, nodeId)
 		if err != nil {

--- a/pkg/gce-pd-csi-driver/utils.go
+++ b/pkg/gce-pd-csi-driver/utils.go
@@ -339,3 +339,17 @@ func containsZone(zones []string, zone string) bool {
 
 	return false
 }
+
+func IsDataCacheEnabledNodePool(ctx context.Context, nodeName string, enableDataCacheFlag bool) (bool, error) {
+	if !enableDataCacheFlag {
+		return false, nil
+	}
+	if nodeName == common.TestNode { // disregard logic below when E2E testing.
+		return true, nil
+	}
+	if len(nodeName) > 0 {
+		dataCacheLSSDCount, err := GetDataCacheCountFromNodeLabel(ctx, nodeName)
+		return dataCacheLSSDCount != 0, err
+	}
+	return false, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
 /kind bug


**What this PR does / why we need it**:
We recently had an issue where data cache related watcher was running on non-data cache nodes as we were defaulting to `true` so updating the default values here to `false`
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Disabling data cache watcher by default if node details are not available.
```
