### PR TITLE
[btrfs] add btrfs-specific `bdi/read_ahead_kb`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,13 @@ Controller-level and node-level deployments will both have priorityClassName set
 As noted in [GCP PD documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/gce-pd-csi-driver), `ext4` and `xfs` are officially supported. `btrfs` support is experimental:
 - As of writing, Ubuntu VM images support btrfs, but [COS does not](https://cloud.google.com/container-optimized-os/docs/concepts/supported-filesystems).
 
-`btrfs` filesystem accepts two "special" mount options:
+`btrfs` filesystem accepts the following "special" mount options and the sysfs paths they target:
 
-- `btrfs-data-bg_reclaim_threshold`
-- `btrfs-metadata-bg_reclaim_threshold`
+- `btrfs-data-bg_reclaim_threshold`: `/sys/fs/btrfs/FS-UUID/allocation/data/bg_reclaim_threshold`.
+- `btrfs-metadata-bg_reclaim_thresho: `/sys/fs/btrfs/FS-UUID/allocation/metadata/bg_reclaim_threshold`.
+- `btrfs-bdi-read_ahead_kb`: `/sys/fs/btrfs/FS-UUID/bdi/read_ahead_kb`.
 
-Which writes to `/sys/fs/btrfs/FS-UUID/allocation/{,meta}data/bg_reclaim_threshold`, as documented [in btrfs docs](https://btrfs.readthedocs.io/en/latest/ch-sysfs.html#uuid-allocations-data-metadata-system).
+See more in the [in btrfs docs](https://btrfs.readthedocs.io/en/latest/ch-sysfs.html#uuid-allocations-data-metadata-system).
 
 ## Further Documentation
 

--- a/pkg/gce-pd-csi-driver/utils.go
+++ b/pkg/gce-pd-csi-driver/utils.go
@@ -306,16 +306,18 @@ func collectMountOptions(fsType string, mntFlags []string) []string {
 	var options []string
 
 	for _, opt := range mntFlags {
+		// The flags below are special flags that aren't
+		// passed directly as an options to the mount command.
 		if readAheadKBMountFlagRegex.FindString(opt) != "" {
-			// The read_ahead_kb flag is a special flag that isn't
-			// passed directly as an option to the mount command.
 			continue
 		}
-
 		if btrfsReclaimDataRegex.FindString(opt) != "" {
 			continue
 		}
 		if btrfsReclaimMetadataRegex.FindString(opt) != "" {
+			continue
+		}
+		if btrfsReadAheadKBRegex.FindString(opt) != "" {
 			continue
 		}
 


### PR DESCRIPTION
Add a knob for the btrfs-specific `bdi/read_ahead_kb`. AFAIK this value is the upper limit of the btrfs read-ahead of the _underlying file_.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:

Confusingly, this option is not related to `/sys/block/sdX/queue/read_ahead_kb`, which is what controls the read-ahead of the block device (regardless of what's in there). The current `read_ahead_kb` "special" mount option configures the value of the block device.

The default `bdi/read_ahead_kb` is 4MiB (on all the systems I've checked). Ext4 does not have this option and relies on the block-device specific readahead, which is 128KiB (again, on all the systems I've checked). After migrating to btrfs we have experienced a notable read amplification and tracked to this setting. Once we changed `bdi/read_ahead_kb` to 128, our IO utilization (and the properties of the underlying workload) became very similar to the one of ext4.

**Which issue(s) this PR fixes**:

Fixes #2155

**Special notes for your reviewer**:

Now that we have 3 btrfs-specific "special" mount options, I refactored the code and tests to make it less repetitive.

**Does this PR introduce a user-facing change?**:
```release-note
add `btrfs-bdi-read_ahead_kb` to control btrfs-specific readahead.
```
