### PR TITLE
Automated cherry pick of #2312: Replace mt kubeconfig helper with sigs package

### DIFF
--- a/pkg/gce-cloud-provider/compute/gce.go
+++ b/pkg/gce-cloud-provider/compute/gce.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/time/rate"
 	"google.golang.org/api/option"
 	"gopkg.in/gcfg.v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute/tenancy"
 
@@ -199,7 +200,12 @@ func CreateCloudProvider(ctx context.Context, vendorVersion string, configPath s
 
 	if multiTenancyEnabled {
 		klog.Info("Setting up multitenancy")
-		ti, err := tenancy.NewTenantsInformer(multiTenancyEnabled, tenancy.GetKubeConfig())
+		cfg, err := config.GetConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get Kubernetes client configuration: %w", err)
+		}
+		ti, err := tenancy.NewTenantsInformer(multiTenancyEnabled, cfg)
+
 		if err != nil {
 			return nil, fmt.Errorf("failed initializing tenant informer: %w", err)
 		}


### PR DESCRIPTION
Cherry pick of #2312 on release-1.25.

#2312: Replace mt kubeconfig helper with sigs package

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```