### PR TITLE
Return early when node name is empty

### DIFF
--- a/pkg/k8sclient/node.go
+++ b/pkg/k8sclient/node.go
@@ -2,6 +2,7 @@ package k8sclient
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -13,6 +14,9 @@ import (
 )
 
 func GetNodeWithRetry(ctx context.Context, nodeName string) (*v1.Node, error) {
+	if nodeName == "" {
+		return nil, fmt.Errorf("node name is empty")
+	}
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This allows node driver to avoid an unnecessary 15 second startup delay when node name flag isn't set.

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #2200

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
