### PR TITLE
fix: nil pointer dereference in waitForZonalOp

### DIFF
--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -1063,7 +1063,7 @@ func (cloud *CloudProvider) waitForZonalOp(ctx context.Context, project, opName 
 	return wait.ExponentialBackoff(WaitForOpBackoff, func() (bool, error) {
 		waitOp, err := cloud.service.ZoneOperations.Wait(project, zone, opName).Context(ctx).Do()
 		// In case of service unavailable do not propogate the error so ExponentialBackoff will retry
-		if err != nil && waitOp.HttpErrorStatusCode == 503 {
+		if err != nil && waitOp != nil && waitOp.HttpErrorStatusCode == 503 {
 			klog.Errorf("WaitForZonalOp(op: %s, zone: %#v, err: %v) failed to poll the operation", opName, zone, err)
 			return false, nil
 		}
@@ -1080,7 +1080,7 @@ func (cloud *CloudProvider) waitForRegionalOp(ctx context.Context, project, opNa
 	return wait.ExponentialBackoff(WaitForOpBackoff, func() (bool, error) {
 		waitOp, err := cloud.service.RegionOperations.Wait(project, region, opName).Context(ctx).Do()
 		// In case of service unavailable do not propogate the error so ExponentialBackoff will retry
-		if err != nil && waitOp.HttpErrorStatusCode == 503 {
+		if err != nil && waitOp != nil && waitOp.HttpErrorStatusCode == 503 {
 			klog.Errorf("WaitForRegionalOp(op: %s, region: %#v, err: %v) failed to poll the operation", opName, region, err)
 			return false, nil
 		}
@@ -1097,7 +1097,7 @@ func (cloud *CloudProvider) waitForGlobalOp(ctx context.Context, project, opName
 	return wait.ExponentialBackoff(WaitForOpBackoff, func() (bool, error) {
 		waitOp, err := cloud.service.GlobalOperations.Wait(project, opName).Context(ctx).Do()
 		// In case of service unavailable do not propogate the error so ExponentialBackoff will retry
-		if err != nil && waitOp.HttpErrorStatusCode == 503 {
+		if err != nil && waitOp != nil && waitOp.HttpErrorStatusCode == 503 {
 			klog.Errorf("WaitForGlobalOp(op: %s, err: %v) failed to poll the operation", opName, err)
 			return false, nil
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

We've seen the following panic intermittently during e2e tests:

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x58 pc=0x22707b8]

goroutine 2822 [running]:
k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x31b08f0, 0x4815f00}, {0x27dac20, 0x4707c10}, {0x4815f00, 0x0, 0x440c58?})
	/go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:114 +0x1a9
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc000186e00?})
	/go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:64 +0x105
panic({0x27dac20?, 0x4707c10?})
	/usr/lib/golang/src/runtime/panic.go:792 +0x132
sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute.(*CloudProvider).resizeZonalDisk.(*CloudProvider).waitForZonalOp.func1()
	/go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute/gce-compute.go:1070 +0x98
k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection(0x1?)
	/go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:150 +0x3e
k8s.io/apimachinery/pkg/util/wait.ExponentialBackoff({0x1bf08eb000, 0x0, 0x0, 0x3, 0x0}, 0xc0007e9518)
	/go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:477 +0x5a
sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute.(*CloudProvider).waitForZonalOp(...)
	/go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute/gce-compute.go:1067
sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute.(*CloudProvider).resizeZonalDisk(0xc000ca5c20, {0x31b0928, 0xc00013c420}, {0xc0001693b9, 0x18}, 0xc00013c4e0, 0x2)
	/go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute/gce-compute.go:1498 +0xc4b
sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute.(*CloudProvider).ResizeDisk(0xc000ca5c20, {0x31b0928, 0xc00013c420}, {0xc0001693b9, 0x18}, 0xc00013c4e0, 0x80000000)
	/go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute/gce-compute.go:1438 +0x2bd
sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-pd-csi-driver.(*GCEControllerServer).ControllerExpandVolume(0xc000232b00, {0x31b0928, 0xc00013c420}, 0x25555e0?)
	/go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pkg/gce-pd-csi-driver/controller.go:1978 +0x283
github.com/container-storage-interface/spec/lib/go/csi._Controller_ControllerExpandVolume_Handler.func1({0x31b0928?, 0xc00013c420?}, {0x2ad18e0?, 0xc00003d220?})
	/go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/vendor/github.com/container-storage-interface/spec/lib/go/csi/csi_grpc.pb.go:649 +0xcb
sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-pd-csi-driver.logGRPC({0x31b0928, 0xc00013c420}, {0x2ad18e0, 0xc00003d220}, 0xc0002f3f60, 0xc000013248)
	/go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pkg/gce-pd-csi-driver/utils.go:83 +0x1a2
github.com/container-storage-interface/spec/lib/go/csi._Controller_ControllerExpandVolume_Handler({0x2dbc2e0, 0xc000232b00}, {0x31b0928, 0xc00013c420}, 0xc00094cf00, 0x2f3cc98)
	/go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/vendor/github.com/container-storage-interface/spec/lib/go/csi/csi_grpc.pb.go:651 +0x143
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000158c00, {0x31b0928, 0xc00013c390}, 0xc0000ade00, 0xc00013c030, 0x4743d28, 0x0)
	/go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/vendor/google.golang.org/grpc/server.go:1405 +0x1036
google.golang.org/grpc.(*Server).handleStream(0xc000158c00, {0x31b12f8, 0xc00012f040}, 0xc0000ade00)
	/go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/vendor/google.golang.org/grpc/server.go:1815 +0xb88
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	/go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/vendor/google.golang.org/grpc/server.go:1035 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 66
	/go/src/github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/vendor/google.golang.org/grpc/server.go:1046 +0x11d
```

In waitForZonalOp (and waitForRegionalOp, waitForGlobalOp) it checks `waitOp.HttpErrorStatusCode` without first checking `waitOp != nil`:

https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/commit/6b7e63f6e6319d8ffada727d4b69c8557d501e8b#diff-0a6cd0afae8c035b921beb3150d39b6955f7b07eedec752c8f06f669619bde57R1070

However, the call to `cloud.service.ZoneOperations.Wait(project, zone, opName).Context(ctx).Do()` does return (nil, err) in some cases, so these calls should explicitly check `waitOp` before deferencing it.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

/cc @prachirp @sunnylovestiramisu

**Does this PR introduce a user-facing change?**:

```release-note
fix: nil pointer dereference in waitForZonalOp
```
