### PR TITLE
Unpublish legacy volume even if it appears in multiple zones

### DIFF
--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -30,7 +30,6 @@ import (
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
-	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/constants"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/parameters"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -103,35 +102,8 @@ func (cloud *FakeCloudProvider) GetDefaultZone() string {
 	return cloud.zone
 }
 
-func (cloud *FakeCloudProvider) RepairUnderspecifiedVolumeKey(ctx context.Context, project string, volumeKey *meta.Key) (string, *meta.Key, error) {
-	if project == constants.UnspecifiedValue {
-		project = cloud.project
-	}
-	switch volumeKey.Type() {
-	case meta.Zonal:
-		if volumeKey.Zone != constants.UnspecifiedValue {
-			return project, volumeKey, nil
-		}
-		for diskVolKey, d := range cloud.disks {
-			if diskVolKey == volumeKey.String() {
-				volumeKey.Zone = d.GetZone()
-				return project, volumeKey, nil
-			}
-		}
-		return "", nil, notFoundError()
-	case meta.Regional:
-		if volumeKey.Region != constants.UnspecifiedValue {
-			return project, volumeKey, nil
-		}
-		r, err := common.GetRegionFromZones([]string{cloud.zone})
-		if err != nil {
-			return "", nil, fmt.Errorf("failed to get region from zones: %w", err)
-		}
-		volumeKey.Region = r
-		return project, volumeKey, nil
-	default:
-		return "", nil, fmt.Errorf("Volume key %v not zonal nor regional", volumeKey.Name)
-	}
+func (cloud *FakeCloudProvider) RepairUnderspecifiedVolumeKey(ctx context.Context, project string, volumeKey *meta.Key, fallbackZone string) (string, *meta.Key, error) {
+	return repairUnderspecifiedVolumeKeyWithProvider(ctx, cloud, project, volumeKey, fallbackZone)
 }
 
 func (cloud *FakeCloudProvider) ListZones(ctx context.Context, region string) ([]string, error) {

--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -39,7 +40,6 @@ import (
 	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/constants"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/parameters"
@@ -101,7 +101,7 @@ type GCECompute interface {
 	GetDefaultZone() string
 	// Disk Methods
 	GetDisk(ctx context.Context, project string, volumeKey *meta.Key) (*CloudDisk, error)
-	RepairUnderspecifiedVolumeKey(ctx context.Context, project string, volumeKey *meta.Key) (string, *meta.Key, error)
+	RepairUnderspecifiedVolumeKey(ctx context.Context, project string, volumeKey *meta.Key, fallbackZone string) (string, *meta.Key, error)
 	InsertDisk(ctx context.Context, project string, volKey *meta.Key, params parameters.DiskParameters, capBytes int64, capacityRange *csi.CapacityRange, replicaZones []string, snapshotID string, volumeContentSourceVolumeID string, multiWriter bool, accessMode string) error
 	DeleteDisk(ctx context.Context, project string, volumeKey *meta.Key) error
 	UpdateDisk(ctx context.Context, project string, volKey *meta.Key, existingDisk *CloudDisk, params parameters.ModifyVolumeParameters) error
@@ -292,26 +292,30 @@ func (cloud *CloudProvider) listInstancesForProject(service *computev1.Service, 
 
 // RepairUnderspecifiedVolumeKey will query the cloud provider and check each zone for the disk specified
 // by the volume key and return a volume key with a correct zone
-func (cloud *CloudProvider) RepairUnderspecifiedVolumeKey(ctx context.Context, project string, volumeKey *meta.Key) (string, *meta.Key, error) {
+func (cloud *CloudProvider) RepairUnderspecifiedVolumeKey(ctx context.Context, project string, volumeKey *meta.Key, fallbackZone string) (string, *meta.Key, error) {
+	return repairUnderspecifiedVolumeKeyWithProvider(ctx, cloud, project, volumeKey, fallbackZone)
+}
+
+func repairUnderspecifiedVolumeKeyWithProvider(ctx context.Context, cloud GCECompute, project string, volumeKey *meta.Key, fallbackZone string) (string, *meta.Key, error) {
 	klog.V(5).Infof("Repairing potentially underspecified volume key %v", volumeKey)
 	if project == constants.UnspecifiedValue {
-		project = cloud.project
+		project = cloud.GetDefaultProject()
 	}
-	region, err := common.GetRegionFromZones([]string{cloud.zone})
+	region, err := common.GetRegionFromZones([]string{cloud.GetDefaultZone()})
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to get region from zones: %w", err)
 	}
 	switch volumeKey.Type() {
 	case meta.Zonal:
-		foundZone := ""
 		if volumeKey.Zone == constants.UnspecifiedValue {
 			// list all zones, try to get disk in each zone
 			zones, err := cloud.ListZones(ctx, region)
 			if err != nil {
 				return "", nil, err
 			}
+			diskZones := []string{}
 			for _, zone := range zones {
-				_, err := cloud.getZonalDiskOrError(ctx, project, zone, volumeKey.Name)
+				_, err := cloud.GetDisk(ctx, project, &meta.Key{Name: volumeKey.Name, Zone: zone})
 				if err != nil {
 					if IsGCENotFoundError(err) {
 						// Couldn't find the disk in this zone so we keep
@@ -322,16 +326,22 @@ func (cloud *CloudProvider) RepairUnderspecifiedVolumeKey(ctx context.Context, p
 					// so we return error immediately
 					return "", nil, err
 				}
-				if len(foundZone) > 0 {
-					return "", nil, fmt.Errorf("found disk %s in more than one zone: %s and %s", volumeKey.Name, foundZone, zone)
-				}
-				foundZone = zone
+				diskZones = append(diskZones, zone)
 			}
 
-			if len(foundZone) == 0 {
+			if len(diskZones) == 0 {
 				return "", nil, notFoundError()
+			} else if len(diskZones) > 1 && fallbackZone == "" {
+				return "", nil, fmt.Errorf("found disk %s in more than one zone and no fallback: %v", volumeKey.Name, diskZones)
+			} else if len(diskZones) > 1 && fallbackZone != "" {
+				if !slices.Contains(diskZones, fallbackZone) {
+					return "", nil, fmt.Errorf("found disk %s in more than one zone (%v) but none match fallback zone %s", volumeKey.Name, diskZones, fallbackZone)
+				}
+				volumeKey.Zone = fallbackZone
+			} else {
+				volumeKey.Zone = diskZones[0]
 			}
-			volumeKey.Zone = foundZone
+
 			return project, volumeKey, nil
 		}
 		return project, volumeKey, nil
@@ -392,22 +402,6 @@ func (cloud *CloudProvider) GetDisk(ctx context.Context, project string, key *me
 	default:
 		return nil, fmt.Errorf("key was neither zonal nor regional, got: %v", key.String())
 	}
-}
-
-func (cloud *CloudProvider) getZonalDiskOrError(ctx context.Context, project, volumeZone, volumeName string) (*computev1.Disk, error) {
-	disk, err := cloud.service.Disks.Get(project, volumeZone, volumeName).Context(ctx).Do()
-	if err != nil {
-		return nil, err
-	}
-	return disk, nil
-}
-
-func (cloud *CloudProvider) getRegionalDiskOrError(ctx context.Context, project, volumeRegion, volumeName string) (*computev1.Disk, error) {
-	disk, err := cloud.service.RegionDisks.Get(project, volumeRegion, volumeName).Context(ctx).Do()
-	if err != nil {
-		return nil, err
-	}
-	return disk, nil
 }
 
 func (cloud *CloudProvider) getZonalBetaDiskOrError(ctx context.Context, project, volumeZone, volumeName string) (*computebeta.Disk, error) {

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -970,7 +970,7 @@ func (gceCS *GCEControllerServer) deleteMultiZoneDisk(ctx context.Context, req *
 func (gceCS *GCEControllerServer) deleteSingleDeviceDisk(ctx context.Context, req *csi.DeleteVolumeRequest, project string, volKey *meta.Key) (*csi.DeleteVolumeResponse, error) {
 	var err error
 	volumeID := req.GetVolumeId()
-	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey)
+	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey, "")
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
 			klog.Warningf("DeleteVolume treating volume as deleted because cannot find volume %v: %v", volumeID, err.Error())
@@ -1146,7 +1146,7 @@ func (gceCS *GCEControllerServer) executeControllerPublishVolume(ctx context.Con
 		volKey = convertMultiZoneVolKeyToZoned(volKey, instanceZone)
 	}
 
-	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey)
+	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey, "")
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
 			return nil, status.Errorf(codes.NotFound, "ControllerPublishVolume could not find volume with ID %v: %v", volumeID, err.Error()), nil
@@ -1294,7 +1294,7 @@ func (gceCS *GCEControllerServer) executeControllerUnpublishVolume(ctx context.C
 		volKey = convertMultiZoneVolKeyToZoned(volKey, instanceZone)
 	}
 
-	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey)
+	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey, instanceZone)
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
 			klog.Warningf("Treating volume %v as unpublished because it could not be found", volumeID)
@@ -1366,7 +1366,7 @@ func (gceCS *GCEControllerServer) ValidateVolumeCapabilities(ctx context.Context
 		return nil, status.Errorf(codes.InvalidArgument, "Volume ID is invalid: %v", err.Error())
 	}
 
-	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey)
+	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey, "")
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
 			return nil, status.Errorf(codes.NotFound, "ValidateVolumeCapabilities could not find volume with ID %v: %v", volumeID, err.Error())
@@ -1962,7 +1962,7 @@ func (gceCS *GCEControllerServer) ControllerExpandVolume(ctx context.Context, re
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "ControllerExpandVolume Volume ID is invalid: %v", err.Error())
 	}
-	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey)
+	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey, "")
 
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

If there are disks with the same name across multiple zones, and a legacy (pre-migration) volume is used, unpublish will fail when trying to reconstruct the full volume key. However, since we have the node when we are unpublishing, we do know the zone and can detach the correct disk.

Failing to do this results in stuck workloads for customers, as if they manually create a node in a second zone before detaching a similarly named one, they can never unpublish.

**Which issue(s) this PR fixes**:

This was found in internal testing in GKE.

```release-note
Unpublish a legacy zonal disk even if there multiple disks with the same name across zones.
```
