### PR TITLE
Enable dynamic disk type selection

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -497,6 +497,10 @@ func HasDiskTypeLabelKeyPrefix(labelKey string) bool {
 	return strings.HasPrefix(labelKey, constants.DiskTypeKeyPrefix)
 }
 
+func DiskTypeFromLabel(labelKey string) string {
+	return strings.TrimPrefix(labelKey, constants.DiskTypeKeyPrefix+"/")
+}
+
 func DiskTypeLabelKey(diskType string) string {
 	return fmt.Sprintf("%s/%s", constants.DiskTypeKeyPrefix, diskType)
 }

--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -475,7 +475,8 @@ func validAccessMode(want, got string) bool {
 // ValidateDiskParameters takes a CloudDisk and returns true if the parameters
 // specified validly describe the disk provided, and false otherwise.
 func ValidateDiskParameters(disk *CloudDisk, params parameters.DiskParameters) error {
-	if disk.GetPDType() != params.DiskType {
+	// Skip this check for dynamic volumes because dynamic is not a valid disk type.
+	if disk.GetPDType() != params.DiskType && !params.IsDiskDynamic() {
 		return fmt.Errorf("actual pd type %s did not match the expected param %s", disk.GetPDType(), params.DiskType)
 	}
 

--- a/pkg/gce-pd-csi-driver/disk_selection.go
+++ b/pkg/gce-pd-csi-driver/disk_selection.go
@@ -1,0 +1,139 @@
+package gceGCEDriver
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
+	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/parameters"
+)
+
+const (
+	defaultTypePD = "pd-balanced"
+	defaultTypeHD = "hyperdisk-balanced"
+)
+
+func SelectDisk(ctx context.Context, req *csi.CreateVolumeRequest, gce gce.GCECompute) (string, error) {
+	// This should never happen in practice.
+	if req == nil {
+		return "", fmt.Errorf("CreateVolumeRequest is nil")
+	}
+
+	dts, err := getDynamicDiskTypes(req.GetParameters())
+	if err != nil {
+		return "", fmt.Errorf("failed to get disk types from request parameters: %v", err)
+	}
+
+	if isSourceVolumeSpecified(req.GetVolumeContentSource()) {
+		return getTypeFromSourceVolume(ctx, req.GetVolumeContentSource(), gce, dts)
+	}
+
+	return selectDiskTypeFromTopologies(req.GetAccessibilityRequirements(), dts), nil
+}
+
+type dynamicDiskTypes struct {
+	PD      string
+	HD      string
+	Default string
+}
+
+// Extract disk types from the CSI CreateVolumeRequest.
+func getDynamicDiskTypes(reqParams map[string]string) (*dynamicDiskTypes, error) {
+	if reqParams == nil {
+		return nil, fmt.Errorf("request parameters are nil")
+	}
+
+	pdType := defaultTypePD
+	if param := strings.ToLower(reqParams[parameters.ParameterPDType]); param != "" {
+		pdType = param
+	}
+
+	hdType := defaultTypeHD
+	if param := strings.ToLower(reqParams[parameters.ParameterHDType]); param != "" {
+		hdType = param
+	}
+
+	// Determine default disk type based on preference parameter. If the parameter is
+	// unspecfied than default to hdType.
+	defaultDiskType := hdType
+	if diskTypePreference, hasParameter := reqParams[parameters.ParameterDiskPreference]; hasParameter {
+		switch strings.ToLower(diskTypePreference) {
+		case parameters.ParameterPDType:
+			defaultDiskType = pdType
+		case parameters.ParameterHDType:
+			defaultDiskType = hdType
+		default:
+			return nil, fmt.Errorf("invalid disk type preference %q, must be %q or %q", diskTypePreference, parameters.ParameterPDType, parameters.ParameterHDType)
+		}
+	}
+
+	return &dynamicDiskTypes{
+		PD:      pdType,
+		HD:      hdType,
+		Default: defaultDiskType,
+	}, nil
+}
+
+func isSourceVolumeSpecified(vcs *csi.VolumeContentSource) bool {
+	switch {
+	case vcs == nil:
+		return false
+	case vcs.GetVolume() == nil:
+		return false
+	default:
+		return true
+	}
+}
+
+func getTypeFromSourceVolume(ctx context.Context, vcs *csi.VolumeContentSource, gce gce.GCECompute, dts *dynamicDiskTypes) (string, error) {
+	volumeContentSourceVolumeID := vcs.GetVolume().GetVolumeId()
+	// Verify that the source VolumeID is in the correct format.
+	project, sourceVolKey, err := common.VolumeIDToKey(volumeContentSourceVolumeID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get source volume key: %v", err)
+	}
+
+	// Verify that the volume in VolumeContentSource exists, and it's disk type
+	// match the specified dynamic disk types.
+	d, err := gce.GetDisk(ctx, project, sourceVolKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to get disk type from source volume: %v", err)
+	}
+	sourceDiskType := d.GetPDType()
+	if sourceDiskType != dts.HD && sourceDiskType != dts.PD {
+		return "", fmt.Errorf("source volume has invalid disk type %q, must be %q or %q", sourceDiskType, dts.PD, dts.HD)
+	}
+
+	return d.GetPDType(), nil
+}
+
+// Select disk type based on the allowed topologies in the CreateVolumeRequest. Only the first node is
+// considered because this node is preferred by the scheduler.
+func selectDiskTypeFromTopologies(topologies *csi.TopologyRequirement, dts *dynamicDiskTypes) string {
+	if len(topologies.GetPreferred()) > 0 {
+		t := topologies.GetPreferred()[0]
+
+		labels := t.GetSegments()
+		supportedDiskTypes := map[string]bool{}
+		for key := range labels {
+			if common.HasDiskTypeLabelKeyPrefix(key) {
+				supportedDiskTypes[common.DiskTypeFromLabel(key)] = true
+			}
+		}
+
+		isHDSupported := supportedDiskTypes[dts.HD]
+		isPDSupported := supportedDiskTypes[dts.PD]
+
+		if isHDSupported && !isPDSupported {
+			return dts.HD
+		}
+		if isPDSupported && !isHDSupported {
+			return dts.PD
+		}
+	}
+
+	return dts.Default
+}

--- a/pkg/gce-pd-csi-driver/disk_selection_test.go
+++ b/pkg/gce-pd-csi-driver/disk_selection_test.go
@@ -1,0 +1,432 @@
+package gceGCEDriver
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/google/go-cmp/cmp"
+	computev1 "google.golang.org/api/compute/v1"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
+	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/parameters"
+)
+
+const (
+	pdTestDiskType = "pd-fake"
+	hdTestDiskType = "hyperdisk-fake"
+
+	testProject = "fake-project"
+	testZone    = "us-central1-f"
+)
+
+var (
+	fakeDiskPD = gce.CloudDiskFromV1(&computev1.Disk{
+		Name: "pd-source-disk",
+		Type: pdTestDiskType,
+	})
+	fakeDiskHD = gce.CloudDiskFromV1(&computev1.Disk{
+		Name: "hd-source-disk",
+		Type: hdTestDiskType,
+	})
+	fakeDiskInvalid = gce.CloudDiskFromV1(&computev1.Disk{
+		Name: "invalid-source-disk",
+		Type: "invalid-type",
+	})
+)
+
+func TestSelectDisk(t *testing.T) {
+	tests := []struct {
+		desc    string
+		req     *csi.CreateVolumeRequest
+		want    string
+		wantErr bool
+	}{
+		{
+			desc: "no topologies select hd by default",
+			req: &csi.CreateVolumeRequest{
+				Parameters: map[string]string{
+					parameters.ParameterPDType: pdTestDiskType,
+					parameters.ParameterHDType: hdTestDiskType,
+				},
+			},
+			want: hdTestDiskType,
+		},
+		{
+			desc: "disk type override",
+			req: &csi.CreateVolumeRequest{
+				Parameters: map[string]string{
+					parameters.ParameterPDType:         pdTestDiskType,
+					parameters.ParameterHDType:         hdTestDiskType,
+					parameters.ParameterDiskPreference: parameters.ParameterPDType,
+				},
+			},
+			want: pdTestDiskType,
+		},
+		{
+			desc: "topologies only support pd",
+			req: &csi.CreateVolumeRequest{
+				Parameters: map[string]string{
+					parameters.ParameterPDType: pdTestDiskType,
+					parameters.ParameterHDType: hdTestDiskType,
+				},
+				AccessibilityRequirements: &csi.TopologyRequirement{
+					Preferred: []*csi.Topology{
+						{
+							Segments: map[string]string{
+								common.DiskTypeLabelKey(pdTestDiskType): "true",
+							},
+						},
+					},
+				},
+			},
+			want: pdTestDiskType,
+		},
+		{
+			desc: "source volume specified",
+			req: &csi.CreateVolumeRequest{
+				Parameters: map[string]string{
+					parameters.ParameterPDType: pdTestDiskType,
+					parameters.ParameterHDType: hdTestDiskType,
+				},
+				VolumeContentSource: &csi.VolumeContentSource{
+					Type: &csi.VolumeContentSource_Volume{
+						Volume: &csi.VolumeContentSource_VolumeSource{
+							VolumeId: fmt.Sprintf("projects/%s/zones/%s/disks/%s", testProject, testZone, fakeDiskPD.GetName())},
+					},
+				},
+			},
+			want: pdTestDiskType,
+		},
+		{
+			desc:    "fail parameters missing",
+			req:     &csi.CreateVolumeRequest{},
+			wantErr: true,
+		},
+		{
+			desc: "fail source volume missing",
+			req: &csi.CreateVolumeRequest{
+				Parameters: map[string]string{
+					parameters.ParameterPDType: pdTestDiskType,
+					parameters.ParameterHDType: hdTestDiskType,
+				},
+				VolumeContentSource: &csi.VolumeContentSource{
+					Type: &csi.VolumeContentSource_Volume{
+						Volume: &csi.VolumeContentSource_VolumeSource{
+							VolumeId: fmt.Sprintf("projects/%s/zones/%s/disks/%s", testProject, testZone, fakeDiskInvalid.GetName())},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			fcp, err := gce.CreateFakeCloudProvider(testProject, testZone, []*gce.CloudDisk{fakeDiskPD})
+			if err != nil {
+				t.Fatalf("Failed to create fake cloud provider: %v", err)
+			}
+			got, err := SelectDisk(context.Background(), tc.req, fcp)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("SelectDisk() wantErr = %v, gotErr = %v", tc.wantErr, err)
+			}
+
+			if got != tc.want {
+				t.Errorf("SelectDisk() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetDiskTypes(t *testing.T) {
+	tests := []struct {
+		desc       string
+		parameters map[string]string
+		want       *dynamicDiskTypes
+		wantErr    bool
+	}{
+		{
+			desc: "successful extraction",
+			parameters: map[string]string{
+				parameters.ParameterPDType: pdTestDiskType,
+				parameters.ParameterHDType: hdTestDiskType,
+			},
+			want: &dynamicDiskTypes{
+				PD:      pdTestDiskType,
+				HD:      hdTestDiskType,
+				Default: hdTestDiskType,
+			},
+		},
+		{
+			desc: "pd default override",
+			parameters: map[string]string{
+				parameters.ParameterPDType:         pdTestDiskType,
+				parameters.ParameterHDType:         hdTestDiskType,
+				parameters.ParameterDiskPreference: parameters.ParameterHDType,
+			},
+			want: &dynamicDiskTypes{
+				PD:      pdTestDiskType,
+				HD:      hdTestDiskType,
+				Default: hdTestDiskType,
+			},
+		},
+		{
+			desc: "hd default override",
+			parameters: map[string]string{
+				parameters.ParameterPDType:         pdTestDiskType,
+				parameters.ParameterHDType:         hdTestDiskType,
+				parameters.ParameterDiskPreference: parameters.ParameterHDType,
+			},
+			want: &dynamicDiskTypes{
+				PD:      pdTestDiskType,
+				HD:      hdTestDiskType,
+				Default: hdTestDiskType,
+			},
+		},
+		{
+			desc: "invalid type preference",
+			parameters: map[string]string{
+				parameters.ParameterPDType:         pdTestDiskType,
+				parameters.ParameterHDType:         hdTestDiskType,
+				parameters.ParameterDiskPreference: "fake-preference",
+			},
+			wantErr: true,
+		},
+		{
+			desc: "missing pd type",
+			parameters: map[string]string{
+				parameters.ParameterHDType: hdTestDiskType,
+			},
+			want: &dynamicDiskTypes{
+				PD:      defaultTypePD,
+				HD:      hdTestDiskType,
+				Default: hdTestDiskType,
+			},
+		},
+		{
+			desc: "missing hd type",
+			parameters: map[string]string{
+				parameters.ParameterPDType: pdTestDiskType,
+			},
+			want: &dynamicDiskTypes{
+				PD:      pdTestDiskType,
+				HD:      defaultTypeHD,
+				Default: defaultTypeHD,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := getDynamicDiskTypes(tc.parameters)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("getDiskTypes() wantErr = %v, gotErr = %v", tc.wantErr, err)
+			}
+
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Errorf("Unexpected disk types (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIsSourceVolumeSpecified(t *testing.T) {
+	tests := []struct {
+		desc         string
+		sourceVolume *csi.VolumeContentSource
+		want         bool
+	}{
+		{
+			desc: "nil volume content source",
+			want: false,
+		},
+		{
+			desc: "snapshot source specified",
+			sourceVolume: &csi.VolumeContentSource{
+				Type: &csi.VolumeContentSource_Snapshot{},
+			},
+			want: false,
+		},
+		{
+			desc: "source volume specified",
+			sourceVolume: &csi.VolumeContentSource{
+				Type: &csi.VolumeContentSource_Volume{
+					Volume: &csi.VolumeContentSource_VolumeSource{
+						VolumeId: "projects/fake-project/zones/us-central1-f/disks/fake-disk"},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := isSourceVolumeSpecified(tc.sourceVolume)
+			if got != tc.want {
+				t.Errorf("isSourceVolumeSpecified() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetTypeFromSourceVolume(t *testing.T) {
+	tests := []struct {
+		desc         string
+		sourceVolume *csi.VolumeContentSource
+		want         string
+		wantErr      bool
+	}{
+		{
+			desc: "source volume select pd type",
+			sourceVolume: &csi.VolumeContentSource{
+				Type: &csi.VolumeContentSource_Volume{
+					Volume: &csi.VolumeContentSource_VolumeSource{
+						VolumeId: fmt.Sprintf("projects/%s/zones/%s/disks/%s", testProject, testZone, fakeDiskPD.GetName())},
+				},
+			},
+			want: pdTestDiskType,
+		},
+		{
+			desc: "source volume select hd type",
+			sourceVolume: &csi.VolumeContentSource{
+				Type: &csi.VolumeContentSource_Volume{
+					Volume: &csi.VolumeContentSource_VolumeSource{
+						VolumeId: fmt.Sprintf("projects/%s/zones/%s/disks/%s", testProject, testZone, fakeDiskHD.GetName())},
+				},
+			},
+			want: hdTestDiskType,
+		},
+		{
+			desc: "fail source type does not match parameters",
+			sourceVolume: &csi.VolumeContentSource{
+				Type: &csi.VolumeContentSource_Volume{
+					Volume: &csi.VolumeContentSource_VolumeSource{
+						VolumeId: fmt.Sprintf("projects/%s/zones/%s/disks/%s", testProject, testZone, fakeDiskInvalid.GetName())},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "fail source volume missing",
+			sourceVolume: &csi.VolumeContentSource{
+				Type: &csi.VolumeContentSource_Volume{
+					Volume: &csi.VolumeContentSource_VolumeSource{
+						VolumeId: fmt.Sprintf("projects/%s/zones/%s/disks/%s", testProject, testZone, "non-existent-disk")},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "fail invalid volume id format",
+			sourceVolume: &csi.VolumeContentSource{
+				Type: &csi.VolumeContentSource_Volume{
+					Volume: &csi.VolumeContentSource_VolumeSource{
+						VolumeId: "invalid-volume-id"},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			fcp, err := gce.CreateFakeCloudProvider(testProject, testZone, []*gce.CloudDisk{fakeDiskPD, fakeDiskHD, fakeDiskInvalid})
+			if err != nil {
+				t.Fatalf("Failed to create fake cloud provider: %v", err)
+			}
+			got, err := getTypeFromSourceVolume(context.Background(), tc.sourceVolume, fcp, &dynamicDiskTypes{
+				PD:      pdTestDiskType,
+				HD:      hdTestDiskType,
+				Default: hdTestDiskType,
+			})
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("getTypeFromSourceVolume() wantErr = %v, gotErr = %v", tc.wantErr, err)
+			}
+
+			if got != tc.want {
+				t.Errorf("getTypeFromSourceVolume() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSelectDiskTypeFromTopology(t *testing.T) {
+	// This is not an actual value, and used only by this test to verify default behavior,
+	const defaultDiskType = "default-type"
+
+	tests := []struct {
+		desc       string
+		topologies *csi.TopologyRequirement
+		want       string
+	}{
+		{
+			desc: "only hd supported",
+			topologies: &csi.TopologyRequirement{
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							common.DiskTypeLabelKey(hdTestDiskType): "true",
+						},
+					},
+				},
+			},
+			want: hdTestDiskType,
+		},
+		{
+			desc: "only pd supported",
+			topologies: &csi.TopologyRequirement{
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							common.DiskTypeLabelKey(pdTestDiskType): "true",
+						},
+					},
+				},
+			},
+			want: pdTestDiskType,
+		},
+		{
+			desc: "both are supported",
+			topologies: &csi.TopologyRequirement{
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							common.DiskTypeLabelKey(pdTestDiskType): "true",
+							common.DiskTypeLabelKey(hdTestDiskType): "true",
+						},
+					},
+				},
+			},
+			want: defaultDiskType,
+		},
+		{
+			desc: "none are supported",
+			topologies: &csi.TopologyRequirement{
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{},
+					},
+				},
+			},
+			want: defaultDiskType,
+		},
+		{
+			desc: "no topologies",
+			want: defaultDiskType,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := selectDiskTypeFromTopologies(tc.topologies, &dynamicDiskTypes{
+				PD:      pdTestDiskType,
+				HD:      hdTestDiskType,
+				Default: defaultDiskType,
+			})
+			if got != tc.want {
+				t.Errorf("selectDiskTypeFromTopologies() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/gce-pd-csi-driver/gce-pd-driver.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver.go
@@ -178,6 +178,7 @@ func NewControllerServer(gceDriver *GCEDriver, cloudProvider gce.GCECompute, err
 		listVolumesConfig:           listVolumesConfig,
 		provisionableDisksConfig:    provisionableDisksConfig,
 		enableHdHA:                  enableHdHA,
+		enableDynamicVolumes:        args.EnableDynamicVolumes,
 		EnableDiskTopology:          args.EnableDiskTopology,
 		EnableDiskSizeValidation:    args.EnableDiskSizeValidation,
 	}

--- a/pkg/parameters/constants.go
+++ b/pkg/parameters/constants.go
@@ -62,4 +62,10 @@ const (
 	// Parameters for VolumeSnapshotClass
 	DiskSnapshotType = "snapshots"
 	DiskImageType    = "images"
+
+	// Parameter for DynamicVolumes
+	DynamicVolumeType       = "dynamic"
+	ParameterHDType         = "hyperdisk-type"
+	ParameterPDType         = "pd-type"
+	ParameterDiskPreference = "disk-type-preference"
 )

--- a/pkg/parameters/sanitize.go
+++ b/pkg/parameters/sanitize.go
@@ -43,9 +43,9 @@ func isPD(diskType string) bool {
 
 type sanitizer func(dp *DiskParameters)
 
-// sanitizeDiskParameters removes any parameters that are not applicable to the specified disk type,
+// SanitizeDiskParameters removes any parameters that are not applicable to the specified disk type,
 // and is intended to only be used for dynamic volumes.
-func sanitizeDiskParameters(dp *DiskParameters) {
+func SanitizeDiskParameters(dp *DiskParameters) {
 	if dp == nil {
 		return
 	}

--- a/pkg/parameters/sanitize_test.go
+++ b/pkg/parameters/sanitize_test.go
@@ -189,7 +189,7 @@ func TestSanitizeDiskParameters(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			sanitizeDiskParameters(tc.parameters)
+			SanitizeDiskParameters(tc.parameters)
 			got := tc.parameters
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("sanitizeDiskParameters() mismatch (-want +got):\n%s", diff)

--- a/pkg/parameters/types.go
+++ b/pkg/parameters/types.go
@@ -21,6 +21,15 @@ type DiskParameters struct {
 	// Values: pd-standard, pd-balanced, pd-ssd, or any other PD disk type. Not validated.
 	// Default: pd-standard
 	DiskType string
+	// Values: any PD type. Not validated.
+	// Default: ""
+	PDType string
+	// Values: any HD type. Not validated.
+	// Default: ""
+	HDType string
+	// Values: pdType, hdType
+	// Default: hdType
+	DiskTypePreference string
 	// Values: "none", regional-pd
 	// Default: "none"
 	ReplicationType string
@@ -66,6 +75,10 @@ func (dp *DiskParameters) IsRegional() bool {
 	return dp.ReplicationType == "regional-pd" || dp.DiskType == DiskTypeHdHA
 }
 
+func (dp *DiskParameters) IsDiskDynamic() bool {
+	return dp.DiskType == DynamicVolumeType
+}
+
 // SnapshotParameters contains normalized and defaulted parameters for snapshots
 type SnapshotParameters struct {
 	StorageLocations []string
@@ -77,14 +90,15 @@ type SnapshotParameters struct {
 }
 
 type ParameterProcessor struct {
-	DriverName         string
-	EnableStoragePools bool
-	EnableMultiZone    bool
-	EnableHdHA         bool
-	EnableDiskTopology bool
-	ExtraVolumeLabels  map[string]string
-	EnableDataCache    bool
-	ExtraTags          map[string]string
+	DriverName           string
+	EnableStoragePools   bool
+	EnableMultiZone      bool
+	EnableHdHA           bool
+	EnableDiskTopology   bool
+	EnableDataCache      bool
+	EnableDynamicVolumes bool
+	ExtraVolumeLabels    map[string]string
+	ExtraTags            map[string]string
 }
 
 func (pp *ParameterProcessor) isHDHADisabled() bool {
@@ -105,6 +119,10 @@ func (pp *ParameterProcessor) isMultiZoneDisabled() bool {
 
 func (pp *ParameterProcessor) isDiskTopologyDisabled() bool {
 	return !pp.EnableDiskTopology
+}
+
+func (pp *ParameterProcessor) isDynamicVolumesDisabled() bool {
+	return !pp.EnableDynamicVolumes
 }
 
 type ModifyVolumeParameters struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This PR enables the dynamic volumes feature, allowing the selection of disk type during CreateVolume depending on what disks are actually supported by the node. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
pdcsi-releaser-new-branch=true

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Introduce dynamic disk provisioning, automatically selecting a volume's disk type for type based on node compatibility (denoted by`disk-type.gke.io/[disk-type]` node labels).
Action: Required: Add the flag "--dynamic-volumes=true" to the PDCSI controller and node components.
```
