### PR TITLE
Remove check on snapshot create support for multi-writer HyperDisk-HA

### DIFF
--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -1620,9 +1620,6 @@ func (gceCS *GCEControllerServer) CreateSnapshot(ctx context.Context, req *csi.C
 		}
 		return nil, common.LoggedError("CreateSnapshot, failed to getDisk: ", err)
 	}
-	if common.IsHyperdisk(disk.GetPDType()) && disk.GetAccessMode() == common.GCEReadWriteManyAccessMode {
-		return nil, status.Errorf(codes.InvalidArgument, "Cannot create snapshot for disk type %s with access mode %s", common.DiskTypeHdHA, common.GCEReadWriteManyAccessMode)
-	}
 
 	snapshotParams, err := common.ExtractAndDefaultSnapshotParameters(req.GetParameters(), gceCS.Driver.name, gceCS.Driver.extraTags)
 	if err != nil {

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -265,24 +265,6 @@ func TestCreateSnapshotArguments(t *testing.T) {
 				ReadyToUse:     false,
 			},
 		},
-		{
-			name: "fail to create snapshot for HdHA multi-writer",
-			req: &csi.CreateSnapshotRequest{
-				Name:           name,
-				SourceVolumeId: testRegionalID,
-				Parameters:     map[string]string{common.ParameterKeyStorageLocations: " US-WEST2"},
-			},
-			seedDisks: []*gce.CloudDisk{
-				gce.CloudDiskFromV1(&compute.Disk{
-					Name:       name,
-					SelfLink:   fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/project/regions/country-region/name/%s", name),
-					Type:       common.DiskTypeHdHA,
-					AccessMode: common.GCEReadWriteManyAccessMode,
-					Region:     "country-region",
-				}),
-			},
-			expErrCode: codes.InvalidArgument,
-		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Let such validations occur at the PD control plane layer as the support will evolve/change going forward and it's better for the CSI-driver layer to not test such supportability.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
bug


**What this PR does / why we need it**:
Removes an unnecessary and potentially incorrect check that multi-writer Hyperdisk doesn't support snapshot. Hyperdisk is in the process of supporting this functionality and the CSI-driver must defer such checks to the PD control plane.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
