### PR TITLE
Add init-container for storage class default annotation restoration

### DIFF
--- a/Dockerfile.default-sc-rollback-handler
+++ b/Dockerfile.default-sc-rollback-handler
@@ -1,0 +1,29 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+
+ARG STAGINGVERSION
+ARG TARGETPLATFORM
+
+WORKDIR /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+ADD . .
+RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') GCE_PD_CSI_STAGING_VERSION=$STAGINGVERSION make gce-pd-default-sc-rollback-handler
+
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/bin/gce-pd-default-sc-rollback-handler .
+USER 65532:65532
+
+ENTRYPOINT ["/gce-pd-default-sc-rollback-handler"]

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,10 @@ GCE_PD_CSI_STAGING_VERSION ?= ${REV}
 STAGINGVERSION=${GCE_PD_CSI_STAGING_VERSION}
 STAGINGIMAGE=${GCE_PD_CSI_STAGING_IMAGE}
 LABELERSTAGINGIMAGE?=${STAGINGIMAGE}/gce-pd-node-labeler
+DEFAULTSCROLLBACKHANDLERSTAGINGIMAGE?=${STAGINGIMAGE}/gce-pd-default-sc-rollback-handler
 DRIVERBINARY=gce-pd-csi-driver
 LABELERBINARY=gce-pd-node-labeler
+DEFAULTSCROLLBACKHANDLERBINARY=gce-pd-default-sc-rollback-handler
 DRIVERWINDOWSBINARY=${DRIVERBINARY}.exe
 
 DOCKER=DOCKER_CLI_EXPERIMENTAL=enabled docker
@@ -45,6 +47,10 @@ gce-pd-driver: require-GCE_PD_CSI_STAGING_VERSION
 gce-pd-node-labeler: require-GCE_PD_CSI_STAGING_VERSION
 	mkdir -p bin
 	CGO_ENABLED=0 go build -mod=vendor -gcflags=$(GCFLAGS) -ldflags "-extldflags=static -X main.version=$(STAGINGVERSION)" -o bin/${LABELERBINARY} ./cmd/gce-pd-node-labeler/
+
+gce-pd-default-sc-rollback-handler: require-GCE_PD_CSI_STAGING_VERSION
+	mkdir -p bin
+	CGO_ENABLED=0 go build -mod=vendor -gcflags=$(GCFLAGS) -ldflags "-extldflags=static -X main.version=$(STAGINGVERSION)" -o bin/${DEFAULTSCROLLBACKHANDLERBINARY} ./cmd/default-sc-rollback-handler/
 
 gce-pd-driver-windows: require-GCE_PD_CSI_STAGING_VERSION
 ifeq (${GOARCH}, amd64)
@@ -86,6 +92,22 @@ build-and-push-multi-arch-debug: build-and-push-container-linux-debug build-and-
 build-and-push-node-labeler-multi-arch: build-node-labeler-container-linux-amd64 build-node-labeler-container-linux-arm64
 	$(DOCKER) manifest create $(LABELERSTAGINGIMAGE):$(STAGINGVERSION) $(LABELERSTAGINGIMAGE):$(STAGINGVERSION)_linux_amd64 $(LABELERSTAGINGIMAGE):$(STAGINGVERSION)_linux_arm64
 	$(DOCKER) manifest push -p $(LABELERSTAGINGIMAGE):$(STAGINGVERSION)
+
+build-default-sc-rollback-handler-linux-amd64: require-GCE_PD_CSI_STAGING_IMAGE init-buildx
+	$(DOCKER) buildx build --file=Dockerfile.default-sc-rollback-handler --platform=linux/amd64 \
+		-t $(DEFAULTSCROLLBACKHANDLERSTAGINGIMAGE):$(STAGINGVERSION)_linux_amd64 \
+		--build-arg BUILDPLATFORM=linux \
+		--build-arg STAGINGVERSION=$(STAGINGVERSION) --push --provenance=false .
+
+build-default-sc-rollback-handler-linux-arm64: require-GCE_PD_CSI_STAGING_IMAGE init-buildx
+	$(DOCKER) buildx build --file=Dockerfile.default-sc-rollback-handler --platform=linux/arm64 \
+		-t $(DEFAULTSCROLLBACKHANDLERSTAGINGIMAGE):$(STAGINGVERSION)_linux_arm64 \
+		--build-arg BUILDPLATFORM=linux \
+		--build-arg STAGINGVERSION=$(STAGINGVERSION) --push --provenance=false .
+
+build-and-push-default-sc-rollback-handler-multi-arch: build-default-sc-rollback-handler-linux-amd64 build-default-sc-rollback-handler-linux-arm64
+	$(DOCKER) manifest create $(DEFAULTSCROLLBACKHANDLERSTAGINGIMAGE):$(STAGINGVERSION) $(DEFAULTSCROLLBACKHANDLERSTAGINGIMAGE):$(STAGINGVERSION)_linux_amd64 $(DEFAULTSCROLLBACKHANDLERSTAGINGIMAGE):$(STAGINGVERSION)_linux_arm64
+	$(DOCKER) manifest push -p $(DEFAULTSCROLLBACKHANDLERSTAGINGIMAGE):$(STAGINGVERSION)
 
 push-container: build-container
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -26,6 +26,16 @@ steps:
       - HOME=/root
     args:
       - build-and-push-node-labeler-multi-arch
+  - name: "gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079"
+    entrypoint: make
+    env:
+      - GCE_PD_CSI_STAGING_IMAGE=gcr.io/${_STAGING_PROJECT}/gce-pd-default-sc-rollback-handler
+      - GCE_PD_CSI_STAGING_VERSION=${_PULL_BASE_REF}
+      # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx
+      # set the home to /root explicitly to if using docker buildx
+      - HOME=/root
+    args:
+      - build-and-push-default-sc-rollback-handler-multi-arch
 
 substitutions:
   _STAGING_PROJECT: "k8s-staging-cloud-provider-gcp"
@@ -34,4 +44,5 @@ substitutions:
 tags:
   - "gcp-compute-persistent-disk-csi-driver"
   - "gce-pd-node-labeler"
+  - "gce-pd-default-sc-rollback-handler"
   - ${_PULL_BASE_REF}

--- a/cmd/default-sc-rollback-handler/main.go
+++ b/cmd/default-sc-rollback-handler/main.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package main is the GCE PD CSI default StorageClass rollback handler entrypoint.
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+	"time"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/scdefaultrestorer"
+)
+
+func main() {
+	var config scdefaultrestorer.Config
+
+	flag.StringVar(&config.StorageClassName, "storageclass-name", "standard-rwo", "Target StorageClass to restore default annotation for")
+	flag.DurationVar(&config.APITimeout, "api-timeout", 30*time.Second, "Maximum time to wait for API server readiness")
+
+	klog.InitFlags(nil)
+	flag.Parse()
+
+	klog.InfoS("Starting MAP default storageclass rollback handler")
+
+	restorer := scdefaultrestorer.New(config)
+	if err := restorer.Run(context.Background()); err != nil {
+		klog.ErrorS(err, "Failed to restore storage class defaults")
+		os.Exit(1)
+	}
+}

--- a/pkg/scdefaultrestorer/restorer.go
+++ b/pkg/scdefaultrestorer/restorer.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scdefaultrestorer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+const (
+	defaultClassAnnotation = "storageclass.kubernetes.io/is-default-class"
+	// markerAnnotation is applied to StorageClasses when their default annotation is
+	// disabled and defaulting is handled by the Mutating Admission Policy (MAP). It tracks that the default annotation
+	// was disabled by the system, allowing us to rollback and restore the default
+	// annotation if required on the clusters.
+	markerAnnotation = "pdcsi.storage.gke.io/install-default-using-map"
+)
+
+type Config struct {
+	StorageClassName string
+	APITimeout       time.Duration
+}
+
+type Restorer struct {
+	config Config
+}
+
+func New(cfg Config) *Restorer {
+	return &Restorer{config: cfg}
+}
+
+func (r *Restorer) Run(ctx context.Context) error {
+	kubeConfig, err := config.GetConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get kubeconfig: %w", err)
+	}
+	clientset, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return fmt.Errorf("failed to build Kubernetes client: %w", err)
+	}
+
+	// Wait for API server to be ready
+	if err := r.waitForAPIServer(ctx, clientset); err != nil {
+		return err
+	}
+
+	// Restore the default annotation on StorageClass
+	return r.restoreDefaultAnnotation(ctx, clientset)
+}
+
+func (r *Restorer) waitForAPIServer(ctx context.Context, client kubernetes.Interface) error {
+	klog.InfoS("Waiting for API server to be ready")
+
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, r.config.APITimeout, true, func(ctx context.Context) (bool, error) {
+		result := client.Discovery().RESTClient().Get().AbsPath("/healthz").Do(ctx)
+		if result.Error() != nil {
+			return false, nil
+		}
+		var statusCode int
+		result.StatusCode(&statusCode)
+		return statusCode == 200, nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("timeout waiting for API server: %w", err)
+	}
+	return nil
+}
+
+func (r *Restorer) restoreDefaultAnnotation(ctx context.Context, client kubernetes.Interface) error {
+	scClient := client.StorageV1().StorageClasses()
+	targetSCName := r.config.StorageClassName
+
+	targetSC, err := scClient.Get(ctx, targetSCName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.Warningf("StorageClass not found, skipping restoration: %s", targetSCName)
+			return nil
+		}
+		return fmt.Errorf("failed to get StorageClass %s: %w", targetSCName, err)
+	}
+
+	annotations := targetSC.GetAnnotations()
+	if annotations == nil || annotations[markerAnnotation] != "true" {
+		klog.InfoS("Marker annotation not found, no restoration needed", "storageclass", targetSCName)
+		return nil
+	}
+
+	klog.InfoS("Marker annotation found, checking for other defaults", "storageclass", targetSCName)
+
+	// List all storage classes to check for other defaults
+	scList, err := scClient.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list storage classes: %w", err)
+	}
+
+	// Find any other StorageClasses marked as default
+	var otherDefaults []string
+	for _, sc := range scList.Items {
+		if sc.Name == targetSCName {
+			continue
+		}
+		if sc.Annotations != nil && sc.Annotations[defaultClassAnnotation] == "true" {
+			otherDefaults = append(otherDefaults, sc.Name)
+		}
+	}
+
+	// Prepare patch: either restore as default or just remove marker
+	var patchBytes []byte
+	if len(otherDefaults) == 0 {
+		klog.InfoS("No other defaults found, restoring as default", "storageclass", targetSCName)
+		patchBytes = []byte(fmt.Sprintf(`{"metadata": {"annotations":{%q:"true", %q: null}}}`, defaultClassAnnotation, markerAnnotation))
+	} else {
+		klog.InfoS("Other defaults found, removing marker only", "storageclass", targetSCName, "otherDefaults", otherDefaults)
+		patchBytes = []byte(fmt.Sprintf(`{"metadata": {"annotations":{%q: null}}}`, markerAnnotation))
+	}
+
+	_, err = scClient.Patch(ctx, targetSCName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to patch storage class %s: %w", targetSCName, err)
+	}
+
+	klog.InfoS("Successfully restored storage class default configuration", "storageclass", targetSCName)
+	return nil
+}

--- a/pkg/scdefaultrestorer/restorer_test.go
+++ b/pkg/scdefaultrestorer/restorer_test.go
@@ -1,0 +1,344 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scdefaultrestorer
+
+import (
+	"context"
+	"testing"
+
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRestoreDefaultAnnotation(t *testing.T) {
+	tests := []struct {
+		name                 string
+		storageClass         *storagev1.StorageClass
+		otherDefaults        []*storagev1.StorageClass
+		expectErr            bool
+		expectedStorageClass *storagev1.StorageClass
+	}{
+		{
+			name: "restore as default when no other defaults exist",
+			storageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "standard-rwo",
+					Annotations: map[string]string{
+						markerAnnotation: "true",
+					},
+				},
+			},
+			otherDefaults: []*storagev1.StorageClass{},
+			expectErr:     false,
+			expectedStorageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "standard-rwo",
+					Annotations: map[string]string{
+						defaultClassAnnotation: "true",
+					},
+				},
+			},
+		},
+		{
+			name: "remove marker only when other defaults exist",
+			storageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "standard-rwo",
+					Annotations: map[string]string{
+						markerAnnotation: "true",
+					},
+				},
+			},
+			otherDefaults: []*storagev1.StorageClass{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pd-ssd",
+						Annotations: map[string]string{
+							defaultClassAnnotation: "true",
+						},
+					},
+				},
+			},
+			expectErr: false,
+			expectedStorageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "standard-rwo",
+					Annotations: map[string]string{},
+				},
+			},
+		},
+		{
+			name: "no marker annotation present",
+			storageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "standard-rwo",
+					Annotations: map[string]string{},
+				},
+			},
+			otherDefaults: []*storagev1.StorageClass{},
+			expectErr:     false,
+			expectedStorageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "standard-rwo",
+					Annotations: map[string]string{},
+				},
+			},
+		},
+		{
+			name:          "storage class not found",
+			storageClass:  nil,
+			otherDefaults: []*storagev1.StorageClass{},
+			expectErr:     false,
+		},
+		{
+			name: "preserve unrelated annotations when restoring as default",
+			storageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "standard-rwo",
+					Annotations: map[string]string{
+						markerAnnotation:      "true",
+						"custom.io/config":    "value1",
+						"app.example.com/ver": "v1.0",
+					},
+				},
+			},
+			otherDefaults: []*storagev1.StorageClass{},
+			expectErr:     false,
+			expectedStorageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "standard-rwo",
+					Annotations: map[string]string{
+						defaultClassAnnotation: "true",
+						"custom.io/config":     "value1",
+						"app.example.com/ver":  "v1.0",
+					},
+				},
+			},
+		},
+		{
+			name: "preserve unrelated annotations when removing marker",
+			storageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "standard-rwo",
+					Annotations: map[string]string{
+						markerAnnotation:      "true",
+						"provisioner.io/prio": "high",
+						"security.io/policy":  "strict",
+						"metadata.io/created": "2024-01-01",
+					},
+				},
+			},
+			otherDefaults: []*storagev1.StorageClass{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pd-ssd",
+						Annotations: map[string]string{
+							defaultClassAnnotation: "true",
+						},
+					},
+				},
+			},
+			expectErr: false,
+			expectedStorageClass: &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "standard-rwo",
+					Annotations: map[string]string{
+						"provisioner.io/prio": "high",
+						"security.io/policy":  "strict",
+						"metadata.io/created": "2024-01-01",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fake client
+			scheme := runtime.NewScheme()
+			storagev1.AddToScheme(scheme)
+
+			objects := []runtime.Object{}
+			if tt.storageClass != nil {
+				objects = append(objects, tt.storageClass)
+			}
+			for _, sc := range tt.otherDefaults {
+				objects = append(objects, sc)
+			}
+
+			fakeClientset := fake.NewClientset(objects...)
+
+			config := Config{
+				StorageClassName: "standard-rwo",
+			}
+			restorer := New(config)
+
+			ctx := context.Background()
+			err := restorer.restoreDefaultAnnotation(ctx, fakeClientset)
+
+			if tt.expectErr && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if tt.expectedStorageClass != nil {
+				// Retrieve the updated StorageClass
+				updatedSC, err := fakeClientset.StorageV1().StorageClasses().Get(ctx, "standard-rwo", metav1.GetOptions{})
+				if err != nil && !apierrors.IsNotFound(err) {
+					t.Errorf("failed to get storage class: %v", err)
+					return
+				}
+
+				if updatedSC == nil {
+					t.Errorf("storage class was not found")
+					return
+				}
+
+				// Verify annotations match expected
+				expectedAnnotations := tt.expectedStorageClass.Annotations
+				if expectedAnnotations == nil {
+					expectedAnnotations = make(map[string]string)
+				}
+				actualAnnotations := updatedSC.Annotations
+				if actualAnnotations == nil {
+					actualAnnotations = make(map[string]string)
+				}
+
+				if len(expectedAnnotations) != len(actualAnnotations) {
+					t.Errorf("expected %d annotations, got %d: expected %v, got %v", len(expectedAnnotations), len(actualAnnotations), expectedAnnotations, actualAnnotations)
+				}
+
+				for key, expectedValue := range expectedAnnotations {
+					actualValue, exists := actualAnnotations[key]
+					if !exists {
+						t.Errorf("annotation %q missing, expected %q", key, expectedValue)
+					} else if actualValue != expectedValue {
+						t.Errorf("annotation %q mismatch: expected %q, got %q", key, expectedValue, actualValue)
+					}
+				}
+
+				for key := range actualAnnotations {
+					if _, exists := expectedAnnotations[key]; !exists {
+						t.Errorf("unexpected annotation %q: %q", key, actualAnnotations[key])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRestoreDefaultAnnotationNoMarker(t *testing.T) {
+	scheme := runtime.NewScheme()
+	storagev1.AddToScheme(scheme)
+
+	storageClass := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "standard-rwo",
+		},
+	}
+
+	fakeClientset := fake.NewClientset(storageClass)
+
+	config := Config{
+		StorageClassName: "standard-rwo",
+	}
+	restorer := New(config)
+
+	ctx := context.Background()
+	err := restorer.restoreDefaultAnnotation(ctx, fakeClientset)
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Verify no annotation changes
+	updatedSC, err := fakeClientset.StorageV1().StorageClasses().Get(ctx, "standard-rwo", metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("failed to get storage class: %v", err)
+	}
+
+	if len(updatedSC.Annotations) > 0 {
+		t.Errorf("expected no annotations, got %v", updatedSC.Annotations)
+	}
+}
+
+func TestRestoreDefaultAnnotationMultipleDefaults(t *testing.T) {
+	scheme := runtime.NewScheme()
+	storagev1.AddToScheme(scheme)
+
+	storageClass := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "standard-rwo",
+			Annotations: map[string]string{
+				markerAnnotation: "true",
+			},
+		},
+	}
+
+	otherDefault1 := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pd-ssd",
+			Annotations: map[string]string{
+				defaultClassAnnotation: "true",
+			},
+		},
+	}
+
+	otherDefault2 := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pd-balanced",
+			Annotations: map[string]string{
+				defaultClassAnnotation: "true",
+			},
+		},
+	}
+
+	fakeClientset := fake.NewSimpleClientset(storageClass, otherDefault1, otherDefault2)
+
+	config := Config{
+		StorageClassName: "standard-rwo",
+	}
+	restorer := New(config)
+
+	ctx := context.Background()
+	err := restorer.restoreDefaultAnnotation(ctx, fakeClientset)
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Verify marker is removed but default is not set
+	updatedSC, err := fakeClientset.StorageV1().StorageClasses().Get(ctx, "standard-rwo", metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("failed to get storage class: %v", err)
+	}
+
+	hasDefault := updatedSC.Annotations != nil && updatedSC.Annotations[defaultClassAnnotation] == "true"
+	hasMarker := updatedSC.Annotations != nil && updatedSC.Annotations[markerAnnotation] == "true"
+
+	if hasDefault {
+		t.Errorf("expected default=false, got true")
+	}
+	if hasMarker {
+		t.Errorf("expected marker=false, got true")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

 /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adds a new init-container component that restores StorageClass default
annotations after GKE cluster upgrades. This is required when default RWX
is disabled in Kubernetes 1.36+.

The init-container:
- Checks cluster version and default RWX configuration
- Waits for kubeconfig and API server readiness
- Restores the default annotation on the target StorageClass
- Either sets as default (if no other defaults exist) or removes the
  marker annotation (if other defaults already exist)
  
Changes:
- Add pkg/scdefaultrestorer package with core restoration logic
- Add cmd/init-container/main.go as the entry point
- Add Dockerfile.init-container for multi-arch builds
- Update Makefile with init-container build targets
- Update cloudbuild.yaml for CI/CD pipeline integration

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add init-container for storage class default annotation restoration
```
