### PR TITLE
Fix partial cache tail latency by correcting the cache chunk size calc

### DIFF
--- a/pkg/gce-pd-csi-driver/cache.go
+++ b/pkg/gce-pd-csi-driver/cache.go
@@ -573,6 +573,7 @@ func isCachingSetup(mainLvName string) (error, bool) {
 	return nil, false
 }
 
+// cacheSize is always in GiB
 func fetchChunkSizeKiB(cacheSize string) (string, error) {
 	var chunkSize float64
 

--- a/pkg/gce-pd-csi-driver/cache.go
+++ b/pkg/gce-pd-csi-driver/cache.go
@@ -576,6 +576,7 @@ func isCachingSetup(mainLvName string) (error, bool) {
 func fetchChunkSizeKiB(cacheSize string) (string, error) {
 	var chunkSize float64
 
+	cacheSize = strings.TrimSuffix(cacheSize, "GiB")
 	cacheSizeInt, err := strconv.ParseInt(cacheSize, 10, 64)
 	if err != nil {
 		return "0", err
@@ -691,10 +692,8 @@ func addRaidedLSSDToVg(vgName, lssdPath string) error {
 
 func fetchPvSizeGiB() (string, error) {
 	args := []string{
-		"--select",
-		"-o",
+		"-o", "pv_name,pv_size",
 		"--noheadings",
-		"pv_size",
 		"--units=b",
 	}
 	// RAIDed device is always registered with its /dev/md127 equivalent in VG so cannot check it directly based on the RAIDed LSSD path which could be /dev/md/csi-driver-data-cache

--- a/pkg/gce-pd-csi-driver/cache_test.go
+++ b/pkg/gce-pd-csi-driver/cache_test.go
@@ -13,23 +13,28 @@ func TestFetchChunkSizeKiB(t *testing.T) {
 	}{
 		{
 			name:         "chunk size is in the allowed range",
-			cacheSize:    "500",
+			cacheSize:    "500GiB",
 			expChunkSize: "512KiB", //range defined in fetchChunkSizeKiB
 		},
 		{
 			name:         "chunk size is set to the range ceil",
-			cacheSize:    "30000000",
+			cacheSize:    "30000000GiB",
 			expChunkSize: "1048576KiB", //range defined in fetchChunkSizeKiB - max 1GiB
 		},
 		{
 			name:         "chunk size is set to the allowed range floor",
-			cacheSize:    "100",
+			cacheSize:    "100GiB",
 			expChunkSize: "160KiB", //range defined in fetchChunkSizeKiB - min 160 KiB
 		},
 		{
 			name:         "cacheSize set to KiB also sets the chunk size to range floor",
-			cacheSize:    "1",
+			cacheSize:    "1GiB",
 			expChunkSize: "160KiB", //range defined in fetchChunkSizeKiB - min 160 KiB
+		},
+		{
+			name:         "chunk size with GiB string parses correctly",
+			cacheSize:    "375GiB",
+			expChunkSize: "384KiB",
 		},
 		{
 			name:         "invalid cacheSize",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The GKE Data Cache was exhibiting extreme tail latency on partially
cached volumes, performing significantly worse than non-cached volumes.
Initial investigation into LVM cache policies and `atime`-induced
write-back thrashing did not reveal the root cause.

A series of `fio` benchmarks comparing cached and uncached volumes
uncovered a bug where the LVM cache was being configured with a
massive 1 GB chunk size. This was traced to a failure in the
`fetchPvSizeGiB` function in `cache.go`. The `pvs` command syntax was
malformed, and a subsequent string parsing error on its empty output
caused the driver to fall back to the default `maxChunkSize` of 1 GB.

This 1 GB chunk size led to extreme "read and write amplification," where a
single 4KB cache miss would trigger an inefficient 1 GB read from the
backing disk, explaining the catastrophic per-miss penalty.

This change corrects the `pvs` command syntax and the string parsing
logic within the driver. With this fix, the cache is now correctly
configured with a reasonable chunk size (e.g., 384 KiB), which resolves
the extreme read and write amplification and restores performance to expected
levels.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fix partial data cache tail latency by correcting the cache chunk size calc
```
