### PR TITLE
Stop verify-gofmt.sh from crashing silently on xargs error

### DIFF
--- a/hack/verify-docker-deps.sh
+++ b/hack/verify-docker-deps.sh
@@ -24,3 +24,5 @@ PKG_ROOT=$(git rev-parse --show-toplevel)
 
 export GCE_PD_CSI_STAGING_IMAGE=validation-image
 make -C "${PKG_ROOT}" validate-container-linux
+
+echo "Successfully verified docker deps"

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -19,10 +19,27 @@ set -o pipefail
 
 echo "Verifying gofmt"
 
-diff=$(find . -name "*.go" | grep -v "\/vendor\/" | xargs gofmt -s -d 2>&1)
+# 1. Find the files and save them to a list
+go_files=$(find . -name "*.go" | grep -v "\/vendor\/")
+
+# 2. Check if we actually found any Go files to check
+if [[ -z "${go_files}" ]]; then
+  echo "No Go files found to verify."
+  exit 0
+fi
+
+# 3. Temporarily turn off 'errexit' (+e) so we can run xargs gofmt.
+# If gofmt finds unformatted code, it will fail, but the script won't crash.
+set +o errexit
+diff=$(echo "${go_files}" | xargs gofmt -s -d 2>&1)
+gofmt_exit_code=$?
+set -o errexit
+
 if [[ -n "${diff}" ]]; then
   echo "${diff}"
   echo
   echo "Please run hack/update-gofmt.sh"
   exit 1
 fi
+
+echo "Successfully verified gofmt"

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -20,3 +20,5 @@ set -o pipefail
 echo "Verifying govet"
 
 go vet $(go list ./... | grep -v vendor)
+
+echo "Successfully verified govet"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Stop verify-gofmt.sh from crashing silently on xargs error as it prevents us from understanding presubmit failures.

## Before this PR
<img width="2304" height="1622" alt="image" src="https://github.com/user-attachments/assets/149a2bcf-700a-4349-aed5-2207a967410b" />

## After this PR
<img width="3454" height="1478" alt="image" src="https://github.com/user-attachments/assets/9f359c74-28a5-4d69-adbf-5c2b33d65133" />

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Stop verify-gofmt.sh from crashing silently on xargs error.
```
