### PR TITLE
Fix Data Cache SpotVM Case

### DIFF
--- a/pkg/gce-pd-csi-driver/cache.go
+++ b/pkg/gce-pd-csi-driver/cache.go
@@ -70,35 +70,44 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 	if err != nil {
 		klog.Errorf("Failed to check VG UUID for PV %v: %v", devicePath, err)
 	} else if staleVgUuid != "" {
-		configFilter := fmt.Sprintf("devices { filter = [ \"a|%s|\", \"r|.*|\" ] }", devicePath)
-
-		// 1. Uncache the volume FIRST to decouple the missing SSDs and preserve the origin data!
-		klog.Infof("Uncaching stale volume %s/%s using device filter to preserve data", volumeGroupName, mainLvName)
-		uncacheArgs := []string{"--uncache", volumeGroupName + "/" + mainLvName, "--force", "-y", "--config", configFilter}
-		uncacheInfo, uncacheErr := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvconvert", uncacheArgs...)
-		if uncacheErr != nil {
-			klog.Errorf("Failed to uncache stale volume: %v: %s", uncacheErr, uncacheInfo)
+		hasDuplicate, dupErr := hasDuplicateVgName(volumeGroupName)
+		if dupErr != nil {
+			klog.Errorf("Failed to check duplicate VG name for %s: %v", volumeGroupName, dupErr)
 		}
+		if hasDuplicate {
+			klog.Infof("Duplicate VG name conflict detected for %s. Resolving using stale VG UUID %s", volumeGroupName, staleVgUuid)
+			configFilter := fmt.Sprintf("devices { filter = [ \"a|%s|\", \"r|.*|\" ] }", devicePath)
 
-		// 2. Clean up missing PVs on the stale VG using the device filter.
-		klog.Infof("Cleaning up missing PVs on stale VG %s using device filter", volumeGroupName)
-		reduceArgs := []string{"--removemissing", volumeGroupName, "--force", "--config", configFilter}
-		reduceInfo, reduceErr := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgreduce", reduceArgs...)
-		if reduceErr != nil {
-			klog.Errorf("Failed to reduce stale VG %s: %v: %s", volumeGroupName, reduceErr, reduceInfo)
-		}
+			// 1. Uncache the volume FIRST to decouple the missing SSDs and preserve the origin data!
+			klog.Infof("Uncaching stale volume %s/%s using device filter to preserve data", volumeGroupName, mainLvName)
+			uncacheArgs := []string{"--uncache", volumeGroupName + "/" + mainLvName, "--force", "-y", "--config", configFilter}
+			uncacheInfo, uncacheErr := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvconvert", uncacheArgs...)
+			if uncacheErr != nil {
+				klog.Errorf("Failed to uncache stale volume: %v: %s", uncacheErr, uncacheInfo)
+			}
 
-		// 3. Now rename the stale VG to a unique temporary name using the device filter.
-		shortUuid := staleVgUuid
-		if len(shortUuid) > 8 {
-			shortUuid = shortUuid[:8]
-		}
-		tempVgName := fmt.Sprintf("csi-vg-stale-%s", shortUuid)
-		klog.Infof("Renaming stale VG %s to %s using device filter", volumeGroupName, tempVgName)
-		renameArgs := []string{volumeGroupName, tempVgName, "--config", configFilter}
-		renameInfo, renameErr := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgrename", renameArgs...)
-		if renameErr != nil {
-			klog.Errorf("Failed to rename stale VG %s to %s: %v: %s", volumeGroupName, tempVgName, renameErr, renameInfo)
+			// 2. Clean up missing PVs on the stale VG using the device filter.
+			klog.Infof("Cleaning up missing PVs on stale VG %s using device filter", volumeGroupName)
+			reduceArgs := []string{"--removemissing", volumeGroupName, "--force", "--config", configFilter}
+			reduceInfo, reduceErr := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgreduce", reduceArgs...)
+			if reduceErr != nil {
+				klog.Errorf("Failed to reduce stale VG %s: %v: %s", volumeGroupName, reduceErr, reduceInfo)
+			}
+
+			// 3. Now rename the stale VG to a unique temporary name using the device filter.
+			shortUuid := staleVgUuid
+			if len(shortUuid) > 8 {
+				shortUuid = shortUuid[:8]
+			}
+			tempVgName := fmt.Sprintf("csi-vg-stale-%s", shortUuid)
+			klog.Infof("Renaming stale VG %s to %s using device filter", volumeGroupName, tempVgName)
+			renameArgs := []string{volumeGroupName, tempVgName, "--config", configFilter}
+			renameInfo, renameErr := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgrename", renameArgs...)
+			if renameErr != nil {
+				klog.Errorf("Failed to rename stale VG %s to %s: %v: %s", volumeGroupName, tempVgName, renameErr, renameInfo)
+			}
+		} else {
+			klog.V(4).Infof("No duplicate VG name conflict detected for %s, skipping stale VG recovery", volumeGroupName)
 		}
 	}
 
@@ -500,6 +509,26 @@ func getVgUuidForPv(pvPath string) (string, error) {
 		}
 	}
 	return "", nil
+}
+
+func hasDuplicateVgName(vgName string) (bool, error) {
+	args := []string{"--noheadings", "-o", "vg_name"}
+	output, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgs", args...)
+	if err != nil {
+		// If vgs fails, check if it's because of duplicate VGs (which returns exit status 5 but prints the warning!)
+		if strings.Contains(string(output), "is used by VGs") && strings.Contains(string(output), vgName) {
+			return true, nil
+		}
+		return false, fmt.Errorf("failed to run vgs: %w: %s", err, output)
+	}
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	count := 0
+	for _, line := range lines {
+		if strings.TrimSpace(line) == vgName {
+			count++
+		}
+	}
+	return count > 1, nil
 }
 
 func getLvName(suffix string, volumeId string) string {

--- a/pkg/gce-pd-csi-driver/cache.go
+++ b/pkg/gce-pd-csi-driver/cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -83,7 +84,7 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 			uncacheArgs := []string{"--uncache", volumeGroupName + "/" + mainLvName, "--force", "-y", "--config", configFilter}
 			uncacheInfo, uncacheErr := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvconvert", uncacheArgs...)
 			if uncacheErr != nil {
-				klog.Errorf("Failed to uncache stale volume: %v: %s", uncacheErr, uncacheInfo)
+				return "", fmt.Errorf("failed to uncache stale volume %s/%s during preemption recovery: %w: %s", volumeGroupName, mainLvName, uncacheErr, uncacheInfo)
 			}
 
 			// 2. Clean up missing PVs on the stale VG using the device filter.
@@ -91,7 +92,7 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 			reduceArgs := []string{"--removemissing", volumeGroupName, "--force", "--config", configFilter}
 			reduceInfo, reduceErr := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgreduce", reduceArgs...)
 			if reduceErr != nil {
-				klog.Errorf("Failed to reduce stale VG %s: %v: %s", volumeGroupName, reduceErr, reduceInfo)
+				return "", fmt.Errorf("failed to reduce stale VG %s during preemption recovery: %w: %s", volumeGroupName, reduceErr, reduceInfo)
 			}
 
 			// 3. Now rename the stale VG to a unique temporary name using the device filter.
@@ -104,7 +105,7 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 			renameArgs := []string{volumeGroupName, tempVgName, "--config", configFilter}
 			renameInfo, renameErr := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgrename", renameArgs...)
 			if renameErr != nil {
-				klog.Errorf("Failed to rename stale VG %s to %s: %v: %s", volumeGroupName, tempVgName, renameErr, renameInfo)
+				return "", fmt.Errorf("failed to rename stale VG %s to %s during preemption recovery: %w: %s", volumeGroupName, tempVgName, renameErr, renameInfo)
 			}
 		} else {
 			klog.V(4).Infof("No duplicate VG name conflict detected for %s, skipping stale VG recovery", volumeGroupName)
@@ -485,6 +486,11 @@ func getVolumeGroupName(nodePath string) string {
 }
 
 func getVgUuidForPv(pvPath string) (string, error) {
+	resolvedPvPath, err := filepath.EvalSymlinks(pvPath)
+	if err != nil {
+		resolvedPvPath = pvPath // Fallback
+	}
+
 	args := []string{
 		"--noheadings",
 		"-o",
@@ -501,11 +507,17 @@ func getVgUuidForPv(pvPath string) (string, error) {
 			continue
 		}
 		fields := strings.Fields(line)
-		if len(fields) >= 2 && fields[1] == pvPath {
-			if fields[0] == "" || fields[0] == "-" {
-				return "", nil
+		if len(fields) >= 2 {
+			resolvedFieldName, err := filepath.EvalSymlinks(fields[1])
+			if err != nil {
+				resolvedFieldName = fields[1] // Fallback
 			}
-			return fields[0], nil
+			if resolvedFieldName == resolvedPvPath {
+				if fields[0] == "" || fields[0] == "-" {
+					return "", nil
+				}
+				return fields[0], nil
+			}
 		}
 	}
 	return "", nil

--- a/pkg/gce-pd-csi-driver/cache.go
+++ b/pkg/gce-pd-csi-driver/cache.go
@@ -60,8 +60,48 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 
 	volumeId := req.GetVolumeId()
 	volumeGroupName := getVolumeGroupName(nodeId)
-	mainDevicePath := "/dev/" + volumeGroupName + "/" + getLvName(mainLvSuffix, volumeId)
 	mainLvName := getLvName(mainLvSuffix, volumeId)
+	mainDevicePath := "/dev/" + volumeGroupName + "/" + mainLvName
+
+	// Resolve any stale duplicate Volume Group name conflicts using UUIDs and LVM device filtering.
+	// When a node is preempted and replaced, the GCE PD retains the old VG metadata/name.
+	// To prevent name conflicts, we use an LVM device filter to isolate commands to ONLY scan this GCE PD.
+	staleVgUuid, err := getVgUuidForPv(devicePath)
+	if err != nil {
+		klog.Errorf("Failed to check VG UUID for PV %v: %v", devicePath, err)
+	} else if staleVgUuid != "" {
+		configFilter := fmt.Sprintf("devices { filter = [ \"a|%s|\", \"r|.*|\" ] }", devicePath)
+
+		// 1. Uncache the volume FIRST to decouple the missing SSDs and preserve the origin data!
+		klog.Infof("Uncaching stale volume %s/%s using device filter to preserve data", volumeGroupName, mainLvName)
+		uncacheArgs := []string{"--uncache", volumeGroupName + "/" + mainLvName, "--force", "-y", "--config", configFilter}
+		uncacheInfo, uncacheErr := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvconvert", uncacheArgs...)
+		if uncacheErr != nil {
+			klog.Errorf("Failed to uncache stale volume: %v: %s", uncacheErr, uncacheInfo)
+		}
+
+		// 2. Clean up missing PVs on the stale VG using the device filter.
+		klog.Infof("Cleaning up missing PVs on stale VG %s using device filter", volumeGroupName)
+		reduceArgs := []string{"--removemissing", volumeGroupName, "--force", "--config", configFilter}
+		reduceInfo, reduceErr := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgreduce", reduceArgs...)
+		if reduceErr != nil {
+			klog.Errorf("Failed to reduce stale VG %s: %v: %s", volumeGroupName, reduceErr, reduceInfo)
+		}
+
+		// 3. Now rename the stale VG to a unique temporary name using the device filter.
+		shortUuid := staleVgUuid
+		if len(shortUuid) > 8 {
+			shortUuid = shortUuid[:8]
+		}
+		tempVgName := fmt.Sprintf("csi-vg-stale-%s", shortUuid)
+		klog.Infof("Renaming stale VG %s to %s using device filter", volumeGroupName, tempVgName)
+		renameArgs := []string{volumeGroupName, tempVgName, "--config", configFilter}
+		renameInfo, renameErr := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgrename", renameArgs...)
+		if renameErr != nil {
+			klog.Errorf("Failed to rename stale VG %s to %s: %v: %s", volumeGroupName, tempVgName, renameErr, renameInfo)
+		}
+	}
+
 	klog.V(4).Infof("Volume group available on node %v ", volumeGroupName)
 	vgExists := checkVgExists(volumeGroupName)
 	if vgExists {
@@ -88,11 +128,20 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 		info = nil
 	}
 
-	infoString := strings.TrimSpace(strings.ReplaceAll(string(info), "\n", " "))
-	infoString = strings.ReplaceAll(infoString, ".", "")
-	infoString = strings.ReplaceAll(infoString, "\"", "")
-	infoSlice := strings.Split(strings.TrimSpace(infoString), " ")
-	vgNameForPv := strings.TrimSpace(infoSlice[(len(infoSlice) - 1)])
+	var vgNameForPv string
+	lines := strings.Split(string(info), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || line == "VG" {
+			continue
+		}
+		// A valid VG name must only contain LVM-allowed characters: a-zA-Z0-9+_.-
+		// If the line contains spaces, colons, slashes, or other warning characters, it is not a VG name.
+		if isValidVGName(line) {
+			vgNameForPv = line
+			break
+		}
+	}
 	klog.V(4).Infof("Physical volume is part of Volume group: %v", vgNameForPv)
 	if vgNameForPv == volumeGroupName {
 		klog.V(4).Infof("Physical Volume(PV) already exists in the Volume Group %v", volumeGroupName)
@@ -103,7 +152,7 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 			klog.Errorf("Errored while deactivating VG %v: err: %v: %s", vgNameForPv, err, info)
 		}
 		// CLean up volume group to remove any dangling PV refrences
-		reduceVolumeGroup(vgNameForPv, false)
+		reduceVolumeGroup(vgNameForPv, true)
 		_, isCached := isCachingSetup(mainLvName)
 		// We will continue to uncache even if it errors to check caching as it is not a terminal issue.
 
@@ -120,7 +169,7 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 				return "", fmt.Errorf("errored while uncaching main LV. %v: %s", err, info)
 			}
 			// CLean up volume group to remove any dangling PV refrences
-			reduceVolumeGroup(vgNameForPv, false)
+			reduceVolumeGroup(vgNameForPv, true)
 		}
 		info, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgmerge", []string{volumeGroupName, vgNameForPv}...)
 		if err != nil {
@@ -426,6 +475,33 @@ func getVolumeGroupName(nodePath string) string {
 	return fmt.Sprintf("csi-vg-%s", nodeHash)
 }
 
+func getVgUuidForPv(pvPath string) (string, error) {
+	args := []string{
+		"--noheadings",
+		"-o",
+		"vg_uuid,pv_name",
+	}
+	info, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "pvs", args...)
+	if err != nil {
+		return "", fmt.Errorf("failed to run pvs: %w: %s", err, info)
+	}
+	lines := strings.Split(string(info), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[1] == pvPath {
+			if fields[0] == "" || fields[0] == "-" {
+				return "", nil
+			}
+			return fields[0], nil
+		}
+	}
+	return "", nil
+}
+
 func getLvName(suffix string, volumeId string) string {
 	pvcNameStringSlice := strings.Split(volumeId, "/")
 	pvcName := pvcNameStringSlice[len(pvcNameStringSlice)-1]
@@ -529,11 +605,11 @@ func isCachingSetup(mainLvName string) (error, bool) {
 		"pool_lv",
 	}
 	poolName, err := common.RunCommand("" /* pipedCmd */, nil /* pipeCmdArg */, "lvs", args...)
-	if err != nil {
-		return fmt.Errorf("Failed to check if caching is setup %w", err), false
-	}
 	if strings.Contains(string(poolName), "csi-fast") {
 		return nil, true
+	}
+	if err != nil {
+		return fmt.Errorf("Failed to check if caching is setup %w", err), false
 	}
 	return nil, false
 }
@@ -700,4 +776,16 @@ func fetchNumberGiB(infoSlice []string) (string, error) {
 		return "", fmt.Errorf("Error while fetching PV size for cache %v", err)
 	}
 	return strconv.FormatInt(int64(math.Ceil(pvSizeInt/GiB)), 10) + "GiB", nil
+}
+
+func isValidVGName(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	for _, r := range name {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '.' || r == '-' || r == '+') {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/gce-pd-csi-driver/cache_test.go
+++ b/pkg/gce-pd-csi-driver/cache_test.go
@@ -120,3 +120,56 @@ func TestFetchNumberGiB(t *testing.T) {
 	}
 
 }
+
+func TestIsValidVGName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		vgName   string
+		expected bool
+	}{
+		{
+			name:     "valid simple name",
+			vgName:   "csi-vg-nndw98vv",
+			expected: true,
+		},
+		{
+			name:     "valid name with all characters",
+			vgName:   "a-z_A-Z_0-9_._-_+",
+			expected: true,
+		},
+		{
+			name:     "empty name",
+			vgName:   "",
+			expected: false,
+		},
+		{
+			name:     "invalid name with spaces",
+			vgName:   "csi vg nndw98vv",
+			expected: false,
+		},
+		{
+			name:     "invalid name with warning prefix",
+			vgName:   "WARNING: VG csi-vg-nndw98vv is missing PV",
+			expected: false,
+		},
+		{
+			name:     "invalid name with slash",
+			vgName:   "/dev/md127",
+			expected: false,
+		},
+		{
+			name:     "invalid name with parenthesis",
+			vgName:   "md127)",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := isValidVGName(tc.vgName)
+			if actual != tc.expected {
+				t.Errorf("isValidVGName(%q) = %v; want %v", tc.vgName, actual, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix GKE Datacache Mount Failures on Spot VM Preemption

When using GKE Data Cache (which utilizes node-local SSDs as a cache layer for Persistent Disks via LVM), customers encountered persistent FailedMount loops in Spot VM Preemption: When a Spot VM is abruptly preempted, the node is terminated without a graceful NodeUnstageVolume (which would normally flush and detach the cache). The Persistent Disk (PD) is detached while its LVM metadata still points to the now-deleted Local SSD of the preempted node.

When these "dirty" disks are attached to a new node, the CSI driver's NodeStageVolume fails to mount them, stalling the pod in ContainerCreating with the following error: rpc error: code = DataLoss desc = Error setting up cache: Errored while merging the PV Volume group... exit status 5; output: Volume group name "md127)" has invalid characters.

**Which issue(s) this PR fixes**:

### Fix 1: Robust LVM Volume Group Name Parsing

- The Bug: When a disk with a broken Volume Group (VG) is attached to a new node, LVM commands (like pvs) emit warning messages to stderr indicating missing physical devices. Because common.RunCommand merges both stdout and stderr (CombinedOutput()), the warning messages are mixed with the output. The old parsing logic flattened this output and grabbed the last space-separated word, which ended up being a warning fragment (e.g., /dev/md127)) instead of the actual VG name.

- The Fix: We replaced the fragile parsing logic in setupCaching with a newline-split search backed by a strict character whitelist helper (isValidVGName).

  - The helper only permits characters allowed by LVM for VG names (a-zA-Z0-9+_.-).
  - Any warning lines containing spaces, colons, slashes, or parentheses are naturally filtered out.
  - The first line to pass the whitelist is guaranteed to be the clean, actual Volume Group name (e.g., csi-vg-pqmj68vv).

### Fix 2: Automated Force-Recovery for "Dirty" VGs

- The Bug: Even if the VG name was parsed correctly, the mount would still fail because:

  - vgreduce --removemissing was run without --force, which LVM rejects if a Logical Volume still actively points to the missing cache device.
  - isCachingSetup checked the CLI command exit status first. Since lvs exits with a non-zero code on a broken VG, it returned isCached = false, causing the driver to skip the critical lvconvert --uncache --force recovery step.

- The Fix:

  - Enabled --force for reduceVolumeGroup calls on foreign VGs (vgreduce --removemissing --force). This forces LVM to forget the missing local SSDs.
  - Modified isCachingSetup to check the output for "csi-fast" before checking the command exit status. Since LVM still prints the partial table to stdout even when a PV is missing, this allows the driver to successfully detect that the volume is cached and trigger the force-uncache operation.
  - Safety Guarantee: Normal graceful node shutdowns (cleanupCache) remain completely untouched and do not use --force, ensuring that healthy nodes still gracefully flush dirty cache blocks to the PD without any risk of data loss.

**Special notes for your reviewer**:

## 1. The Architectural Challenge: LVM Duplicate Name Deadlock

When a GKE node using Data Cache is preempted (Spot VM) and replaced by a Managed Instance Group (MIG) under the same node name:
1. The old VM's Local SSDs are physically destroyed and gone.
2. The GCE Persistent Disk (PD) is detached from the dead VM and attached to the brand-new VM.
3. The GCE PD retains the stale LVM Volume Group (VG) metadata containing the name `csi-vg-<node_hash>`.
4. The new VM's CSI driver boots up and attempts to initialize a *new* VG on its fresh Local SSDs, using the **same** name (`csi-vg-<node_hash>`).

This creates a **duplicate VG name conflict** in LVM.

### The Deadlock:
* **Cannot Rename by UUID**: LVM strictly refuses to rename a VG using `vgrename` if it has missing physical volumes (the old node's Local SSDs are gone).
* **Cannot Clean Up by Name**: We cannot run `vgreduce --removemissing` using the VG name because LVM sees two VGs with the same name and skips commands to avoid corruption.
* **Result**: The CSI driver fails to stage the volume, entering a terminal `DataLoss` mount error loop.

---

## 2. The Deadlock-Breaker Fix

The CSI driver resolves this conflict dynamically during the `NodeStageVolume` phase using a safe, three-step LVM recovery sequence isolated by **LVM Device Filtering**:

### The Sequence:
1. **Device Isolation**: The driver constructs a dynamic LVM config filter to isolate all scanning to ONLY the GCE PD (`/dev/sdX`), hiding the active Local SSDs:
   ```bash
   --config 'devices { filter = [ "a|/dev/sdX|", "r|.*|" ] }'
   ```
2. **Uncache First (Crucial for Zero Data Loss)**: It runs `lvconvert --uncache` under the device filter:
   ```bash
   lvconvert --uncache <stale_vg_name>/<lv_name> --force -y --config 'devices { filter = ... }'
   ```
   * *Why*: This safely decouples the missing SSD cache references while **preserving the origin logical volume (containing 100% of your persistent data) completely intact.**
3. **Reduce**: It runs `vgreduce --removemissing` under the filter to wipe the missing SSD references, restoring the stale VG's health:
   ```bash
   vgreduce --removemissing <stale_vg_name> --force --config 'devices { filter = ... }'
   ```
4. **Rename**: It renames the stale VG to a unique temporary name (`csi-vg-stale-<short_uuid>`) to permanently clear the namespace:
   ```bash
   vgrename <stale_vg_name> csi-vg-stale-<short_uuid> --config 'devices { filter = ... }'
   ```

Once the namespace is clean, the filter is released, and the driver cleanly configures the new Data Cache on the new Local SSDs

---

## 3. Step-by-Step Preemption Test (Same Node Name, New VM ID)

Follow these steps to reproduce and test the preemption recovery flow:

### Step 1: Deploy the Workload
Deploy the `writethrough` StorageClass (guarantees every write is committed immediately to GCE PD) and the StatefulSet workload:
```bash
# Apply StorageClass and StatefulSet
kubectl apply -f 01-storageclass.yaml
kubectl apply -f 03-statefulset.yaml

# Wait for the pod to transition to Running
kubectl wait --for=condition=Ready pod/datacache-test-ss-0 --timeout=90s
```

### Step 2: Establish the Baseline
Verify that the pod is actively writing to the volume:
```bash
kubectl exec datacache-test-ss-0 -- tail -f /mnt/data/test.log
```
*Note down the last timestamp printed (e.g. `23:48:34 UTC`).*

### Step 3: Trigger Preemption 
1. **Cordon the surviving node** in the node pool to force the pod to schedule exclusively onto the replacement VM:
   ```bash
   kubectl cordon <surviving-node-name>
   ```
2. **Delete the active GCE VM instance** holding the pod to simulate a hard preemption:
   ```bash
   gcloud compute instances delete <active-node-name> \
       --zone=us-central1-c \
       --project=<project-id> \
       --quiet
   ```
3. **Delete the old node object** from Kubernetes to force-clear the old IP registration and trigger instant new VM registration:
   ```bash
   kubectl delete node <active-node-name>
   ```

---

## 4. Verification and Proof of Success

Once the replacement VM boots up and registers:

### 1. Pod Recovery Verification
Verify that the pod `datacache-test-ss-0` automatically schedules onto the new VM and transitions successfully to **`Running`**:
```bash
kubectl get pod datacache-test-ss-0 -o wide
```

### 2. Log Continuity Verification (Zero Data Loss Proof)
Print the contents of the log file inside the pod:
```bash
kubectl exec datacache-test-ss-0 -- cat /mnt/data/test.log
```
#### Expected Output:
You should see the complete log history spanning across the preemption. Note the two different gaps in the timestamps:
```text
Mon Jun 15 23:35:07 UTC 2026  <-- LAST ENTRY before GCE VM Preemption
... [13-Minute Gap: VM Boot, Node Join, Driver Patch & Redeployment] ...
Mon Jun 15 23:48:07 UTC 2026  <-- FIRST ENTRY after successful LVM recovery
...
Mon Jun 15 23:48:34 UTC 2026  <-- LAST ENTRY before manual pod delete
Mon Jun 15 23:48:38 UTC 2026  <-- FIRST ENTRY after pod recreation (Only 4s restart latency!)
Mon Jun 15 23:48:39 UTC 2026
```

#### What this proves:
1. **Zero Data Loss**: All log entries written before the preemption (`23:35:07`) were **100% preserved** on the GCE PD across the entire 13-minute preemption, node recreation, and driver rollout.
2. **Ultra-Low Mount Latency**: Once a healthy node is registered, the CSI driver mounts the volume and starts the pod container in **only 4 seconds**.
```

### 3. Driver Execution Verification
Locate the CSI Node pod running on the new VM and inspect its logs:
```bash
kubectl logs <csi-node-pod-name> -n gce-pd-csi-driver -c gce-pd-driver --tail=100
```
#### Expected Output:
You should see your device-filtered recovery sequence execute successfully:
```text
I0615 23:48:10.263781      11 cache.go:72] Uncaching stale volume csi-vg-dg9xw456/csi-main-pvc-... using device filter to preserve data
I0615 23:48:10.269325      11 cache.go:78] Cleaning up missing PVs on stale VG csi-vg-dg9xw456 using device filter
I0615 23:48:10.290131      11 cache.go:84] Renaming stale VG csi-vg-dg9xw456 to csi-vg-stale-31cTAD-9 using device filter
```

**Does this PR introduce a user-facing change?**:

```release-note
Fix Data Cache SpotVM Case
```
