### PR TITLE
Unpublish legacy volume even if it appears in multiple zones

### DIFF
--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -101,35 +101,8 @@ func (cloud *FakeCloudProvider) GetDefaultZone() string {
 	return cloud.zone
 }
 
-func (cloud *FakeCloudProvider) RepairUnderspecifiedVolumeKey(ctx context.Context, project string, volumeKey *meta.Key) (string, *meta.Key, error) {
-	if project == common.UnspecifiedValue {
-		project = cloud.project
-	}
-	switch volumeKey.Type() {
-	case meta.Zonal:
-		if volumeKey.Zone != common.UnspecifiedValue {
-			return project, volumeKey, nil
-		}
-		for diskVolKey, d := range cloud.disks {
-			if diskVolKey == volumeKey.String() {
-				volumeKey.Zone = d.GetZone()
-				return project, volumeKey, nil
-			}
-		}
-		return "", nil, notFoundError()
-	case meta.Regional:
-		if volumeKey.Region != common.UnspecifiedValue {
-			return project, volumeKey, nil
-		}
-		r, err := common.GetRegionFromZones([]string{cloud.zone})
-		if err != nil {
-			return "", nil, fmt.Errorf("failed to get region from zones: %w", err)
-		}
-		volumeKey.Region = r
-		return project, volumeKey, nil
-	default:
-		return "", nil, fmt.Errorf("Volume key %v not zonal nor regional", volumeKey.Name)
-	}
+func (cloud *FakeCloudProvider) RepairUnderspecifiedVolumeKey(ctx context.Context, project string, volumeKey *meta.Key, fallbackZone string) (string, *meta.Key, error) {
+	return repairUnderspecifiedVolumeKeyWithProvider(ctx, cloud, project, volumeKey, fallbackZone)
 }
 
 func (cloud *FakeCloudProvider) ListZones(ctx context.Context, region string) ([]string, error) {

--- a/pkg/gce-cloud-provider/compute/gce-compute_test.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute_test.go
@@ -16,9 +16,12 @@ package gcecloudprovider
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	computebeta "google.golang.org/api/compute/v0.beta"
+	"google.golang.org/api/compute/v1"
 	computev1 "google.golang.org/api/compute/v1"
 	"google.golang.org/grpc/codes"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
@@ -327,5 +330,120 @@ func TestCodeForGCEOpError(t *testing.T) {
 		if errCode != tc.expCode {
 			t.Errorf("test %v failed: got %v, expected %v", tc.name, errCode, tc.expCode)
 		}
+	}
+}
+
+func TestRepairUnderspecifiedVolumeKey(t *testing.T) {
+	cloudProvider, err := CreateFakeCloudProvider("project-id", "country-region-fakefirstzone", []*CloudDisk{
+		CloudDiskFromV1(&compute.Disk{
+			Name:     "disk-a",
+			Zone:     "country-region-fakefirstzone",
+			SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/project-id/zones/country-region-fakefirstzone/disks/disk-a"),
+		}),
+		CloudDiskFromV1(&compute.Disk{
+			Name:     "disk-ab",
+			Zone:     "country-region-fakefirstzone",
+			SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/project-id/zones/country-region-fakefirstzone/disks/disk-ab"),
+		}),
+		CloudDiskFromV1(&compute.Disk{
+			Name:     "disk-ab",
+			Zone:     "country-region-fakesecondzone",
+			SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/project-id/zones/country-region-fakesecondzone/disks/disk-ab"),
+		}),
+	})
+	if err != nil {
+		t.Fatalf("can't create fake cloud provider: %v", err)
+	}
+
+	for _, tc := range []struct {
+		testName        string
+		project         string
+		key             meta.Key
+		fallback        string
+		expectedProject string
+		expectedKey     meta.Key
+		expectError     bool
+	}{
+		{
+			testName:        "fully specified",
+			project:         "my-project",
+			key:             meta.Key{Name: "disk", Zone: "zone-1"},
+			expectedProject: "my-project",
+			expectedKey:     meta.Key{Name: "disk", Zone: "zone-1"},
+		},
+		{
+			testName:        "fully specified, fallback ignored",
+			project:         "my-project",
+			key:             meta.Key{Name: "disk", Zone: "zone-1"},
+			fallback:        "zone-2",
+			expectedProject: "my-project",
+			expectedKey:     meta.Key{Name: "disk", Zone: "zone-1"},
+		},
+		{
+			testName:        "unspecified zonal",
+			project:         "UNSPECIFIED",
+			key:             meta.Key{Name: "disk-a", Zone: "UNSPECIFIED"},
+			expectedProject: "project-id",
+			expectedKey:     meta.Key{Name: "disk-a", Zone: "country-region-fakefirstzone"},
+		},
+		{
+			testName:        "unspecified regional",
+			project:         "UNSPECIFIED",
+			key:             meta.Key{Name: "disk-a", Region: "UNSPECIFIED"},
+			expectedProject: "project-id",
+			expectedKey:     meta.Key{Name: "disk-a", Region: "country-region"},
+		},
+		{
+			testName:        "multizone regional",
+			project:         "UNSPECIFIED",
+			key:             meta.Key{Name: "disk-ab", Region: "UNSPECIFIED"},
+			expectedProject: "project-id",
+			expectedKey:     meta.Key{Name: "disk-ab", Region: "country-region"},
+		},
+		{
+			testName:    "multi-zone, no fallback",
+			project:     "project-id",
+			key:         meta.Key{Name: "disk-ab", Zone: "UNSPECIFIED"},
+			expectError: true,
+		},
+		{
+			testName:    "multi-zone, no matching fallback",
+			project:     "project-id",
+			key:         meta.Key{Name: "disk-ab", Zone: "UNSPECIFIED"},
+			fallback:    "unknown-zone",
+			expectError: true,
+		},
+		{
+			testName:        "multi-zone, fallback",
+			project:         "my-project",
+			key:             meta.Key{Name: "disk-ab", Zone: "UNSPECIFIED"},
+			fallback:        "country-region-fakesecondzone",
+			expectedProject: "my-project",
+			expectedKey:     meta.Key{Name: "disk-ab", Zone: "country-region-fakesecondzone"},
+		},
+	} {
+		t.Run(tc.testName, func(t *testing.T) {
+			// RepairUnderspecifiedVolumeKey mutates the argument as well as returning it, sigh. We verify those semantics here
+			key := tc.key
+			prj, retKey, err := cloudProvider.RepairUnderspecifiedVolumeKey(context.Background(), tc.project, &key, tc.fallback)
+			if tc.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got %v", err)
+				}
+				if retKey != &key {
+					t.Error("Did not return argument key")
+				}
+				if prj != tc.expectedProject {
+					t.Errorf("Got project %s, expected %s", prj, tc.expectedProject)
+				}
+				if key.Name != tc.expectedKey.Name || key.Zone != tc.expectedKey.Zone || key.Region != tc.expectedKey.Region {
+					t.Errorf("Got key %+v, expected %+v", key, tc.expectedKey)
+				}
+			}
+		})
 	}
 }

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -967,7 +967,7 @@ func (gceCS *GCEControllerServer) deleteMultiZoneDisk(ctx context.Context, req *
 func (gceCS *GCEControllerServer) deleteSingleDeviceDisk(ctx context.Context, req *csi.DeleteVolumeRequest, project string, volKey *meta.Key) (*csi.DeleteVolumeResponse, error) {
 	var err error
 	volumeID := req.GetVolumeId()
-	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey)
+	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey, "")
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
 			klog.Warningf("DeleteVolume treating volume as deleted because cannot find volume %v: %v", volumeID, err.Error())
@@ -1143,7 +1143,7 @@ func (gceCS *GCEControllerServer) executeControllerPublishVolume(ctx context.Con
 		volKey = convertMultiZoneVolKeyToZoned(volKey, instanceZone)
 	}
 
-	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey)
+	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey, "")
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
 			return nil, status.Errorf(codes.NotFound, "ControllerPublishVolume could not find volume with ID %v: %v", volumeID, err.Error()), nil
@@ -1291,7 +1291,7 @@ func (gceCS *GCEControllerServer) executeControllerUnpublishVolume(ctx context.C
 		volKey = convertMultiZoneVolKeyToZoned(volKey, instanceZone)
 	}
 
-	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey)
+	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey, instanceZone)
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
 			klog.Warningf("Treating volume %v as unpublished because it could not be found", volumeID)
@@ -1363,7 +1363,7 @@ func (gceCS *GCEControllerServer) ValidateVolumeCapabilities(ctx context.Context
 		return nil, status.Errorf(codes.InvalidArgument, "Volume ID is invalid: %v", err.Error())
 	}
 
-	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey)
+	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey, "")
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {
 			return nil, status.Errorf(codes.NotFound, "ValidateVolumeCapabilities could not find volume with ID %v: %v", volumeID, err.Error())
@@ -1959,7 +1959,7 @@ func (gceCS *GCEControllerServer) ControllerExpandVolume(ctx context.Context, re
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "ControllerExpandVolume Volume ID is invalid: %v", err.Error())
 	}
-	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey)
+	project, volKey, err = gceCS.CloudProvider.RepairUnderspecifiedVolumeKey(ctx, project, volKey, "")
 
 	if err != nil {
 		if gce.IsGCENotFoundError(err) {


### PR DESCRIPTION
Manual cherry-pick of #2207

(conflicts due to refactoring of pkg/common).

/kind bug

```release-note
Unpublish a legacy zonal disk even if there multiple disks with the same name across zones.
```
