### PR TITLE
Add an overlay for SELinuxMount

### DIFF
--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -20,7 +20,8 @@ The current structure for kustomization is as follows. Note that Windows support
   * `noauth` Based on stable-master, patches the [base controller configuration](deploy/kubernetes/base/controller.yaml) to remove any dependencies on service account keys.
   * `noauth-debug`: Based on stable-master, used for debugging purposes only, see docs/kubernetes/development.md.
   * `prow-stable-sidecar-rc-master`: Used for prow tests on OSS testgrid to test the latest sidecars. Contains deployment specs of a driver with k8s master branch, driver latest release candidate, and stable sidecars.
-  * `prow-canary-sidecar`: Used for prow tests on OSS testgrid to test release candidates when a new release is being cut. Contains deployment specs of a driver with k8s master branch, Kubernetes driver latest build, and canary sidecars. 
+  * `prow-canary-sidecar`: Used for prow tests on OSS testgrid to test release candidates when a new release is being cut. Contains deployment specs of a driver with k8s master branch, Kubernetes driver latest build, and canary sidecars.
+  * `selinuxmount`: Based on stable-master, enables SELinux mount support ([KEP 1710](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1710-selinux-relabeling)). Sets `seLinuxMount: true` on the CSIDriver object and mounts `/etc/selinux` into the node plugin so that `mount(8)` can apply `context=` mount options. Requires Kubernetes 1.32+ with the `SELinuxMount` feature gate enabled and an SELinux-enforcing node (e.g. Fedora, RHEL).
 
   ## NVME support
   udev folder under deploy/kubernetes contains google_nvme_id script required for NVME support. Source is downloaded from [GoogleCloudPlatform/guest-configs](https://github.com/GoogleCloudPlatform/guest-configs). README file in the folder contains the downloaded version.

--- a/deploy/kubernetes/overlays/selinuxmount/csidriver-selinuxmount.yaml
+++ b/deploy/kubernetes/overlays/selinuxmount/csidriver-selinuxmount.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/seLinuxMount
+  value: true

--- a/deploy/kubernetes/overlays/selinuxmount/kustomization.yaml
+++ b/deploy/kubernetes/overlays/selinuxmount/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../stable-master
+patchesJson6902:
+- path: csidriver-selinuxmount.yaml
+  target:
+    group: storage.k8s.io
+    kind: CSIDriver
+    name: pd.csi.storage.gke.io
+    version: v1
+- path: node-selinuxmount.yaml
+  target:
+    group: apps
+    kind: DaemonSet
+    name: csi-gce-pd-node
+    version: v1

--- a/deploy/kubernetes/overlays/selinuxmount/node-selinuxmount.yaml
+++ b/deploy/kubernetes/overlays/selinuxmount/node-selinuxmount.yaml
@@ -1,0 +1,15 @@
+# Mount /etc/selinux from the host so mount(8) can read SELinux policy.
+# /sys/fs/selinux is already accessible via the existing /sys mount.
+- op: add
+  path: /spec/template/spec/containers/1/volumeMounts/-
+  value:
+    name: etc-selinux
+    mountPath: /etc/selinux
+    readOnly: true
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: etc-selinux
+    hostPath:
+      path: /etc/selinux
+      type: DirectoryOrCreate


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
SELinuxMount feature [1] needs /etc/selinux and /sys/fs/selinux bind-mounted from the host to the driver container in the node DaemonSet.

/bin/mount in the container, together with libselinux, uses it to detect that SELinux is enabled on the host and pass SELinux mount options to kernel.

Without these HostPath volumes, /bin/mount stripes the SELinux mount option and the feature does not work.

There are no code changes necessary. The driver only needs to pass SELinux mount options from NodeStage / NodePublish calls to kernel. And the driver announces capability to do so in its CSIDriver instance.

I don't expect a high demand for SELinux, so I keep it as a new overlay. Tested with Fedora 34 + kubeadm + Kubernetes 1.36.

1: https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1710-selinux-relabeling and especially
[#csi-driver-considerations](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/1710-selinux-relabeling#csi-driver-considerations)


**Why it is important**

1. kOps uses manifests from this repository as a base for Kubernetes installation on GCE. We use kOps as an installer in [kubernetes/kubernetes CI jobs](https://github.com/kubernetes/test-infra/blob/69815d7bc187455c01e317cf1a447c8cc5f77b71/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml#L226) that require SELinux, as it's the only one that supports SELinux in k/k CI out of the box. Right now, [we have code in kOps](https://github.com/kubernetes/kops/blob/551a385517e3b5d5d6808b521877577ef06a2df6/upup/models/cloudup/resources/addons/gcp-pd-csi-driver.addons.k8s.io/k8s-1.23.yaml.template#L703-L706) to add the support, however, next time someone syncs the yaml files from here, these changes may get lost.
2. SELinuxMount is graduating to GA soon and community CSI drivers should provide a way how to use it. I admin the demand may be very little.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added a new kustomize overlay to enable SELinuxMount support
```
