### PR TITLE
Wrap CreateSnapshot Timeout in DeadlineExceeded Error Code

### DIFF
--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -1579,7 +1579,7 @@ func (cloud *CloudProvider) waitForSnapshotCreation(ctx context.Context, project
 				}
 			}
 		case <-timer.C:
-			return nil, fmt.Errorf("Timeout waiting for snapshot %s to be created.", snapshotName)
+			return nil, status.Errorf(codes.DeadlineExceeded, "Timeout waiting for snapshot %s to be created.", snapshotName)
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently timeout of CreateSnapshot is translated into internal error, which mess around with SLOs. Wrap the error code in DeadlineExceeded error code so we can filter it out. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Wrap CreateSnapshot Timeout in DeadlineExceeded Error Code
```
