### PR TITLE
fix: update Hyperdisk attach limits to match GCP documentation for Ge…

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -65,15 +65,42 @@ const (
 	AttachLimitOverrideLabel   = "gke-volume-attach-limit-override"
 )
 
-// doc https://cloud.google.com/compute/docs/disks/hyperdisks#max-total-disks-per-vm
-var Gen4MachineHyperdiskAttachLimitMap = []struct {
+// doc https://cloud.google.com/compute/docs/general-purpose-machines
+// MachineHyperdiskLimit represents the mapping between max vCPUs and hyperdisk (balanced) attach limit
+type MachineHyperdiskLimit struct {
 	max   int64
 	value int64
-}{
+}
+
+// C4 Machine Types - Hyperdisk Balanced Limits
+var C4MachineHyperdiskAttachLimitMap = []MachineHyperdiskLimit{
+	{max: 2, value: 7},
 	{max: 4, value: 15},
-	{max: 8, value: 23},
-	{max: 16, value: 31},
-	{max: 32, value: 49},
-	{max: 64, value: 63},
-	{max: 1024, value: 127},
+	{max: 24, value: 31},
+	{max: 48, value: 63},
+	{max: 96, value: 127},
+}
+
+// C4D Machine Types - Hyperdisk Balanced Limits
+var C4DMachineHyperdiskAttachLimitMap = []MachineHyperdiskLimit{
+	{max: 2, value: 3},
+	{max: 4, value: 7},
+	{max: 8, value: 15},
+	{max: 96, value: 31},
+	{max: 192, value: 63},
+	{max: 384, value: 127},
+}
+
+// N4 Machine Types - Hyperdisk Balanced Limits
+var N4MachineHyperdiskAttachLimitMap = []MachineHyperdiskLimit{
+	{max: 8, value: 15},
+	{max: 80, value: 31},
+}
+
+// C4A Machine Types - Hyperdisk Balanced Limits
+var C4AMachineHyperdiskAttachLimitMap = []MachineHyperdiskLimit{
+	{max: 2, value: 7},
+	{max: 8, value: 15},
+	{max: 48, value: 31},
+	{max: 72, value: 63},
 }

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -762,14 +762,39 @@ func ShortString(s string) string {
 	return string(short)
 }
 
-// MapNumber is a function to map input cpu number to the Hyperdisk attach limit
-func MapNumber(num int64) int64 {
-	for _, r := range Gen4MachineHyperdiskAttachLimitMap {
-		if num <= r.max {
-			return r.value
+// GetHyperdiskAttachLimit returns the hyperdisk attach limit based on machine type prefix and vCPUs
+func GetHyperdiskAttachLimit(machineTypePrefix string, vCPUs int64) int64 {
+	var limitMap []MachineHyperdiskLimit
+
+	switch machineTypePrefix {
+	case "c4":
+		limitMap = C4MachineHyperdiskAttachLimitMap
+	case "c4d":
+		limitMap = C4DMachineHyperdiskAttachLimitMap
+	case "n4":
+		limitMap = N4MachineHyperdiskAttachLimitMap
+	case "c4a":
+		limitMap = C4AMachineHyperdiskAttachLimitMap
+	default:
+		// Fallback to the most conservative Gen4 map for unknown types
+		return MapNumber(vCPUs, C4DMachineHyperdiskAttachLimitMap)
+	}
+
+	return MapNumber(vCPUs, limitMap)
+}
+
+// mapNumber maps the vCPUs to the appropriate hyperdisk limit
+func MapNumber(vCPUs int64, limitMap []MachineHyperdiskLimit) int64 {
+	for _, limit := range limitMap {
+		if vCPUs <= limit.max {
+			return limit.value
 		}
 	}
-	return 0
+	// Return the last value if vCPUs exceeds all max values
+	if len(limitMap) > 0 {
+		return limitMap[len(limitMap)-1].value
+	}
+	return 15
 }
 
 func DiskTypeLabelKey(diskType string) string {

--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -858,17 +858,19 @@ func (ns *GCENodeServer) GetVolumeLimits(ctx context.Context) (int64, error) {
 				if err != nil {
 					return volumeLimitBig, fmt.Errorf("invalid cpuString %s for machine type: %v", cpuString, machineType)
 				}
-				return common.MapNumber(cpus), nil
+				// Extract the machine type prefix (e.g., "c4", "c4a", "n4")
+				prefix := strings.TrimSuffix(gen4Prefix, "-")
+				return common.GetHyperdiskAttachLimit(prefix, cpus), nil
 			} else {
 				return volumeLimitBig, fmt.Errorf("unconventional machine type: %v", machineType)
 			}
 		}
-		if strings.HasPrefix(machineType, "x4-") {
-			return x4HyperdiskLimit, nil
-		}
-		if strings.HasPrefix(machineType, "a4-") {
-			return a4HyperdiskLimit, nil
-		}
+	}
+	if strings.HasPrefix(machineType, "x4-") {
+		return x4HyperdiskLimit, nil
+	}
+	if strings.HasPrefix(machineType, "a4-") {
+		return a4HyperdiskLimit, nil
 	}
 
 	return volumeLimitBig, nil

--- a/pkg/gce-pd-csi-driver/node_test.go
+++ b/pkg/gce-pd-csi-driver/node_test.go
@@ -279,6 +279,11 @@ func TestNodeGetVolumeLimits(t *testing.T) {
 			expVolumeLimit: 63,
 		},
 		{
+			name:           "c4-standard-2",
+			machineType:    "c4-standard-2",
+			expVolumeLimit: 7,
+		},
+		{
 			name:           "c4a-standard-4",
 			machineType:    "c4a-standard-4",
 			expVolumeLimit: 15,
@@ -302,7 +307,7 @@ func TestNodeGetVolumeLimits(t *testing.T) {
 		{
 			name:           "n4-custom-8-12345-ext",
 			machineType:    "n4-custom-8-12345-ext",
-			expVolumeLimit: 23,
+			expVolumeLimit: 15,
 		},
 		{
 			name:           "n4-custom-16-12345",
@@ -338,12 +343,12 @@ func TestNodeGetVolumeLimits(t *testing.T) {
 		{
 			name:           "c4a-standard-32-lssd",
 			machineType:    "c4a-standard-32-lssd",
-			expVolumeLimit: 49,
+			expVolumeLimit: 31,
 		},
 		{
 			name:           "c4d-standard-32",
 			machineType:    "c4d-standard-32",
-			expVolumeLimit: 49,
+			expVolumeLimit: 31,
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:
This PR updates the Hyperdisk balanced attach limits to align with the latest GCP documentation for Gen4 machine families (`C4`, `C4D`, `N4`, and `C4A`).
Previously, a single generic map was used, which did not reflect the correct per-family attach limits for newer machine types.

Key changes:

* Adds separate Hyperdisk attach limit maps for `C4`, `C4D`, `N4`, and `C4A` machines.
* Updates the attach limit calculation logic to use the appropriate map based on the machine type prefix.
* Updates unit tests to cover new machine type mappings and verify correct limits.

This fixes inaccurate attach limits for Gen4 machines, ensuring compliance with the [[official GCP guidance](https://cloud.google.com/compute/docs/general-purpose-machines)](https://cloud.google.com/compute/docs/general-purpose-machines).

**Which issue(s) this PR fixes**:
Fixes #<!-- TODO: link related issue if you have one -->

**Special notes for your reviewer**:

* Please verify the machine type prefixes and limit values match the official GCP tables.


```release-note
fix: Updated Hyperdisk balanced attach limits for C4, C4D, N4, and C4A machine families to match current GCP documentation.
```