### PR TITLE
Automated cherry pick of #2112: dafult data cache enabled to false

### DIFF
--- a/cmd/gce-pd-csi-driver/main.go
+++ b/cmd/gce-pd-csi-driver/main.go
@@ -245,7 +245,7 @@ func handle() {
 		if err != nil {
 			klog.Fatalf("Failed to set up metadata service: %v", err.Error())
 		}
-		isDataCacheEnabledNodePool, err := isDataCacheEnabledNodePool(ctx, *nodeName)
+		isDataCacheEnabledNodePool, err := driver.IsDataCacheEnabledNodePool(ctx, *nodeName, *enableDataCacheFlag)
 		if err != nil {
 			klog.Fatalf("Failed to get node info from API server: %v", err.Error())
 		}
@@ -349,17 +349,6 @@ func urlFlag(target **url.URL, name string, usage string) {
 		klog.Errorf("Error parsing endpoint compute endpoint %v", err)
 		return err
 	})
-}
-
-func isDataCacheEnabledNodePool(ctx context.Context, nodeName string) (bool, error) {
-	if !*enableDataCacheFlag {
-		return false, nil
-	}
-	if len(nodeName) > 0 && nodeName != common.TestNode { // disregard logic below when E2E testing.
-		dataCacheLSSDCount, err := driver.GetDataCacheCountFromNodeLabel(ctx, nodeName)
-		return dataCacheLSSDCount != 0, err
-	}
-	return true, nil
 }
 
 func fetchLssdsForRaiding(lssdCount int) ([]string, error) {

--- a/deploy/kubernetes/images/stable-master/image.yaml
+++ b/deploy/kubernetes/images/stable-master/image.yaml
@@ -22,7 +22,7 @@ metadata:
   name: imagetag-csi-resizer
 imageTag:
   name: registry.k8s.io/sig-storage/csi-resizer
-  newTag: "v1.12.0"
+  newTag: "v1.13.2"
 ---
 
 apiVersion: builtin

--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -526,7 +526,7 @@ func (ns *GCENodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUns
 
 	// The NodeUnstageVolume does not have any volume or publish context, we need to get the info from LVM locally
 	// Check if cache group cache-{volumeID} exist in LVM
-	if ns.EnableDataCache {
+	if ns.EnableDataCache && ns.DataCacheEnabledNodePool {
 		nodeId := ns.MetadataService.GetName()
 		err := cleanupCache(volumeID, nodeId)
 		if err != nil {

--- a/pkg/gce-pd-csi-driver/utils.go
+++ b/pkg/gce-pd-csi-driver/utils.go
@@ -331,3 +331,17 @@ func containsZone(zones []string, zone string) bool {
 
 	return false
 }
+
+func IsDataCacheEnabledNodePool(ctx context.Context, nodeName string, enableDataCacheFlag bool) (bool, error) {
+	if !enableDataCacheFlag {
+		return false, nil
+	}
+	if nodeName == common.TestNode { // disregard logic below when E2E testing.
+		return true, nil
+	}
+	if len(nodeName) > 0 {
+		dataCacheLSSDCount, err := GetDataCacheCountFromNodeLabel(ctx, nodeName)
+		return dataCacheLSSDCount != 0, err
+	}
+	return false, nil
+}


### PR DESCRIPTION
Cherry pick of #2112 on release-1.17.

#2112: dafult data cache enabled to false

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Disabling data cache watcher by default if node details are not available.
```