### PR TITLE
Add parameter sanitization logic

### DIFF
--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -320,7 +320,7 @@ func (gceCS *GCEControllerServer) createVolumeInternal(ctx context.Context, req 
 	var err error
 	// Apply Parameters (case-insensitive). We leave validation of
 	// the values to the cloud provider.
-	params, dataCacheParams, err := gceCS.parameterProcessor().ExtractAndDefaultParameters(req.GetParameters(), gceCS.Driver.extraVolumeLabels, gceCS.enableDataCache, gceCS.Driver.extraTags)
+	params, dataCacheParams, err := gceCS.parameterProcessor().ExtractAndDefaultParameters(req.GetParameters())
 	metrics.UpdateRequestMetadataFromParams(ctx, params)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to extract parameters: %v", err.Error())
@@ -1349,6 +1349,9 @@ func (gceCS *GCEControllerServer) parameterProcessor() *parameters.ParameterProc
 		EnableMultiZone:    gceCS.multiZoneVolumeHandleConfig.Enable,
 		EnableHdHA:         gceCS.enableHdHA,
 		EnableDiskTopology: gceCS.EnableDiskTopology,
+		ExtraVolumeLabels:  gceCS.Driver.extraVolumeLabels,
+		EnableDataCache:    gceCS.enableDataCache,
+		ExtraTags:          gceCS.Driver.extraTags,
 	}
 }
 
@@ -1394,7 +1397,7 @@ func (gceCS *GCEControllerServer) ValidateVolumeCapabilities(ctx context.Context
 	}
 
 	// Validate the disk parameters match the disk we GET
-	params, _, err := gceCS.parameterProcessor().ExtractAndDefaultParameters(req.GetParameters(), gceCS.Driver.extraVolumeLabels, gceCS.enableDataCache, gceCS.Driver.extraTags)
+	params, _, err := gceCS.parameterProcessor().ExtractAndDefaultParameters(req.GetParameters())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to extract parameters: %v", err.Error())
 	}

--- a/pkg/parameters/parameters.go
+++ b/pkg/parameters/parameters.go
@@ -29,9 +29,7 @@ import (
 
 // ExtractAndDefaultParameters will take the relevant parameters from a map and
 // put them into a well defined struct making sure to default unspecified fields.
-// extraVolumeLabels are added as labels; if there are also labels specified in
-// parameters, any matching extraVolumeLabels will be overridden.
-func (pp *ParameterProcessor) ExtractAndDefaultParameters(parameters map[string]string, extraVolumeLabels map[string]string, enableDataCache bool, extraTags map[string]string) (DiskParameters, DataCacheParameters, error) {
+func (pp *ParameterProcessor) ExtractAndDefaultParameters(parameters map[string]string) (DiskParameters, DataCacheParameters, error) {
 	p := DiskParameters{
 		DiskType:             "pd-standard",           // Default
 		ReplicationType:      replicationTypeNone,     // Default
@@ -43,15 +41,15 @@ func (pp *ParameterProcessor) ExtractAndDefaultParameters(parameters map[string]
 
 	// Set data cache mode default
 	d := DataCacheParameters{}
-	if enableDataCache && parameters[ParameterKeyDataCacheSize] != "" {
+	if pp.EnableDataCache && parameters[ParameterKeyDataCacheSize] != "" {
 		d.DataCacheMode = constants.DataCacheModeWriteThrough
 	}
 
-	for k, v := range extraVolumeLabels {
+	for k, v := range pp.ExtraVolumeLabels {
 		p.Labels[k] = v
 	}
 
-	for k, v := range extraTags {
+	for k, v := range pp.ExtraTags {
 		p.ResourceTags[k] = v
 	}
 
@@ -64,7 +62,7 @@ func (pp *ParameterProcessor) ExtractAndDefaultParameters(parameters map[string]
 		case ParameterKeyType:
 			if v != "" {
 				p.DiskType = strings.ToLower(v)
-				if !pp.EnableHdHA && p.DiskType == DiskTypeHdHA {
+				if pp.isHDHADisabled() && p.DiskType == DiskTypeHdHA {
 					return p, d, fmt.Errorf("parameters contain invalid disk type %s", DiskTypeHdHA)
 				}
 			}
@@ -128,7 +126,7 @@ func (pp *ParameterProcessor) ExtractAndDefaultParameters(parameters map[string]
 
 			p.EnableConfidentialCompute = paramEnableConfidentialCompute
 		case ParameterKeyStoragePools:
-			if !pp.EnableStoragePools {
+			if pp.isStoragePoolDisabled() {
 				return p, d, fmt.Errorf("parameters contains invalid option %q", ParameterKeyStoragePools)
 			}
 			storagePools, err := ParseStoragePools(v)
@@ -137,8 +135,8 @@ func (pp *ParameterProcessor) ExtractAndDefaultParameters(parameters map[string]
 			}
 			p.StoragePools = storagePools
 		case ParameterKeyDataCacheSize:
-			if !enableDataCache {
-				return p, d, fmt.Errorf("data caching enabled: %v; parameters contains invalid option %q", enableDataCache, ParameterKeyDataCacheSize)
+			if pp.isDataCacheDisabled() {
+				return p, d, fmt.Errorf("data caching enabled: %v; parameters contains invalid option %q", pp.EnableDataCache, ParameterKeyDataCacheSize)
 			}
 
 			paramDataCacheSize, err := convert.ConvertGiStringToInt64(v)
@@ -150,8 +148,8 @@ func (pp *ParameterProcessor) ExtractAndDefaultParameters(parameters map[string]
 			}
 			d.DataCacheSize = strconv.FormatInt(paramDataCacheSize, 10)
 		case ParameterKeyDataCacheMode:
-			if !enableDataCache {
-				return p, d, fmt.Errorf("data caching enabled %v; parameters contains invalid option %q", enableDataCache, ParameterKeyDataCacheMode)
+			if pp.isDataCacheDisabled() {
+				return p, d, fmt.Errorf("data caching enabled %v; parameters contains invalid option %q", pp.EnableDataCache, ParameterKeyDataCacheMode)
 			}
 			if err := ValidateDataCacheMode(v); err != nil {
 				return p, d, fmt.Errorf("parameters contains invalid option: %s: %w", ParameterKeyDataCacheMode, err)
@@ -162,7 +160,7 @@ func (pp *ParameterProcessor) ExtractAndDefaultParameters(parameters map[string]
 				return p, d, err
 			}
 		case ParameterKeyEnableMultiZoneProvisioning:
-			if !pp.EnableMultiZone {
+			if pp.isMultiZoneDisabled() {
 				return p, d, fmt.Errorf("parameters contains invalid option %q", ParameterKeyEnableMultiZoneProvisioning)
 			}
 			paramEnableMultiZoneProvisioning, err := convert.ConvertStringToBool(v)
@@ -179,7 +177,7 @@ func (pp *ParameterProcessor) ExtractAndDefaultParameters(parameters map[string]
 				p.AccessMode = v
 			}
 		case ParameterKeyUseAllowedDiskTopology:
-			if !pp.EnableDiskTopology {
+			if pp.isDiskTopologyDisabled() {
 				klog.Warningf("parameters contains invalid option %q when disk topology is not enabled", ParameterKeyUseAllowedDiskTopology)
 				continue
 			}

--- a/pkg/parameters/parameters_test.go
+++ b/pkg/parameters/parameters_test.go
@@ -543,8 +543,11 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 				EnableMultiZone:    tc.enableMultiZone,
 				EnableHdHA:         tc.enableHdHA,
 				EnableDiskTopology: tc.enableDiskTopology,
+				ExtraVolumeLabels:  tc.labels,
+				EnableDataCache:    tc.enableDataCache,
+				ExtraTags:          tc.extraTags,
 			}
-			p, d, err := pp.ExtractAndDefaultParameters(tc.parameters, tc.labels, tc.enableDataCache, tc.extraTags)
+			p, d, err := pp.ExtractAndDefaultParameters(tc.parameters)
 			if gotErr := err != nil; gotErr != tc.expectErr {
 				t.Fatalf("ExtractAndDefaultParameters(%+v) = %v; expectedErr: %v", tc.parameters, err, tc.expectErr)
 			}

--- a/pkg/parameters/sanitize.go
+++ b/pkg/parameters/sanitize.go
@@ -1,0 +1,55 @@
+package parameters
+
+import "strings"
+
+// Map of sanitizers for parameters that apply to only a subset of disk types. Each sanitizeer
+// should only be responsible for a single parameter.
+var sanitizers = map[string]sanitizer{
+	"ReplicationType": func(dp *DiskParameters) {
+		// Only sanitize replication type if parameter has been specified.
+		if isHD(dp.DiskType) && dp.ReplicationType != "" {
+			dp.ReplicationType = replicationTypeNone
+		}
+	},
+	"ProvisionedIOPSOnCreate": func(dp *DiskParameters) {
+		if isPD(dp.DiskType) && dp.DiskType != "pd-extreme" {
+			dp.ProvisionedIOPSOnCreate = 0
+		}
+	},
+	"ProvisionedThroughputOnCreate": func(dp *DiskParameters) {
+		if isPD(dp.DiskType) {
+			dp.ProvisionedThroughputOnCreate = 0
+		}
+	},
+	"StoragePools": func(dp *DiskParameters) {
+		if isPD(dp.DiskType) {
+			dp.StoragePools = nil
+		}
+	},
+	"ForceAttach": func(dp *DiskParameters) {
+		if isHD(dp.DiskType) {
+			dp.ForceAttach = false
+		}
+	},
+}
+
+func isHD(diskType string) bool {
+	return strings.HasPrefix(diskType, "hyperdisk-")
+}
+
+func isPD(diskType string) bool {
+	return strings.HasPrefix(diskType, "pd-")
+}
+
+type sanitizer func(dp *DiskParameters)
+
+// sanitizeDiskParameters removes any parameters that are not applicable to the specified disk type,
+// and is intended to only be used for dynamic volumes.
+func sanitizeDiskParameters(dp *DiskParameters) {
+	if dp == nil {
+		return
+	}
+	for _, sanitizer := range sanitizers {
+		sanitizer(dp)
+	}
+}

--- a/pkg/parameters/sanitize_test.go
+++ b/pkg/parameters/sanitize_test.go
@@ -1,0 +1,201 @@
+package parameters
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSanitizeDiskParameters(t *testing.T) {
+	tests := []struct {
+		desc       string
+		parameters *DiskParameters
+		want       *DiskParameters
+	}{
+		{
+			desc:       "nil parameters",
+			parameters: nil,
+		},
+		{
+			desc:       "empty parameters unchanged",
+			parameters: &DiskParameters{},
+			want:       &DiskParameters{},
+		},
+		{
+			desc: "general parameters unchanged PD",
+			parameters: &DiskParameters{
+				DiskType:                  "pd-balanced",
+				DiskEncryptionKMSKey:      "fake-kms-key",
+				Tags:                      map[string]string{"fake-tag": "fake-resource-tag-value"},
+				Labels:                    map[string]string{"fake-label": "fake-label-value"},
+				EnableConfidentialCompute: true,
+				ResourceTags:              map[string]string{"fake-resource-tag": "fake-resource-tag-value"},
+				AccessMode:                "READ_WRITE_SINGLE",
+				UseAllowedDiskTopology:    true,
+			},
+			want: &DiskParameters{
+				DiskType:                  "pd-balanced",
+				DiskEncryptionKMSKey:      "fake-kms-key",
+				Tags:                      map[string]string{"fake-tag": "fake-resource-tag-value"},
+				Labels:                    map[string]string{"fake-label": "fake-label-value"},
+				EnableConfidentialCompute: true,
+				ResourceTags:              map[string]string{"fake-resource-tag": "fake-resource-tag-value"},
+				AccessMode:                "READ_WRITE_SINGLE",
+				UseAllowedDiskTopology:    true,
+			},
+		},
+		{
+			desc: "general parameters unchanged HD",
+			parameters: &DiskParameters{
+				DiskType:                  "hyperdisk-balanced",
+				DiskEncryptionKMSKey:      "fake-kms-key",
+				Tags:                      map[string]string{"fake-tag": "fake-resource-tag-value"},
+				Labels:                    map[string]string{"fake-label": "fake-label-value"},
+				EnableConfidentialCompute: true,
+				ResourceTags:              map[string]string{"fake-resource-tag": "fake-resource-tag-value"},
+				AccessMode:                "READ_WRITE_SINGLE",
+				UseAllowedDiskTopology:    true,
+			},
+			want: &DiskParameters{
+				DiskType:                  "hyperdisk-balanced",
+				DiskEncryptionKMSKey:      "fake-kms-key",
+				Tags:                      map[string]string{"fake-tag": "fake-resource-tag-value"},
+				Labels:                    map[string]string{"fake-label": "fake-label-value"},
+				EnableConfidentialCompute: true,
+				ResourceTags:              map[string]string{"fake-resource-tag": "fake-resource-tag-value"},
+				AccessMode:                "READ_WRITE_SINGLE",
+				UseAllowedDiskTopology:    true,
+			},
+		},
+		{
+			// For replication type, the sanitized value is "none" instead of an empty string.
+			desc: "ReplicationType sanitized for HD",
+			parameters: &DiskParameters{
+				DiskType:        "hyperdisk-balanced",
+				ReplicationType: "regional-pd",
+			},
+			want: &DiskParameters{
+				DiskType:        "hyperdisk-balanced",
+				ReplicationType: "none",
+			},
+		},
+		{
+			desc: "ReplicationType unchanged for PD",
+			parameters: &DiskParameters{
+				DiskType:        "pd-balanced",
+				ReplicationType: "regional",
+			},
+			want: &DiskParameters{
+				DiskType:        "pd-balanced",
+				ReplicationType: "regional",
+			},
+		},
+		{
+			desc: "ProvisionedIOPSOnCreate sanitized for PD",
+			parameters: &DiskParameters{
+				DiskType:                "pd-balanced",
+				ProvisionedIOPSOnCreate: 1000,
+			},
+			want: &DiskParameters{
+				DiskType: "pd-balanced",
+			},
+		},
+		{
+			desc: "ProvisionedIOPSOnCreate unchanged for HD",
+			parameters: &DiskParameters{
+				DiskType:                "hyperdisk-balanced",
+				ProvisionedIOPSOnCreate: 5000,
+			},
+			want: &DiskParameters{
+				DiskType:                "hyperdisk-balanced",
+				ProvisionedIOPSOnCreate: 5000,
+			},
+		},
+		{
+			desc: "ProvisionedIOPSOnCreate unchanged for pd-extreme",
+			parameters: &DiskParameters{
+				DiskType:                "pd-extreme",
+				ProvisionedIOPSOnCreate: 5000,
+			},
+			want: &DiskParameters{
+				DiskType:                "pd-extreme",
+				ProvisionedIOPSOnCreate: 5000,
+			},
+		},
+		{
+			desc: "ProvisionedThroughputOnCreate sanitized for PD",
+			parameters: &DiskParameters{
+				DiskType:                      "pd-standard",
+				ProvisionedThroughputOnCreate: 200,
+			},
+			want: &DiskParameters{
+				DiskType: "pd-standard",
+			},
+		},
+		{
+			desc: "ProvisionedThroughputOnCreate unchanged for HD",
+			parameters: &DiskParameters{
+				DiskType:                      "hyperdisk-balanced",
+				ProvisionedThroughputOnCreate: 200,
+			},
+			want: &DiskParameters{
+				DiskType:                      "hyperdisk-balanced",
+				ProvisionedThroughputOnCreate: 200,
+			},
+		},
+		{
+			desc: "StoragePools sanitized for PD",
+			parameters: &DiskParameters{
+				DiskType:     "pd-balanced",
+				StoragePools: []StoragePool{{Name: "fake-pool"}},
+			},
+			want: &DiskParameters{
+				DiskType: "pd-balanced",
+			},
+		},
+		{
+			desc: "StoragePools unchanged for HD",
+			parameters: &DiskParameters{
+				DiskType:     "hyperdisk-balanced",
+				StoragePools: []StoragePool{{Name: "fake-pool"}},
+			},
+			want: &DiskParameters{
+				DiskType:     "hyperdisk-balanced",
+				StoragePools: []StoragePool{{Name: "fake-pool"}},
+			},
+		},
+		{
+			desc: "ForceAttach sanitized for HD",
+			parameters: &DiskParameters{
+				DiskType:    "hyperdisk-balanced",
+				ForceAttach: true,
+			},
+			want: &DiskParameters{
+				DiskType: "hyperdisk-balanced",
+			},
+		},
+		{
+			desc: "ForceAttach unchanged for PD",
+			parameters: &DiskParameters{
+				DiskType:    "pd-balanced",
+				ForceAttach: true,
+			},
+			want: &DiskParameters{
+				DiskType:    "pd-balanced",
+				ForceAttach: true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			sanitizeDiskParameters(tc.parameters)
+			got := tc.parameters
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("sanitizeDiskParameters() mismatch (-want +got):\n%s", diff)
+			}
+
+		})
+	}
+
+}

--- a/pkg/parameters/types.go
+++ b/pkg/parameters/types.go
@@ -42,6 +42,7 @@ type DiskParameters struct {
 	// Values: {bool}
 	// Default: false
 	EnableConfidentialCompute bool
+	// Values: {bool}
 	// Default: false
 	ForceAttach bool
 	// Values: {[]string}
@@ -56,7 +57,7 @@ type DiskParameters struct {
 	// Values: READ_WRITE_SINGLE, READ_ONLY_MANY, READ_WRITE_MANY
 	// Default: READ_WRITE_SINGLE
 	AccessMode string
-	// Values {}
+	// Values: {bool}
 	// Default: false
 	UseAllowedDiskTopology bool
 }
@@ -81,6 +82,29 @@ type ParameterProcessor struct {
 	EnableMultiZone    bool
 	EnableHdHA         bool
 	EnableDiskTopology bool
+	ExtraVolumeLabels  map[string]string
+	EnableDataCache    bool
+	ExtraTags          map[string]string
+}
+
+func (pp *ParameterProcessor) isHDHADisabled() bool {
+	return !pp.EnableHdHA
+}
+
+func (pp *ParameterProcessor) isStoragePoolDisabled() bool {
+	return !pp.EnableStoragePools
+}
+
+func (pp *ParameterProcessor) isDataCacheDisabled() bool {
+	return !pp.EnableDataCache
+}
+
+func (pp *ParameterProcessor) isMultiZoneDisabled() bool {
+	return !pp.EnableMultiZone
+}
+
+func (pp *ParameterProcessor) isDiskTopologyDisabled() bool {
+	return !pp.EnableDiskTopology
 }
 
 type ModifyVolumeParameters struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind feature

**What this PR does / why we need it**:
This PR adds functionality for sanitizing parameters based on disk type. This will be used by the generic volumes feature to remove any parameters that are invalid for the selected disk. 

It also cleans up the ParameterProcessor to reduce the amount of arguments in ExtractAndProcessParameters. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
