### PR TITLE
Add cluster identification label

### DIFF
--- a/cmd/gce-pd-csi-driver/main.go
+++ b/cmd/gce-pd-csi-driver/main.go
@@ -113,7 +113,8 @@ var (
 
 	dynamicVolumes = flag.Bool("dynamic-volumes", false, "If set to true, the CSI driver will automatically select a compatible disk type based on the presence of the dynamic-volume parameter and disk types defined in the StorageClass. Disabled by default.")
 
-	gceDiskStatus = flag.Bool("gce-disk-status", false, "If set to true, the CSI driver will update the volume-publish-status-gke-io label on GCE disks after successful attachment to indicate the attachment status. Disabled by default.")
+	gceDiskStatus      = flag.Bool("gce-disk-status", false, "If set to true, the CSI driver will update the volume-publish-status-gke-io label on the GCE disk resource after successful attachment to indicate the attachment status. Disabled by default.")
+	clusterOwnershipID = flag.String("cluster-ownership-id", "", "The identifier for the cluster to which the CSI driver belongs. When specified, the id is applied to the GCE disk resource as a label")
 
 	diskCacheSyncPeriod = flag.Duration("disk-cache-sync-period", 10*time.Minute, "Period for the disk cache to check the /dev/disk/by-id/ directory and evaluate the symlinks")
 
@@ -231,6 +232,10 @@ func handle() {
 		klog.Fatalf("Bad extra tags: %v", err.Error())
 	}
 
+	if convert.CheckLabelValue(*clusterOwnershipID) != nil {
+		klog.Fatalf("Bad cluster ownership ID: %v", *clusterOwnershipID)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -296,6 +301,7 @@ func handle() {
 			EnableDynamicVolumes:     *dynamicVolumes,
 			EnableGCEDiskStatus:      *gceDiskStatus,
 			EnablePdConversion:       *enablePdConversion,
+			ClusterOwnershipID:       *clusterOwnershipID,
 		}
 
 		controllerServer = driver.NewControllerServer(gceDriver, cloudProvider, initialBackoffDuration, maxBackoffDuration, fallbackRequisiteZones, *enableStoragePoolsFlag, *enableDataCacheFlag, multiZoneVolumeHandleConfig, listVolumesConfig, provisionableDisksConfig, *enableHdHAFlag, args)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -81,6 +81,9 @@ const (
 	VolumePublishStatus = "volume-publish-status-gke-io"
 	ProvisioningStatus  = "provisioning"
 	AttachedStatus      = "attaching"
+
+	// ClusterIDLabel is the key in disk labels to indicate the cluster identifier of the disk.
+	ClusterIDLabel = "cluster-id-gke-io"
 )
 
 // doc https://cloud.google.com/compute/docs/general-purpose-machines

--- a/pkg/convert/convert.go
+++ b/pkg/convert/convert.go
@@ -56,6 +56,14 @@ func ConvertStringToBool(str string) (bool, error) {
 	return false, fmt.Errorf("Unexpected boolean string %s", str)
 }
 
+func CheckLabelValue(value string) error {
+	regexValue, _ := regexp.Compile(`^[\p{Ll}0-9_-]{0,63}$`)
+	if !regexValue.MatchString(value) {
+		return fmt.Errorf("label value %q is invalid (lowercase letter, digit, _ and - chars are allowed / 0-63 characters", value)
+	}
+	return nil
+}
+
 // ConvertLabelsStringToMap converts the labels from string to map
 // example: "key1=value1,key2=value2" gets converted into {"key1": "value1", "key2": "value2"}
 // See https://cloud.google.com/compute/docs/labeling-resources#label_format for details.
@@ -76,15 +84,6 @@ func ConvertLabelsStringToMap(labels string) (map[string]string, error) {
 		return nil
 	}
 
-	regexValue, _ := regexp.Compile(`^[\p{Ll}0-9_-]{0,63}$`)
-	checkLabelValueFn := func(value string) error {
-		if !regexValue.MatchString(value) {
-			return fmt.Errorf("label value %q is invalid (lowercase letter, digit, _ and - chars are allowed / 0-63 characters", value)
-		}
-
-		return nil
-	}
-
 	keyValueStrings := strings.Split(labels, labelsDelimiter)
 	for _, keyValue := range keyValueStrings {
 		keyValue := strings.Split(keyValue, labelsKeyValueDelimiter)
@@ -99,7 +98,7 @@ func ConvertLabelsStringToMap(labels string) (map[string]string, error) {
 		}
 
 		value := strings.TrimSpace(keyValue[1])
-		if err := checkLabelValueFn(value); err != nil {
+		if err := CheckLabelValue(value); err != nil {
 			return nil, err
 		}
 

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -122,6 +122,9 @@ type GCEControllerServer struct {
 	// If set to true, the CSI Driver will update volume publish status labels on GCE disks.
 	enableGCEDiskStatus bool
 
+	// ClusterOwnershipID stores the cluster ownership identifier.
+	clusterOwnershipID string
+
 	multiZoneVolumeHandleConfig MultiZoneVolumeHandleConfig
 
 	listVolumesConfig ListVolumesConfig
@@ -144,6 +147,7 @@ type GCEControllerServerArgs struct {
 	EnableDynamicVolumes     bool
 	EnableGCEDiskStatus      bool
 	EnablePdConversion       bool
+	ClusterOwnershipID       string
 }
 
 type MultiZoneVolumeHandleConfig struct {
@@ -1536,6 +1540,7 @@ func (gceCS *GCEControllerServer) parameterProcessor() *parameters.ParameterProc
 		ExtraTags:            gceCS.Driver.extraTags,
 		EnableDynamicVolumes: gceCS.enableDynamicVolumes,
 		EnableGCEDiskStatus:  gceCS.enableGCEDiskStatus,
+		ClusterOwnershipID:   gceCS.clusterOwnershipID,
 	}
 }
 

--- a/pkg/gce-pd-csi-driver/gce-pd-driver.go
+++ b/pkg/gce-pd-csi-driver/gce-pd-driver.go
@@ -184,6 +184,7 @@ func NewControllerServer(gceDriver *GCEDriver, cloudProvider gce.GCECompute, err
 		EnableDiskSizeValidation:    args.EnableDiskSizeValidation,
 		enableGCEDiskStatus:         args.EnableGCEDiskStatus,
 		EnablePdConversion:          args.EnablePdConversion,
+		clusterOwnershipID:          args.ClusterOwnershipID,
 	}
 }
 

--- a/pkg/parameters/parameters.go
+++ b/pkg/parameters/parameters.go
@@ -52,6 +52,9 @@ func (pp *ParameterProcessor) ExtractAndDefaultParameters(parameters map[string]
 	if pp.EnableGCEDiskStatus {
 		p.Labels[constants.VolumePublishStatus] = constants.ProvisioningStatus
 	}
+	if pp.ClusterOwnershipID != "" {
+		p.Labels[constants.ClusterIDLabel] = pp.ClusterOwnershipID
+	}
 
 	for k, v := range pp.ExtraTags {
 		p.ResourceTags[k] = v

--- a/pkg/parameters/parameters_test.go
+++ b/pkg/parameters/parameters_test.go
@@ -30,6 +30,7 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 		name                  string
 		parameters            map[string]string
 		labels                map[string]string
+		clusterID             string
 		enableStoragePools    bool
 		enableDataCache       bool
 		enableMultiZone       bool
@@ -550,12 +551,29 @@ func TestExtractAndDefaultParameters(t *testing.T) {
 				ResourceTags: map[string]string{},
 			},
 		},
+		{
+			name:       "Cluster ownership ID specified",
+			clusterID:  "test-cluster",
+			parameters: map[string]string{},
+			labels:     map[string]string{},
+			expectParams: DiskParameters{
+				DiskType:             "pd-standard",
+				ReplicationType:      "none",
+				DiskEncryptionKMSKey: "",
+				Tags:                 map[string]string{},
+				Labels: map[string]string{
+					constants.ClusterIDLabel: "test-cluster",
+				},
+				ResourceTags: map[string]string{},
+			},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			pp := ParameterProcessor{
 				DriverName:          "testDriver",
+				ClusterOwnershipID:  tc.clusterID,
 				EnableStoragePools:  tc.enableStoragePools,
 				EnableMultiZone:     tc.enableMultiZone,
 				EnableHdHA:          tc.enableHdHA,

--- a/pkg/parameters/types.go
+++ b/pkg/parameters/types.go
@@ -98,6 +98,7 @@ type ParameterProcessor struct {
 	EnableDataCache      bool
 	EnableDynamicVolumes bool
 	EnableGCEDiskStatus  bool
+	ClusterOwnershipID   string
 	ExtraVolumeLabels    map[string]string
 	ExtraTags            map[string]string
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
/kind feature

**What this PR does / why we need it**:
This PR adds a cluster id label to GCE disks on creation. These labels can be used to identify which GCE disks are associated with what cluster. 

This is an important prerequisite for the garbage collector to prevent deleting disks associated with tombstone clusters. In GKE this flag will be set via the control plane to a base 32 encoding of the cluster hash. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Enable cluster-id labels add to GCE disks by setting the `--cluster-identifier` flag.
```
