### PR TITLE
release-1.20: fix snapshot storage-locations regex for regions with two-digit suffix

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -70,8 +70,8 @@ const (
 	// Reference: https://cloud.google.com/storage/docs/locations
 	// Example: us
 	multiRegionalLocationFmt = "^[a-z]+$"
-	// Example: us-east1
-	regionalLocationFmt = "^[a-z]+-[a-z]+[0-9]$"
+	// Example: us-east1, europe-west10 (suffix may be one or two digits)
+	regionalLocationFmt = "^[a-z]+-[a-z]+[0-9]{1,2}$"
 
 	// Full or partial URL of the machine type resource, in the format:
 	//   zones/zone/machineTypes/machine-type

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -805,6 +805,18 @@ func TestSnapshotStorageLocations(t *testing.T) {
 			false,
 		},
 		{
+			"valid region two-digit suffix (europe-west10)",
+			"europe-west10",
+			[]string{"europe-west10"},
+			false,
+		},
+		{
+			"valid region two-digit suffix (europe-west12)",
+			"EUROPE-WEST12",
+			[]string{"europe-west12"},
+			false,
+		},
+		{
 			// Zones are not valid bucket/snapshot locations.
 			"single zone",
 			"us-east1a",


### PR DESCRIPTION
## Problem
`ProcessStorageLocations` rejected valid GCP regions whose name ends in two digits (e.g. `europe-west10`, `europe-west12`) because `regionalLocationFmt` only allowed a single trailing digit (`[0-9]$`). That produced CSI errors such as:

```
Invalid snapshot parameters: invalid location for snapshot: "europe-west10"
```

before any Compute Engine API call. GKE 1.20.x still ships a driver built from this line of releases.

## Change
- Use `[0-9]{1,2}$` to match release-1.21+ and master (`pkg/parameters/utils.go`).
- Extend `TestSnapshotStorageLocations` with `europe-west10` / `europe-west12`.

## Testing
```
go test ./pkg/common/... -run TestSnapshotStorageLocations -count=1 -v
```

Made with [Cursor](https://cursor.com)