### PR TITLE
Backport: Update CSI Resizer version

### DIFF
--- a/deploy/kubernetes/images/stable-master/image.yaml
+++ b/deploy/kubernetes/images/stable-master/image.yaml
@@ -15,16 +15,14 @@ imageTag:
   name: registry.k8s.io/sig-storage/csi-attacher
   newTag: "v4.4.3"
 ---
-
 apiVersion: builtin
 kind: ImageTagTransformer
 metadata:
   name: imagetag-csi-resizer
 imageTag:
   name: registry.k8s.io/sig-storage/csi-resizer
-  newTag: "v1.12.0"
+  newTag: "v1.13.2"
 ---
-
 apiVersion: builtin
 kind: ImageTagTransformer
 metadata:
@@ -33,7 +31,6 @@ imageTag:
   name: registry.k8s.io/sig-storage/csi-snapshotter
   newTag: "v7.0.2"
 ---
-
 apiVersion: builtin
 kind: ImageTagTransformer
 metadata:
@@ -42,7 +39,6 @@ imageTag:
   name: registry.k8s.io/sig-storage/csi-node-driver-registrar
   newTag: "v2.9.3"
 ---
-
 apiVersion: builtin
 kind: ImageTagTransformer
 metadata:
@@ -54,3 +50,4 @@ imageTag:
   newName: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
   newTag: "v1.15.0"
 ---
+


### PR DESCRIPTION
In order to support the RecoverVolumeExpansionFailure feature gate and fix tests that are failing as a result, bumping the csi-resizer version to 1.13.2