### PR TITLE
cloudbuild: pin gcb-docker-gcloud to current digest

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,7 +6,7 @@ options:
   substitution_option: ALLOW_LOOSE
 
 steps:
-  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079"
+  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2" # v20260205-38cfa9523f
     entrypoint: make
     env:
       - GCE_PD_CSI_STAGING_IMAGE=gcr.io/${_STAGING_PROJECT}/gcp-compute-persistent-disk-csi-driver
@@ -16,7 +16,7 @@ steps:
       - HOME=/root
     args:
       - build-and-push-multi-arch
-  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079"
+  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2" # v20260205-38cfa9523f
     entrypoint: make
     env:
       - GCE_PD_CSI_STAGING_IMAGE=gcr.io/${_STAGING_PROJECT}/gce-pd-node-labeler


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind cleanup

**What this PR does / why we need it**:

Staging registry retention removed older `gcb-docker-gcloud` tags; the previous tag caused `manifest unknown` on image push jobs. Pin both Cloud Build steps to the current image digest and keep the semantic tag in a comment for readability.

**Which issue(s) this PR fixes**:
Related: https://github.com/kubernetes/kubernetes/issues/138936

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
