### PR TITLE
Revert the image path change to what it was an increment patch version

### DIFF
--- a/deploy/kubernetes/images/stable-master/image.yaml
+++ b/deploy/kubernetes/images/stable-master/image.yaml
@@ -44,9 +44,8 @@ metadata:
   name: imagetag-gcepd-driver
 imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
-  # Don't change stable image without changing pdImagePlaceholder in
-  # test/k8s-integration/main.go
-  newName: us-central1-docker.pkg.dev/enginakdemir-gke-dev/csi-dev/gcp-compute-persistent-disk-csi-driver
-  newTag: "latest"
+  # pdImagePlaceholder in test/k8s-integration/main.go is updated automatically with the newTag
+  newName: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+  newTag: "v1.17.3"
 ---
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The image.yaml should not use the personal dev projects


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
