### PR TITLE
Added filtering for incorrect slo boosting logs

### DIFF
--- a/pkg/gce-cloud-provider/compute/gce.go
+++ b/pkg/gce-cloud-provider/compute/gce.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"runtime"
 	"sync"
 	"time"
@@ -75,6 +76,11 @@ const (
 	// gcpTagsRequestTokenBucketSize is the burst/token bucket size used
 	// for limiting API requests.
 	gcpTagsRequestTokenBucketSize = 8
+)
+
+var (
+	ssAlreadyExistsRegex = regexp.MustCompile("The resource [^']+ already exists")
+	gcpViolationRegex    = regexp.MustCompile("violates constraint constraints/gcp.")
 )
 
 // ResourceType indicates the type of a compute resource.
@@ -440,4 +446,14 @@ func IsGCENotFoundError(err error) bool {
 // invalid reason
 func IsGCEInvalidError(err error) bool {
 	return IsGCEError(err, "invalid")
+}
+
+// IsSnapshotAlreadyExistsError checks if the error is a snapshot already exists error.
+func IsSnapshotAlreadyExistsError(err error) bool {
+	return ssAlreadyExistsRegex.MatchString(err.Error())
+}
+
+// IsGCPOrgViolationError checks if the error is a GCP organization policy violation error.
+func IsGCPOrgViolationError(err error) bool {
+	return gcpViolationRegex.MatchString(err.Error())
 }

--- a/pkg/gce-cloud-provider/compute/gce_test.go
+++ b/pkg/gce-cloud-provider/compute/gce_test.go
@@ -108,9 +108,19 @@ func TestErrorIsGCPViolationRegex(t *testing.T) {
 		expectedResult bool
 	}{
 		{
-			name:           "is gcp org violation error",
-			inputErr:       errors.New("Your api request violates constraint constraints/gcp.resourceLocations"),
+			name:           "is gcp org violation error, error code 400",
+			inputErr:       errors.New("Failed to scale up: googleapi: Error 400: 'us-central1' violates constraint '`constraints/gcp.resourceLocations`' on the resource 'projects/test-project/locations/us-central1/clusters/test-cluster/nodePools/test-node-pool'"),
 			expectedResult: true,
+		},
+		{
+			name:           "is gcp org violation error, error code 412",
+			inputErr:       errors.New("createSnapshot for content [snapcontent-xyz]: error occurred in createSnapshotWrapper: failed to take snapshot of the volume projects/test-project/regions/europe-west3/disks/pvc-test: \"rpc error: code = Internal desc = Failed to create snapshot: googleapi: Error 412: Location EU violates constraint constraints/gcp.resourceLocations on the resource projects/test-project/global/snapshots/snapshot-xyz., conditionNotMet\""),
+			expectedResult: true,
+		},
+		{
+			name:           "is not gcp org violation, error doesn't match",
+			inputErr:       errors.New("createSnapshot for content [snapcontent-xyz]: error occurred in createSnapshotWrapper: failed to take snapshot of the volume projects/test-project/regions/europe-west3/disks/pvc-test: \"rpc error: code = Internal desc = Failed to create snapshot: googleapi: Error 500: Location EU violates constraint constraints/gcp.resourceLocations on the resource projects/test-project/global/snapshots/snapshot-xyz., conditionNotMet\""),
+			expectedResult: false,
 		},
 		{
 			name:           "is not gcp org violation error",
@@ -135,12 +145,12 @@ func TestErrorIsSnapshotExistsError(t *testing.T) {
 		expectedResult bool
 	}{
 		{
-			name:           "is ss error",
-			inputErr:       errors.New("The resource projects/dcme-pre-opt-mdp-rmp-00/global/snapshots/snapshot-3c208602-d815-40ae-a61e-3259e3bd29ca already exists, alreadyExists"),
+			name:           "is snapshot already exists error",
+			inputErr:       errors.New("The resource projects/test-project/global/snapshots/snapshot-xyz already exists, alreadyExists"),
 			expectedResult: true,
 		},
 		{
-			name:           "is not ss already exists error",
+			name:           "is not snapshot already exists error",
 			inputErr:       errors.New("Some incorrect error message"),
 			expectedResult: false,
 		},

--- a/pkg/gce-cloud-provider/compute/gce_test.go
+++ b/pkg/gce-cloud-provider/compute/gce_test.go
@@ -101,6 +101,60 @@ func TestIsGCEError(t *testing.T) {
 	}
 }
 
+func TestErrorIsGCPViolationRegex(t *testing.T) {
+	testCases := []struct {
+		name           string
+		inputErr       error
+		expectedResult bool
+	}{
+		{
+			name:           "is gcp org violation error",
+			inputErr:       errors.New("Your api request violates constraint constraints/gcp.resourceLocations"),
+			expectedResult: true,
+		},
+		{
+			name:           "is not gcp org violation error",
+			inputErr:       errors.New("Some incorrect error message"),
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Logf("Running test: %v", tc.name)
+		result := IsGCPOrgViolationError(tc.inputErr)
+		if tc.expectedResult != result {
+			t.Fatalf("Got '%t', expected '%t'", result, tc.expectedResult)
+		}
+	}
+}
+
+func TestErrorIsSnapshotExistsError(t *testing.T) {
+	testCases := []struct {
+		name           string
+		inputErr       error
+		expectedResult bool
+	}{
+		{
+			name:           "is ss error",
+			inputErr:       errors.New("The resource projects/dcme-pre-opt-mdp-rmp-00/global/snapshots/snapshot-3c208602-d815-40ae-a61e-3259e3bd29ca already exists, alreadyExists"),
+			expectedResult: true,
+		},
+		{
+			name:           "is not ss already exists error",
+			inputErr:       errors.New("Some incorrect error message"),
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Logf("Running test: %v", tc.name)
+		result := IsSnapshotAlreadyExistsError(tc.inputErr)
+		if tc.expectedResult != result {
+			t.Fatalf("Got '%t', expected '%t'", result, tc.expectedResult)
+		}
+	}
+}
+
 func TestGetComputeVersion(t *testing.T) {
 	testCases := []struct {
 		name               string

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -1668,6 +1668,16 @@ func (gceCS *GCEControllerServer) createPDSnapshot(ctx context.Context, project 
 			if gce.IsGCEError(err, "notFound") {
 				return nil, status.Errorf(codes.NotFound, "Could not find volume with ID %v: %v", volKey.String(), err.Error())
 			}
+
+			// Identified as incorrect error handling
+			if gce.IsSnapshotAlreadyExistsError(err) {
+				return nil, status.Errorf(codes.AlreadyExists, "Snapshot already exists: %v", err.Error())
+			}
+
+			// Identified as incorrect error handling
+			if gce.IsGCPOrgViolationError(err) {
+				return nil, status.Errorf(codes.FailedPrecondition, "Violates GCP org policy: %v", err.Error())
+			}
 			return nil, common.LoggedError("Failed to create snapshot: ", err)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Recently we were out of SLO for the PDCSI CreateSnapshot endpoint. After analysis of the errors contributing to our slo we have identified the issue to be an excessive amount of INTERNAL errors. Further analysis of these internal errors has brought to light two major types of errors that are being incorrectly tagged as internal. These should not be contributing to our slos, they are the following:
Already exists errors should be converted from INTERNAL to ALREADY_EXISTS
Org policy violations should be converted from INTERNAL to FAILED_PRECONDITION

These errors are both returned from the create snapshot gcp endpoint

This change introduces methods that use regex to identify these two types of errors in the response payload and correctly marks them as ALREADY_EXISTS and FAILED_PRECONDITION errors.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://b.corp.google.com/issues/398008774
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
