### PR TITLE
Increase e2e tests timeout for ARM tests

### DIFF
--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -5,9 +5,6 @@ set -x
 
 readonly PKGDIR=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 
-TIMEOUT=50m
-if [ "$RUN_CONTROLLER_MODIFY_VOLUME_TESTS" = true ]; then
-    TIMEOUT=45m
-fi
+TIMEOUT=60m
 
 go test --timeout "${TIMEOUT}" --v "${PKGDIR}/test/e2e/tests" --run-in-prow=true --delete-instances=true --logtostderr $@


### PR DESCRIPTION
**What type of PR is this?**
 /kind failing-test

**What this PR does / why we need it**:
ARM tests failed with [timeout mostly](https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/pr-logs/directory/pull-gcp-compute-persistent-disk-csi-driver-e2e-arm), increasing it as a temp fix.

The original PR for controller modify volume was set to 15mins longer than the base e2e tests, so removing that check as well: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1826

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Increase e2e tests timeout for ARM tests
```
