### PR TITLE
[btrfs-only] fix blkid argument

### DIFF
--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -538,7 +538,7 @@ func (ns *GCENodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStage
 
 	// Part 6: if configured, write sysfs values
 	if len(btrfsSysfs) > 0 {
-		args := []string{"--match-tag", "UUID", "--output", "value", stagingTargetPath}
+		args := []string{"--match-tag", "UUID", "--output", "value", devicePath}
 		cmd := ns.Mounter.Exec.Command("blkid", args...)
 		var stderr bytes.Buffer
 		cmd.SetStderr(&stderr)

--- a/pkg/gce-pd-csi-driver/node_test.go
+++ b/pkg/gce-pd-csi-driver/node_test.go
@@ -958,7 +958,7 @@ func TestNodeStageVolume(t *testing.T) {
 				},
 				{
 					cmd:    "blkid",
-					args:   fmt.Sprintf("--match-tag UUID --output value %v", stagingPath),
+					args:   fmt.Sprintf("--match-tag UUID --output value /dev/disk/fake-path"),
 					stdout: btrfsUUID + "\n",
 				},
 			},
@@ -1027,7 +1027,7 @@ func TestNodeStageVolume(t *testing.T) {
 				},
 				{
 					cmd:    "blkid",
-					args:   fmt.Sprintf("--match-tag UUID --output value %v", stagingPath),
+					args:   fmt.Sprintf("--match-tag UUID --output value /dev/disk/fake-path"),
 					stdout: btrfsUUID + "\n",
 				},
 			},


### PR DESCRIPTION
This is a stupidly silly error. `blkid` accepts device path, not the mount point.

When I initially backported my changes from the internal repo, I backported them from the wrong branch.

**What type of PR is this?**

/kind bug

**Which issue(s) this PR fixes**:
Fixes #2247

I would _love_ to add an integration test that tests for those, but we need CoS 125+ on the test runners.

```release-note
Use device path instead of mount point for blkid
```