### PR TITLE
Return failed precondition googleapi errors

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -97,11 +97,12 @@ var (
 
 	// userErrorCodeMap tells how API error types are translated to error codes.
 	userErrorCodeMap = map[int]codes.Code{
-		http.StatusForbidden:       codes.PermissionDenied,
-		http.StatusBadRequest:      codes.InvalidArgument,
-		http.StatusTooManyRequests: codes.ResourceExhausted,
-		http.StatusNotFound:        codes.NotFound,
-		http.StatusConflict:        codes.FailedPrecondition,
+		http.StatusForbidden:          codes.PermissionDenied,
+		http.StatusBadRequest:         codes.InvalidArgument,
+		http.StatusTooManyRequests:    codes.ResourceExhausted,
+		http.StatusNotFound:           codes.NotFound,
+		http.StatusConflict:           codes.FailedPrecondition,
+		http.StatusPreconditionFailed: codes.FailedPrecondition,
 	}
 
 	csiRetryableErrorCodes = []codes.Code{codes.Canceled, codes.DeadlineExceeded, codes.Unavailable, codes.Aborted, codes.ResourceExhausted}

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -554,6 +554,11 @@ func TestCodeForError(t *testing.T) {
 			inputErr: &TemporaryError{code: codes.Aborted, err: context.Canceled},
 			expCode:  codes.Aborted,
 		},
+		{
+			name:     "CMEK precondition failed error, under layers of wrapping",
+			inputErr: fmt.Errorf("unknown Insert disk error: %w", &googleapi.Error{Code: http.StatusPreconditionFailed, Message: "CMEK policy violated"}),
+			expCode:  codes.FailedPrecondition,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION

**What this PR does / why we need it**:
CreateVolume currently returns an internal error on googleapi error 412 (Failed Precondition), eg attempting to create a volume without cmek in violation of org policy. This burns SLO and it should be returned as failed precondition instead.


```release-note
Return failed precondition on 412 errors (eg, creating a volume without cmek in violation of org policy).
```

/assign @amacaskill 
