### PR TITLE
Adds a 4-hour maintenance exclusion window to the GKE cluster creation process in the integration tests

### DIFF
--- a/test/k8s-integration/cluster.go
+++ b/test/k8s-integration/cluster.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
@@ -205,6 +206,13 @@ func clusterUpGKE(gceZone, gceRegion string, numNodes int, numWindowsNodes int, 
 	cmdParams := []string{"container", "clusters", "create", *gkeTestClusterName,
 		locationArg, locationVal, "--num-nodes", strconv.Itoa(numNodes),
 		"--quiet", "--machine-type", "n1-standard-2", "--no-enable-autoupgrade"}
+
+	// To avoid unexpected GKE maintenance, create a 4-hour maintenance exclusion window.
+	t := time.Now().UTC()
+	cmdParams = append(cmdParams, "--maintenance-exclusion",
+		"start="+t.Format("2006-01-02T15:04:05Z")+
+			",end="+t.Add(4*time.Hour).Format("2006-01-02T15:04:05Z")+
+			",name=e2e-test")
 
 	if imageType == "win2019" || imageType == "win2022" {
 		cmdParams = append(cmdParams, "--image-type", "WINDOWS_LTSC_CONTAINERD")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind flake

**What this PR does / why we need it**:
This prevents unexpected upgrade disruptions during test runs by ensuring that GKE maintenance does not occur while tests are in progress. Our tests have been flaking more frequently because of this.

This change does not impact https://testgrid.canary.kubernetes.io/provider-gcp-compute-persistent-disk-csi-driver

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
