### PR TITLE
Fix typo: Recieved -> Received in test error message

### DIFF
--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -6124,7 +6124,7 @@ func TestCreateConfidentialVolume(t *testing.T) {
 				if !ok {
 					t.Fatalf("Could not get error status code from err: %v", serverError)
 				}
-				t.Errorf("Recieved error %v", serverError)
+				t.Errorf("Received error %v", serverError)
 			}
 
 			volumeId := resp.GetVolume().VolumeId


### PR DESCRIPTION
Corrects the misspelling 'Recieved' to 'Received' in a controller test error message.

```release-note
NONE
```