### PR TITLE
pkg/common/utils.go: update regionalLocationFmt for Europe with 10+ regions

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -71,7 +71,7 @@ const (
 	// Example: us
 	multiRegionalLocationFmt = "^[a-z]+$"
 	// Example: us-east1
-	regionalLocationFmt = "^[a-z]+-[a-z]+[0-9]+$"
+	regionalLocationFmt = "^[a-z]+-[a-z]+[0-9]{1,2}$"
 
 	// Full or partial URL of the machine type resource, in the format:
 	//   zones/zone/machineTypes/machine-type

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -71,7 +71,7 @@ const (
 	// Example: us
 	multiRegionalLocationFmt = "^[a-z]+$"
 	// Example: us-east1
-	regionalLocationFmt = "^[a-z]+-[a-z]+[0-9]$"
+	regionalLocationFmt = "^[a-z]+-[a-z]+[0-9]+$"
 
 	// Full or partial URL of the machine type resource, in the format:
 	//   zones/zone/machineTypes/machine-type

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -805,9 +805,15 @@ func TestSnapshotStorageLocations(t *testing.T) {
 			false,
 		},
 		{
+			"valid region in large continent",
+			"europe-west12",
+			[]string{"europe-west12"},
+			false,
+		},
+		{
 			// Zones are not valid bucket/snapshot locations.
 			"single zone",
-			"us-east1a",
+			"us-east1-a",
 			[]string{},
 			true,
 		},


### PR DESCRIPTION
GCP now offers more than 10 regions in Europe. Update the regex accordingly.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This driver does not work in europe-west10, 11 and 12. Tested in europe-west-12 (Turin, Italy) and got:
```
Failed to create snapshot: failed to take snapshot of the volume projects/own-lab-462214/zones/europe-west12-a/disks/pvc-da12fb90-1832-4e6c-9187-24f4ab3f64d9: "rpc error: code = InvalidArgument desc = Invalid snapshot parameters: invalid location for snapshot: \"europe-west12\""
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I need this please 🙏 This looks broken.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

