### PR TITLE
[btrfs] add an integration test

### DIFF
--- a/test/k8s-integration/config/sc-btrfs.yaml
+++ b/test/k8s-integration/config/sc-btrfs.yaml
@@ -11,5 +11,4 @@ mountOptions:
 parameters:
   type: pd-balanced
   csi.storage.k8s.io/fstype: btrfs
-  labels: key1=value1,key2=value2
 volumeBindingMode: WaitForFirstConsumer

--- a/test/k8s-integration/config/sc-btrfs.yaml
+++ b/test/k8s-integration/config/sc-btrfs.yaml
@@ -1,0 +1,15 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-gcepd-btrfs
+provisioner: pd.csi.storage.gke.io
+mountOptions:
+  - discard=async
+  - compress=zstd:3
+  - btrfs-bdi-read_ahead_kb=128
+  - btrfs-allocation-data-dynamic_reclaim=1
+parameters:
+  type: pd-balanced
+  csi.storage.k8s.io/fstype: btrfs
+  labels: key1=value1,key2=value2
+volumeBindingMode: WaitForFirstConsumer

--- a/test/k8s-integration/driver-config.go
+++ b/test/k8s-integration/driver-config.go
@@ -102,17 +102,20 @@ func generateDriverConfigFile(testParams *testParameters) (string, error) {
 			} else {
 				gkeVer = mustParseVersion(testParams.clusterVersion)
 			}
-			if gkeVer.lessThan(mustParseVersion("1.18.0")) {
-				// XFS is not supported on COS before 1.18.0
-			} else {
+
+			if gkeVer.atLeast(mustParseVersion("1.18.0")) {
 				fsTypes = append(fsTypes, "xfs")
 			}
+
+			if gkeVer.atLeast(mustParseVersion("1.34.0")) {
+				fsTypes = append(fsTypes, "btrfs")
+			}
 		} else {
-			// XFS is supported on all non-COS images.
-			fsTypes = append(fsTypes, "xfs")
+			// XFS and Btrfs are supported on all non-COS images.
+			fsTypes = append(fsTypes, "xfs", "btrfs")
 		}
 	case "gce":
-		fsTypes = append(fsTypes, "xfs")
+		fsTypes = append(fsTypes, "xfs", "btrfs")
 	default:
 		return "", fmt.Errorf("got unknown deployment strat %s, expected gce or gke", testParams.deploymentStrategy)
 	}

--- a/test/run-k8s-integration-ci.sh
+++ b/test/run-k8s-integration-ci.sh
@@ -43,7 +43,7 @@ rm -rf /usr/local/go && tar -xzf go_tar.tar.gz -C /usr/local
 # to run go commands with this go version.
 export PATH=$PATH:/usr/local/go/bin && go version && rm go_tar.tar.gz
 
-storage_classes=sc-ssd.yaml,sc-xfs.yaml
+storage_classes=sc-ssd.yaml,sc-xfs.yaml,sc-btrfs.yaml
 
 if [[ $test_pd_labels = true ]] ; then
   storage_classes=${storage_classes},sc-balanced.yaml

--- a/test/run-k8s-integration.sh
+++ b/test/run-k8s-integration.sh
@@ -48,7 +48,7 @@ base_cmd="${PKGDIR}/bin/k8s-integration-test \
             --run-in-prow=true --service-account-file=${E2E_GOOGLE_APPLICATION_CREDENTIALS} \
             --do-driver-build=${do_driver_build} --teardown-driver=${teardown_driver} \
             --do-k8s-build=${do_k8s_build} --boskos-resource-type=${boskos_resource_type} \
-            --storageclass-files=sc-btrfs.yaml --snapshotclass-files=pd-volumesnapshotclass.yaml \
+            --storageclass-files=sc-balanced.yaml --snapshotclass-files=pd-volumesnapshotclass.yaml \
             --storageclass-for-vac-file=sc-hdb.yaml \
             --kube-runtime-config=api/all=true \
             --deployment-strategy=${deployment_strategy} --test-version=${test_version} \

--- a/test/run-k8s-integration.sh
+++ b/test/run-k8s-integration.sh
@@ -48,7 +48,7 @@ base_cmd="${PKGDIR}/bin/k8s-integration-test \
             --run-in-prow=true --service-account-file=${E2E_GOOGLE_APPLICATION_CREDENTIALS} \
             --do-driver-build=${do_driver_build} --teardown-driver=${teardown_driver} \
             --do-k8s-build=${do_k8s_build} --boskos-resource-type=${boskos_resource_type} \
-            --storageclass-files=sc-balanced.yaml --snapshotclass-files=pd-volumesnapshotclass.yaml \
+            --storageclass-files=sc-btrfs.yaml --snapshotclass-files=pd-volumesnapshotclass.yaml \
             --storageclass-for-vac-file=sc-hdb.yaml \
             --kube-runtime-config=api/all=true \
             --deployment-strategy=${deployment_strategy} --test-version=${test_version} \


### PR DESCRIPTION
Now that the integration tests seem to be running on COS 125, we can add an integration test for Btrfs (for which supported is enabled from COS 125 onwards).

Adding various mountOptions: some of them are native to btrfs, others (`btrfs-`) are this pdcsi-specific and are handled specially.

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Follow-up from #2001

**Special notes for your reviewer**:  The change in `test/run-k8s-integration.sh is up for debate: do we want to use Btrfs in the pre-merge integration tests, or shall we satisfy running them on TestGrid alone?

**Does this PR introduce a user-facing change?**: NONE