### PR TITLE
Switch to nanoserver images for windows.  They're smaller and faster!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ DRIVERWINDOWSBINARY=${DRIVERBINARY}.exe
 
 DOCKER=DOCKER_CLI_EXPERIMENTAL=enabled docker
 
-BASE_IMAGE_LTSC2019=mcr.microsoft.com/windows/servercore:ltsc2019
-BASE_IMAGE_LTSC2022=mcr.microsoft.com/windows/servercore:ltsc2022
+BASE_IMAGE_LTSC2019=mcr.microsoft.com/windows/nanoserver:ltsc2019
+BASE_IMAGE_LTSC2022=mcr.microsoft.com/windows/nanoserver:ltsc2022
 
 # Both arrays MUST be index aligned.
 WINDOWS_IMAGE_TAGS=ltsc2019


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Windows builds are very slow!  This is partially due to the size of the servercore base images we use.

Change to `nanoserver` images removes much of the bloat (UIs, lots of parts of windows).

I tested the `build-and-push...` commands for both windows versions with servercore and nanoserver:

```
Servercore: lstc2019 took 8 min, 21 seconds
Nanoserver: ltsc2019 took 3 min, 38 seconds

Servercore: ltsc2022 took 8 min, 29 seconds
Nanoserver: ltsc2022 took 1 min, 45 seconds
```

Big improvements!  Let's see if it passes the tests.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
