### PR TITLE
Move wg.Add outside of gofunc in setup_e2e_test

### DIFF
--- a/test/e2e/tests/setup_e2e_test.go
+++ b/test/e2e/tests/setup_e2e_test.go
@@ -120,8 +120,8 @@ var _ = BeforeSuite(func() {
 				tcc <- NewDefaultTestContext(curZone, strconv.Itoa(randInt))
 			}(zone, j)
 		}
+		wg.Add(1)
 		go func(curZone string) {
-			wg.Add(1)
 			defer GinkgoRecover()
 			defer wg.Done()
 			hdtcc <- NewTestContext(curZone, *hdMinCpuPlatform, *hdMachineType, "0")

--- a/test/remote/instance.go
+++ b/test/remote/instance.go
@@ -248,9 +248,9 @@ func (i *InstanceInfo) CreateOrGetInstance(localSSDCount int) error {
 			i.externalIP = externalIP
 		}
 
-		if sshOut, err := i.SSHCheckAlive(); err != nil {
+		if err := i.SSHCheckAlive(); err != nil {
 			err = fmt.Errorf("Instance %v in state RUNNING but not available by SSH: %v", i.cfg.Name, err.Error())
-			klog.Warningf("SSH encountered an error: %v, output: %v", err, sshOut)
+			klog.Warningf("SSH encountered an error: %v", err)
 			return false, nil
 		}
 		klog.V(4).Infof("Instance %v in state RUNNING and available by SSH", i.cfg.Name)


### PR DESCRIPTION
/kind cleanup

Fix waitgroup usage in setup_e2e_test, for govet error discovered in #2178.

Also trying to fix flakes on ssh (I suspect C3s may have more delay from the instance going ready to ssh being available than n2s?)

```release-note
None
```
