### PR TITLE
Correctly use the wait group when there is no hyperdisk

### DIFF
--- a/test/e2e/tests/setup_e2e_test.go
+++ b/test/e2e/tests/setup_e2e_test.go
@@ -127,8 +127,8 @@ var _ = BeforeSuite(func() {
 				tcc <- NewDefaultTestContext(curZone, strconv.Itoa(randInt))
 			}(zone, j)
 		}
-		wg.Add(1)
 		if *hdMachineType != noMachineType {
+			wg.Add(1)
 			go func(curZone string) {
 				defer GinkgoRecover()
 				defer wg.Done()


### PR DESCRIPTION
An extra wg.Add(1) was mistakenly called when no hyperdisk was used, leading to deadlock in the e2e test on platforms like arm where there is no hyperdisk.

/kind failing-test

```release-note
None
```
