### PR TITLE
Improve observability in the pdcsi process

### DIFF
--- a/cmd/gce-pd-csi-driver/main.go
+++ b/cmd/gce-pd-csi-driver/main.go
@@ -198,6 +198,7 @@ func handle() {
 	runServiceWithMetrics := *runControllerService || *runNodeService
 	if runServiceWithMetrics && *httpEndpoint != "" {
 		mm := metrics.NewMetricsManager()
+		mm.RegisterRuntimeMetrics()
 		mm.InitializeHttpHandler(*httpEndpoint, *metricsPath)
 
 		switch {

--- a/cmd/gce-pd-csi-driver/main.go
+++ b/cmd/gce-pd-csi-driver/main.go
@@ -56,7 +56,7 @@ var (
 	endpoint             = flag.String("endpoint", "unix:/tmp/csi.sock", "CSI endpoint")
 	runControllerService = flag.Bool("run-controller-service", true, "If set to false then the CSI driver does not activate its controller service (default: true)")
 	runNodeService       = flag.Bool("run-node-service", true, "If set to false then the CSI driver does not activate its node service (default: true)")
-	httpEndpoint         = flag.String("http-endpoint", "", "The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled.")
+	httpEndpoint         = flag.String("http-endpoint", "", "The TCP network address where the prometheus metrics endpoint will listen (example: `127.0.0.1:8080`). The default is empty string, which means metrics endpoint is disabled. The endpoint contains internal system state (go runtime), which can help attackers better understand system internals, so should not be publicly exposed")
 	metricsPath          = flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.")
 	grpcLogCharCap       = flag.Int("grpc-log-char-cap", 10000, "The maximum amount of characters logged for every grpc responses")
 	enableOtelTracing    = flag.Bool("enable-otel-tracing", false, "If set, enable opentelemetry tracing for the driver. The tracing is disabled by default. Configure the exporter endpoint with OTEL_EXPORTER_OTLP_ENDPOINT and other env variables, see https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration.")

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -20,8 +20,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/pprof"
 	"os"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc/codes"
 	"k8s.io/component-base/metrics"
 	"k8s.io/klog/v2"
@@ -92,6 +94,13 @@ func (mm *MetricsManager) GetRegistry() metrics.KubeRegistry {
 
 func (mm *MetricsManager) registerComponentVersionMetric() {
 	mm.registry.MustRegister(gkeComponentVersion)
+}
+
+func (mm *MetricsManager) RegisterRuntimeMetrics() {
+	mm.registry.RawMustRegister(
+		prometheus.NewGoCollector(),
+		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+	)
 }
 
 func (mm *MetricsManager) RegisterPDCSIMetric() {
@@ -168,10 +177,15 @@ func (mm *MetricsManager) registerToServer(s Server, metricsPath string) {
 			ErrorHandling: metrics.ContinueOnError}))
 }
 
-// InitializeHttpHandler sets up a server and creates a handler for metrics.
+// InitializeHttpHandler sets up a server and creates a handler for metrics and pprof.
 func (mm *MetricsManager) InitializeHttpHandler(address, path string) {
 	mux := http.NewServeMux()
 	mm.registerToServer(mux, path)
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	go func() {
 		klog.Infof("Metric server listening at %q", address)
 		if err := http.ListenAndServe(address, mux); err != nil {


### PR DESCRIPTION
1. Add pprof endpoints, so one can use `go tool pprof <...>`:

    go tool pprof -http=127.0.0.1:8081 http://localhost:22015/debug/pprof/heap

    .. opens up a browser with the detailed heap profile.

2. Add `/metrics` endpoint, which will emit Go runtime metrics for scraping:

```
$ curl -s localhost:22015/metrics | grep -v ^# | head
go_gc_duration_seconds{quantile="0"} 4.4184e-05
go_gc_duration_seconds{quantile="0.25"} 5.0415e-05
go_gc_duration_seconds{quantile="0.5"} 5.1984e-05
go_gc_duration_seconds{quantile="0.75"} 5.4292e-05
go_gc_duration_seconds{quantile="1"} 6.5013e-05
go_gc_duration_seconds_sum 0.483941779
go_gc_duration_seconds_count 8954
go_gc_gogc_percent 100
go_gc_gomemlimit_bytes 9.223372036854776e+18
go_goroutines 15
```

This is only enabled when pdcsi is invoked with `--http-endpoint=:PORT`, which is off by default.

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**: understand the Go runtime of pdcsi better.

**Does this PR introduce a user-facing change?**: YES
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
If --http-endpoint=:PORT is passed to the pdcsi-node process, `/debug/pprof` and `/metrics` endpoints become available.
```
