### PR TITLE
fix: remove duplicate call to mutex.Unlock

### DIFF
--- a/pkg/gce-cloud-provider/compute/tenancy/informer.go
+++ b/pkg/gce-cloud-provider/compute/tenancy/informer.go
@@ -78,7 +78,6 @@ func RegisterTenantEventHandlers(ti TenantsInformer, handler TenantLifecycleHand
 			defer mutex.Unlock()
 			if _, ok := tenantServiceMap[tenantMeta.ProjectNumber]; ok {
 				klog.Infof("Tenant GCE client already exists for tenant project number %s, skipping GCE client instantiation.", tenantMeta.ProjectNumber)
-				mutex.Unlock()
 				return
 			}
 


### PR DESCRIPTION
The deferred unlock would result in unlock being called twice, which leads to a panic.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind bug

**What this PR does / why we need it**:

This fixes a code path which could lead to two calls to `Unlock()`, resulting in a panic

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

**Special notes for your reviewer**: None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
