### PR TITLE
Replace kubelet volume mount  with subdirectories

### DIFF
--- a/deploy/kubernetes/base/node_linux/node.yaml
+++ b/deploy/kubernetes/base/node_linux/node.yaml
@@ -56,8 +56,11 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
-            - name: kubelet-dir
-              mountPath: /var/lib/kubelet
+            - name:  kubelet-plugin-dir
+              mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
+              mountPropagation: "Bidirectional"
+            - name: kubelet-pods
+              mountPath: /var/lib/kubelet/pods
               mountPropagation: "Bidirectional"
             - name: plugin-dir
               mountPath: /csi
@@ -81,10 +84,13 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins_registry/
             type: Directory
-        - name: kubelet-dir
+        - name: kubelet-pods
           hostPath:
-            path: /var/lib/kubelet
-            type: Directory
+            path: /var/lib/kubelet/pods
+        - name: kubelet-plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/kubernetes.io/csi
+            type: DirectoryOrCreate
         - name: plugin-dir
           hostPath:
             path: /var/lib/kubelet/plugins/pd.csi.storage.gke.io/

--- a/deploy/kubernetes/base/node_windows/node.yaml
+++ b/deploy/kubernetes/base/node_windows/node.yaml
@@ -50,8 +50,11 @@ spec:
           command:
             - /gce-pd-csi-driver
           volumeMounts:
-            - name: kubelet-dir
-              mountPath: C:\var\lib\kubelet
+            - name: kubelet-plugin-dir
+              mountPath: C:\var\lib\kubelet\plugins\kubernetes.io\csi
+              mountPropagation: "None"
+            - name: kubelet-pods
+              mountPath: C:\var\lib\kubelet\pods
               mountPropagation: "None"
             - name: plugin-dir
               mountPath: C:\csi
@@ -100,10 +103,13 @@ spec:
         hostPath:
           path: \var\lib\kubelet\plugins_registry
           type: Directory
-      - name: kubelet-dir
+      - name: kubelet-pods
         hostPath:
-          path: \var\lib\kubelet
-          type: Directory
+          path: \var\lib\kubelet\pods
+      - name: kubelet-plugin-dir
+        hostPath:
+          path: \var\lib\kubelet\plugins\kubernetes.io\csi
+          type: DirectoryOrCreate
       - name: plugin-dir
         hostPath:
           path: \var\lib\kubelet\plugins\pd.csi.storage.gke.io


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind bug

**What this PR does / why we need it**:

The driver was previously mounting the entire /var/lib/kubelet host directory. This broad access violates the principle of least privilege by exposing sensitive subdirectories—such as /var/lib/kubelet/pki/ (node certificates) and /var/lib/kubelet/pods/ (all pod volumes and tokens)—to the CSI container. 

This change replaces the single broad root mount with restricted hostPath mounts.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
