### PR TITLE
Garbage collector for leaked disks

### DIFF
--- a/cmd/gce-pd-csi-driver/main.go
+++ b/cmd/gce-pd-csi-driver/main.go
@@ -114,6 +114,7 @@ var (
 	dynamicVolumes = flag.Bool("dynamic-volumes", false, "If set to true, the CSI driver will automatically select a compatible disk type based on the presence of the dynamic-volume parameter and disk types defined in the StorageClass. Disabled by default.")
 
 	gceDiskStatus      = flag.Bool("gce-disk-status", false, "If set to true, the CSI driver will update the volume-publish-status-gke-io label on the GCE disk resource after successful attachment to indicate the attachment status. Disabled by default.")
+	enableDiskCleanup  = flag.Bool("enable-disk-cleanup", false, "If set to true, the CSI driver will run a routine on startup to cleanup leaked GCE disks resources. Requires the cluster-ownership-id flag to be set. Disabled by default.")
 	clusterOwnershipID = flag.String("cluster-ownership-id", "", "The identifier for the cluster to which the CSI driver belongs. When specified, the id is applied to the GCE disk resource as a label")
 
 	diskCacheSyncPeriod = flag.Duration("disk-cache-sync-period", 10*time.Minute, "Period for the disk cache to check the /dev/disk/by-id/ directory and evaluate the symlinks")
@@ -126,10 +127,6 @@ var (
 	taintMetricsAddr   = flag.String("taint-metrics-addr", ":8081", "The address the taint controller metrics endpoint binds to.")
 
 	version string
-)
-
-const (
-	driverName = "pd.csi.storage.gke.io"
 )
 
 func init() {
@@ -305,6 +302,15 @@ func handle() {
 		}
 
 		controllerServer = driver.NewControllerServer(gceDriver, cloudProvider, initialBackoffDuration, maxBackoffDuration, fallbackRequisiteZones, *enableStoragePoolsFlag, *enableDataCacheFlag, multiZoneVolumeHandleConfig, listVolumesConfig, provisionableDisksConfig, *enableHdHAFlag, args)
+		if *gceDiskStatus {
+			// Block startup if configured incorrectly, but fail-open on the cleanup routine.
+			if *clusterOwnershipID == "" {
+				klog.Fatalf("Cannot enable cleanup routine without cluster ownership ID specified")
+			}
+			if err := controllerServer.VerifyClusterDisks(ctx, *enableDiskCleanup); err != nil {
+				klog.Errorf("Failed to verify cluster disks: %v", err)
+			}
+		}
 	} else if *cloudConfigFilePath != "" {
 		klog.Warningf("controller service is disabled but cloud config given - it has no effect")
 	}
@@ -328,7 +334,7 @@ func handle() {
 			klog.Fatalf("Failed to get node info from API server: %v", err.Error())
 		}
 
-		deviceCache, err := linkcache.NewDeviceCacheForNode(ctx, *diskCacheSyncPeriod, *nodeName, driverName, deviceUtils, metricsManager)
+		deviceCache, err := linkcache.NewDeviceCacheForNode(ctx, *diskCacheSyncPeriod, *nodeName, constants.DriverName, deviceUtils, metricsManager)
 		if err != nil {
 			klog.Warningf("Failed to create device cache: %v", err.Error())
 		} else {
@@ -366,7 +372,7 @@ func handle() {
 
 	}
 
-	err = gceDriver.SetupGCEDriver(driverName, version, extraVolumeLabels, extraTags, identityServer, controllerServer, nodeServer)
+	err = gceDriver.SetupGCEDriver(constants.DriverName, version, extraVolumeLabels, extraTags, identityServer, controllerServer, nodeServer)
 	if err != nil {
 		klog.Fatalf("Failed to initialize GCE CSI Driver: %v", err.Error())
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -21,6 +21,8 @@ import (
 )
 
 const (
+	DriverName = "pd.csi.storage.gke.io"
+
 	// Keys for Topology. This key will be shared amongst drivers from GCP
 	TopologyKeyZone = "topology.gke.io/zone"
 
@@ -80,6 +82,7 @@ const (
 	// VolumePublishStatus is the key in volume publish context to indicate the status of the volume.
 	VolumePublishStatus = "volume-publish-status-gke-io"
 	ProvisioningStatus  = "provisioning"
+	ProvisionedStatus   = "provisioned"
 	AttachedStatus      = "attaching"
 
 	// ClusterIDLabel is the key in disk labels to indicate the cluster identifier of the disk.

--- a/pkg/gce-pd-csi-driver/cleanup.go
+++ b/pkg/gce-pd-csi-driver/cleanup.go
@@ -1,0 +1,180 @@
+package gceGCEDriver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	computev1 "google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+	corev1 "k8s.io/api/core/v1"
+	kubeApiErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/constants"
+)
+
+const (
+	selfLinkPrefix = "https://www.googleapis.com/compute/v1/"
+
+	pvcNamespaceKey = "kubernetes.io/created-for/pvc/namespace"
+	pvcNameKey      = "kubernetes.io/created-for/pvc/name"
+	pvNameKey       = "kubernetes.io/created-for/pv/name"
+	createdByKey    = "storage.gke.io/created-by"
+)
+
+// VerifyClusterDisks checks validateds GCE disks associated with the cluster for potential leaked resources,
+// and deletes them if enableDiskCleanup is true.
+func (gceCS *GCEControllerServer) VerifyClusterDisks(ctx context.Context, enableDiskCleanup bool) error {
+	klog.V(4).Infof("Starting disk leak cleanup cycle")
+
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get Kubernetes config: %w", err)
+	}
+	kc, err := client.New(cfg, client.Options{})
+	if err != nil {
+		return fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	disks, err := gceCS.listDisks(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list disks: %w", err)
+	}
+
+	// Avoid blocking controller start up by handling the disks asynchronously. Since
+	// handle disk performs a no-op if a PVC exists, race conditions with the driver is a
+	// a non-issue.
+	go func() {
+		bgCtx := context.WithoutCancel(ctx)
+		for _, disk := range disks {
+			if err := handleDisk(bgCtx, disk, kc, gceCS, enableDiskCleanup); err != nil {
+				klog.Errorf("failed to handle potential leaked disk %v", disk.SelfLink)
+			}
+		}
+	}()
+	return nil
+}
+
+func (gceCS *GCEControllerServer) listDisks(ctx context.Context) ([]*computev1.Disk, error) {
+	if gceCS.clusterOwnershipID == "" {
+		return nil, fmt.Errorf("missing cluster ownership identifier")
+	}
+	clusterFilter := labelFilter(constants.ClusterIDLabel, gceCS.clusterOwnershipID)
+	statusFilter := labelFilter(constants.VolumePublishStatus, constants.ProvisioningStatus)
+	filter := fmt.Sprintf("%s AND %s", clusterFilter, statusFilter)
+	disks, _, err := gceCS.CloudProvider.ListDisksWithFilter(ctx, []googleapi.Field{}, filter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list disks: %w", err)
+	}
+	klog.V(4).Infof("Listed %d disks with filter: %s", len(disks), filter)
+	return disks, nil
+}
+
+func handleDisk(ctx context.Context, disk *computev1.Disk, kc client.Client, gceCS *GCEControllerServer, enableDiskCleanup bool) error {
+	volumeID, tags, err := getDiskMeta(disk)
+	if err != nil {
+		return fmt.Errorf("failed to parse disk meta: %v", err)
+	}
+
+	project, volKey, err := common.VolumeIDToKey(strings.TrimPrefix(disk.SelfLink, selfLinkPrefix))
+	if err != nil {
+		return fmt.Errorf("failed to parse volume ID: %w", err)
+	}
+
+	hasPV, hasPVC, err := validateAssociatedObjects(ctx, kc, tags)
+	if err != nil {
+		return fmt.Errorf("failed to validate associated objects: %v", err)
+	}
+
+	// Refetch the disk to check current state since time may have passed since the initial list.
+	curDisk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey)
+	if err != nil {
+		return fmt.Errorf("failed to get current disk state for %s: %v", volKey, err)
+	}
+	lbls := curDisk.GetLabels()
+	if lbls == nil {
+		lbls = make(map[string]string)
+	}
+	// If current disk now has ProvisionedStatus, skip further processing.
+	if lbls[constants.VolumePublishStatus] == constants.ProvisionedStatus {
+		klog.V(4).Infof("Disk %s now has ProvisionedStatus, skipping processing", volumeID)
+		return nil
+	}
+
+	// Apply "provisioned" status to disks with existing PV.
+	if hasPV {
+		lbls[constants.VolumePublishStatus] = constants.ProvisionedStatus
+		err = gceCS.CloudProvider.SetDiskLabels(ctx, project, volKey, curDisk, lbls)
+		if err != nil {
+			return fmt.Errorf("failed to update status label for %s: %v", volKey, err)
+		}
+	}
+
+	// Skip cleanup for disks with existing PVC, as they may be in the process of being provisioned.
+	if hasPVC {
+		return nil
+	}
+
+	// Delete disks with no associated PV/PVC
+	klog.Warningf("Disk %s is leaked", volumeID)
+	if enableDiskCleanup {
+		err = gceCS.CloudProvider.DeleteDisk(ctx, project, volKey)
+		if err != nil {
+			return fmt.Errorf("failed to delete leaked disk %v: %v", volKey, err)
+		}
+	}
+	return nil
+}
+
+func labelFilter(key, value string) string {
+	return fmt.Sprintf("labels.%s=%s", key, value)
+}
+
+func getDiskMeta(disk *computev1.Disk) (string, map[string]string, error) {
+	volumeID := strings.TrimPrefix(disk.SelfLink, selfLinkPrefix)
+
+	var tags map[string]string
+	if err := json.Unmarshal([]byte(disk.Description), &tags); err != nil {
+		return "", nil, fmt.Errorf("failed to unmarshal disk description for disk: %w", err)
+	}
+
+	requiredKeys := []string{pvcNamespaceKey, pvcNameKey, pvNameKey, createdByKey}
+	for _, key := range requiredKeys {
+		if tags[key] == "" {
+			return "", nil, fmt.Errorf("disk description is missing value %s", key)
+		}
+	}
+	if tags[createdByKey] != constants.DriverName {
+		return "", nil, fmt.Errorf("disk is not managed by CSI driver")
+	}
+
+	return volumeID, tags, nil
+}
+
+func validateAssociatedObjects(ctx context.Context, c client.Client, tags map[string]string) (bool, bool, error) {
+	pvName := tags[pvNameKey]
+	pvcName := tags[pvcNameKey]
+	pvcNamespace := tags[pvcNamespaceKey]
+
+	var pvExists, pvcExists bool
+
+	err := c.Get(ctx, client.ObjectKey{Name: pvName}, &corev1.PersistentVolume{})
+	if err == nil {
+		pvExists = true
+	} else if !kubeApiErrors.IsNotFound(err) {
+		return false, false, fmt.Errorf("failed to get PV %s: %v", pvName, err)
+	}
+
+	err = c.Get(ctx, client.ObjectKey{Namespace: pvcNamespace, Name: pvcName}, &corev1.PersistentVolumeClaim{})
+	if err == nil {
+		pvcExists = true
+	} else if !kubeApiErrors.IsNotFound(err) {
+		return false, false, fmt.Errorf("failed to get PVC %s/%s: %v", pvcNamespace, pvcName, err)
+	}
+
+	return pvExists, pvcExists, nil
+}

--- a/pkg/gce-pd-csi-driver/cleanup_test.go
+++ b/pkg/gce-pd-csi-driver/cleanup_test.go
@@ -1,0 +1,336 @@
+package gceGCEDriver
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	computev1 "google.golang.org/api/compute/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/constants"
+	gcecloudprovider "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute"
+)
+
+const (
+	diskName = "test-disk"
+	volumeID = "projects/test-project/zones/us-central1-a/disks/test-disk"
+
+	testNamespace  = "default"
+	testPVCName    = "test-pvc"
+	testPVName     = "test-pv"
+	testDriverName = "pd.csi.storage.gke.io"
+)
+
+func TestGetDiskMeta(t *testing.T) {
+	tests := []struct {
+		name         string
+		disk         *computev1.Disk
+		wantVolumeID string
+		wantTags     map[string]string
+		wantErr      bool
+	}{
+		{
+			name: "valid disk with all required metadata",
+			disk: &computev1.Disk{
+				SelfLink: selfLinkPrefix + volumeID,
+				Description: mustMarshal(map[string]string{
+					pvcNamespaceKey: testNamespace,
+					pvcNameKey:      testPVCName,
+					pvNameKey:       testPVName,
+					createdByKey:    testDriverName,
+				}),
+			},
+			wantVolumeID: "projects/test-project/zones/us-central1-a/disks/test-disk",
+			wantTags: map[string]string{
+				pvcNamespaceKey: testNamespace,
+				pvcNameKey:      testPVCName,
+				pvNameKey:       testPVName,
+				createdByKey:    testDriverName,
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing pv name",
+			disk: &computev1.Disk{
+				SelfLink: selfLinkPrefix + volumeID,
+				Description: mustMarshal(map[string]string{
+					pvcNamespaceKey: testNamespace,
+					pvcNameKey:      testPVCName,
+					createdByKey:    "gce-pd-csi-driver",
+				}),
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing pvc name",
+			disk: &computev1.Disk{
+				SelfLink: selfLinkPrefix + volumeID,
+				Description: mustMarshal(map[string]string{
+					pvcNamespaceKey: testNamespace,
+					pvNameKey:       testPVName,
+					createdByKey:    "gce-pd-csi-driver",
+				}),
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing pvc namespace",
+			disk: &computev1.Disk{
+				SelfLink: selfLinkPrefix + volumeID,
+				Description: mustMarshal(map[string]string{
+					pvcNameKey:   testPVCName,
+					pvNameKey:    testPVName,
+					createdByKey: "gce-pd-csi-driver",
+				}),
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid JSON in description",
+			disk: &computev1.Disk{
+				SelfLink:    selfLinkPrefix + volumeID,
+				Description: "invalid json",
+			},
+			wantErr: true,
+		},
+		{
+			name: "disk not managed by CSI driver",
+			disk: &computev1.Disk{
+				SelfLink: selfLinkPrefix + volumeID,
+				Description: mustMarshal(map[string]string{
+					pvcNamespaceKey: testNamespace,
+					pvcNameKey:      testPVCName,
+					pvNameKey:       testPVName,
+					createdByKey:    "some-other-driver",
+				}),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotVolumeID, gotTags, err := getDiskMeta(tt.disk)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getDiskMeta() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if diff := cmp.Diff(tt.wantVolumeID, gotVolumeID); diff != "" {
+					t.Errorf("getDiskMeta() volumeID mismatch (-want +got):\n%s", diff)
+				}
+				if diff := cmp.Diff(tt.wantTags, gotTags); diff != "" {
+					t.Errorf("getDiskMeta() tags mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestLabelFilter(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+		want  string
+	}{
+		{
+			name:  "cluster ID filter",
+			key:   "cluster-id",
+			value: "test-cluster",
+			want:  "labels.cluster-id=test-cluster",
+		},
+		{
+			name:  "status filter",
+			key:   "status",
+			value: "provisioning",
+			want:  "labels.status=provisioning",
+		},
+		{
+			name:  "empty value",
+			key:   "key",
+			value: "",
+			want:  "labels.key=",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := labelFilter(tt.key, tt.value)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("labelFilter() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func mustMarshal(data map[string]string) string {
+	b, err := json.Marshal(data)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+func TestHandleDisk(t *testing.T) {
+	tests := []struct {
+		name               string
+		disk               *computev1.Disk
+		enableDiskDeletion bool
+		initialObjects     []client.Object
+		wantDisk           *gcecloudprovider.CloudDisk
+	}{
+		{
+			name: "pv & pvc exist -> update disk status",
+			disk: &computev1.Disk{
+				Name:     diskName,
+				SelfLink: selfLinkPrefix + volumeID,
+				Description: mustMarshal(map[string]string{
+					pvcNamespaceKey: testNamespace,
+					pvcNameKey:      testPVCName,
+					pvNameKey:       testPVName,
+					createdByKey:    testDriverName,
+				}),
+				Labels: map[string]string{
+					constants.VolumePublishStatus: constants.ProvisioningStatus,
+				},
+			},
+			initialObjects: []client.Object{
+				&v1.PersistentVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testPVName,
+					},
+				},
+				&v1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testPVCName,
+						Namespace: testNamespace,
+					},
+				},
+			},
+			enableDiskDeletion: true,
+			wantDisk: gcecloudprovider.CloudDiskFromV1(&computev1.Disk{
+				Labels: map[string]string{
+					constants.VolumePublishStatus: constants.ProvisionedStatus,
+				},
+			}),
+		},
+		{
+			name: "pvc only -> do nothing",
+			disk: &computev1.Disk{
+				Name:     diskName,
+				SelfLink: selfLinkPrefix + volumeID,
+				Description: mustMarshal(map[string]string{
+					pvcNamespaceKey: testNamespace,
+					pvcNameKey:      testPVCName,
+					pvNameKey:       testPVName,
+					createdByKey:    testDriverName,
+				}),
+				Labels: map[string]string{
+					constants.VolumePublishStatus: constants.ProvisioningStatus,
+				},
+			},
+			initialObjects: []client.Object{
+				&v1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testPVCName,
+						Namespace: testNamespace,
+					},
+				},
+			},
+			enableDiskDeletion: true,
+			wantDisk: gcecloudprovider.CloudDiskFromV1(&computev1.Disk{
+				Labels: map[string]string{
+					constants.VolumePublishStatus: constants.ProvisioningStatus,
+				},
+			}),
+		},
+		{
+			name: "no associated objects -> delete disk",
+			disk: &computev1.Disk{
+				Name:     diskName,
+				SelfLink: selfLinkPrefix + volumeID,
+				Description: mustMarshal(map[string]string{
+					pvcNamespaceKey: testNamespace,
+					pvcNameKey:      testPVCName,
+					pvNameKey:       testPVName,
+					createdByKey:    testDriverName,
+				}),
+				Labels: map[string]string{
+					constants.VolumePublishStatus: constants.ProvisioningStatus,
+				},
+			},
+			enableDiskDeletion: true,
+			wantDisk:           nil,
+		},
+		{
+			name: "no associated object with disk cleanup disabled -> do nothing",
+			disk: &computev1.Disk{
+				Name:     diskName,
+				SelfLink: selfLinkPrefix + volumeID,
+				Description: mustMarshal(map[string]string{
+					pvcNamespaceKey: testNamespace,
+					pvcNameKey:      testPVCName,
+					pvNameKey:       testPVName,
+					createdByKey:    testDriverName,
+				}),
+				Labels: map[string]string{
+					constants.VolumePublishStatus: constants.ProvisioningStatus,
+				},
+			},
+			enableDiskDeletion: false,
+			wantDisk: gcecloudprovider.CloudDiskFromV1(&computev1.Disk{
+				Labels: map[string]string{
+					constants.VolumePublishStatus: constants.ProvisioningStatus,
+				},
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Setup k8s fake client
+			builder := fake.NewClientBuilder()
+			if len(tt.initialObjects) > 0 {
+				builder.WithObjects(tt.initialObjects...)
+			}
+			kc := builder.Build()
+
+			// Setup fake cloud provider
+			var cloudDisks []*gcecloudprovider.CloudDisk
+			if tt.disk != nil {
+				cloudDisks = append(cloudDisks, gcecloudprovider.CloudDiskFromV1(tt.disk))
+			}
+			fcp, err := gcecloudprovider.CreateFakeCloudProvider("test-project", "us-central1-a", cloudDisks)
+			if err != nil {
+				t.Fatalf("failed to create fake cloud provider: %v", err)
+			}
+
+			gceCS := &GCEControllerServer{
+				CloudProvider: fcp,
+			}
+
+			if err := handleDisk(ctx, tt.disk, kc, gceCS, tt.enableDiskDeletion); err != nil {
+				t.Fatalf("handleDisk() error = %v", err)
+			}
+
+			project, volKey, err := common.VolumeIDToKey(volumeID)
+			if err != nil {
+				t.Fatalf("failed to parse volume ID: %v", err)
+			}
+
+			gotDisk, _ := fcp.GetDisk(ctx, project, volKey)
+			if diff := cmp.Diff(tt.wantDisk, gotDisk, cmp.AllowUnexported(gcecloudprovider.CloudDisk{}), cmpopts.IgnoreFields(computev1.Disk{}, "Description", "Name", "SelfLink")); diff != "" {
+				t.Errorf("disk mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


/kind feature

**What this PR does / why we need it**:
This PR adds a cleanup routine the controller start up, that verifies GCE disks associated with the cluster and deletes
any disks that never successfully became associated with a PersistentVolume. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Introduced `--enable-disk-cleanup` flag to enable deletion of leaked GCE disk resources. This requires both `--gce-disk-status` and `--cluster-ownership-id` to be set. 
```
