### PR TITLE
feat: Instrument node metrics for unexpected device path changes

### DIFF
--- a/cmd/gce-pd-csi-driver/main.go
+++ b/cmd/gce-pd-csi-driver/main.go
@@ -174,6 +174,7 @@ func handle() {
 				klog.Errorf("Failed to emit process start time: %v", err.Error())
 			}
 			mm.RegisterMountMetric()
+			mm.RegisterUnexpectedDevicePathChangesMetric()
 		}
 		metricsManager = &mm
 	}
@@ -282,7 +283,7 @@ func handle() {
 			klog.Fatalf("Failed to get node info from API server: %v", err.Error())
 		}
 
-		deviceCache, err := linkcache.NewDeviceCacheForNode(ctx, *diskCacheSyncPeriod, *nodeName, driverName, deviceUtils)
+		deviceCache, err := linkcache.NewDeviceCacheForNode(ctx, *diskCacheSyncPeriod, *nodeName, driverName, deviceUtils, metricsManager)
 		if err != nil {
 			klog.Warningf("Failed to create device cache: %v", err.Error())
 		} else {

--- a/pkg/linkcache/devices_windows.go
+++ b/pkg/linkcache/devices_windows.go
@@ -8,9 +8,10 @@ import (
 
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/deviceutils"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/metrics"
 )
 
-func NewDeviceCacheForNode(ctx context.Context, period time.Duration, nodeName string, driverName string, deviceUtils deviceutils.DeviceUtils) (*DeviceCache, error) {
+func NewDeviceCacheForNode(ctx context.Context, period time.Duration, nodeName string, driverName string, deviceUtils deviceutils.DeviceUtils, metricsManager *metrics.MetricsManager) (*DeviceCache, error) {
 	klog.Infof("NewDeviceCacheForNode is not implemented for Windows")
 	return nil, nil
 }

--- a/pkg/linkcache/types.go
+++ b/pkg/linkcache/types.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/deviceutils"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/metrics"
 )
 
 type deviceMapping struct {
@@ -17,6 +18,7 @@ type DeviceCache struct {
 	symlinks map[string]deviceMapping
 	period   time.Duration
 	// dir is the directory to look for device symlinks
-	dir         string
-	deviceUtils deviceutils.DeviceUtils
+	dir            string
+	deviceUtils    deviceutils.DeviceUtils
+	metricsManager *metrics.MetricsManager
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -63,6 +63,15 @@ var (
 	},
 		[]string{"driver_name", "file_system_format", "error_type"},
 	)
+
+	unexpectedDevicePathChangesMetric = metrics.NewCounterVec(&metrics.CounterOpts{
+		Subsystem:      "node",
+		Name:           "unexpected_device_path_changes",
+		Help:           "Unexpected device path changes",
+		StabilityLevel: metrics.ALPHA,
+	},
+		[]string{"driver_name"},
+	)
 )
 
 type MetricsManager struct {
@@ -92,6 +101,10 @@ func (mm *MetricsManager) RegisterMountMetric() {
 	mm.registry.MustRegister(mountErrorMetric)
 }
 
+func (mm *MetricsManager) RegisterUnexpectedDevicePathChangesMetric() {
+	mm.registry.MustRegister(unexpectedDevicePathChangesMetric)
+}
+
 func (mm *MetricsManager) recordComponentVersionMetric() error {
 	v := getEnvVar(envGKEPDCSIVersion)
 	if v == "" {
@@ -119,6 +132,11 @@ func (mm *MetricsManager) RecordMountErrorMetric(fs_format string, err error) {
 	errType := mountErrorType(err)
 	mountErrorMetric.WithLabelValues(pdcsiDriverName, fs_format, errType).Inc()
 	klog.Infof("Recorded mount error type: %q", errType)
+}
+
+func (mm *MetricsManager) RecordUnexpectedDevicePathChangesMetric() {
+	unexpectedDevicePathChangesMetric.WithLabelValues(pdcsiDriverName).Inc()
+	klog.Infof("Recorded unexpected device path change")
 }
 
 func (mm *MetricsManager) EmmitProcessStartTime() error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
>
> /kind feature

**What this PR does / why we need it**:
Adds a new metric, `unexpected_device_path_changes`, to track unexpected device path changes. This metric is incremented whenever the device path for a volume changes, as detected by the linkcache's periodic check.

This helps in monitoring and alerting on potentially unstable device paths, which can be an indicator of underlying issues.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add a new node server metric `unexpected_device_path_changes` to track unexpected device path changes.
```
