### PR TITLE
Refactor node_taint webhook to fix data drop issue.

### DIFF
--- a/pkg/webhook/taint/node_taint.go
+++ b/pkg/webhook/taint/node_taint.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/constants"
 )
@@ -45,17 +47,60 @@ func (a *NodeTainter) Handle(ctx context.Context, req admission.Request) admissi
 		return admission.Allowed("Node already has startup taint")
 	}
 
-	// Apply taint
-	node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
+	// Apply taint via explicit JSON patch to avoid dropping unknown fields.
+	taintObj := corev1.Taint{
 		Key:    constants.StartupTaintKey,
 		Value:  constants.StartupTaintValue,
 		Effect: constants.StartupTaintEffect,
-	})
-	marshaledNode, err := json.Marshal(node)
+	}
+	patches := buildTaintPatches(node.Spec.Taints, taintObj)
+
+	return createPatchResponse(patches, "Applying startup taint")
+}
+
+// buildTaintPatches generates the JSON patch operations for adding the taint
+func buildTaintPatches(existingTaints []corev1.Taint, taintObj corev1.Taint) []map[string]interface{} {
+	hasExistingTaints := len(existingTaints) > 0
+	var patches []map[string]interface{}
+
+	if hasExistingTaints {
+		patches = append(patches, map[string]interface{}{
+			"op":    "add",
+			"path":  "/spec/taints/-",
+			"value": taintObj,
+		})
+	} else {
+		// Initialize null taint array.
+		patches = append(patches, map[string]interface{}{
+			"op":    "add",
+			"path":  "/spec/taints",
+			"value": []corev1.Taint{taintObj},
+		})
+	}
+
+	return patches
+}
+
+// createPatchResponse constructs a patch-based admission response.
+func createPatchResponse(patches []map[string]interface{}, message string) admission.Response {
+	patchBytes, err := json.Marshal(patches)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
-	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledNode)
+
+	patchType := admissionv1.PatchTypeJSONPatch
+
+	return admission.Response{
+		AdmissionResponse: admissionv1.AdmissionResponse{
+			Allowed:   true,
+			Patch:     patchBytes,
+			PatchType: &patchType,
+			Result: &metav1.Status{
+				Code:    http.StatusOK,
+				Message: message,
+			},
+		},
+	}
 }
 
 // InjectDecoder injects the decoder (required by controller-runtime)

--- a/pkg/webhook/taint/node_taint_test.go
+++ b/pkg/webhook/taint/node_taint_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"gomodules.xyz/jsonpatch/v2"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,7 +26,7 @@ func TestNodeTainter_Handle(t *testing.T) {
 		name          string
 		node          *corev1.Node
 		wantAllowed   bool
-		wantPatches   []jsonpatch.JsonPatchOperation
+		wantPatches   []map[string]interface{}
 		wantResultMsg string
 	}{
 		{
@@ -37,11 +36,11 @@ func TestNodeTainter_Handle(t *testing.T) {
 				Spec:       corev1.NodeSpec{Taints: []corev1.Taint{}},
 			},
 			wantAllowed: true,
-			wantPatches: []jsonpatch.JsonPatchOperation{
+			wantPatches: []map[string]interface{}{
 				{
-					Operation: "add",
-					Path:      "/spec/taints",
-					Value: []interface{}{
+					"op":   "add",
+					"path": "/spec/taints",
+					"value": []interface{}{
 						map[string]interface{}{
 							"effect": string(constants.StartupTaintEffect),
 							"key":    constants.StartupTaintKey,
@@ -62,7 +61,7 @@ func TestNodeTainter_Handle(t *testing.T) {
 				},
 			},
 			wantAllowed:   true,
-			wantPatches:   []jsonpatch.JsonPatchOperation{},
+			wantPatches:   []map[string]interface{}{},
 			wantResultMsg: "Node already has startup taint",
 		},
 		{
@@ -77,7 +76,7 @@ func TestNodeTainter_Handle(t *testing.T) {
 				Spec: corev1.NodeSpec{Taints: []corev1.Taint{}},
 			},
 			wantAllowed:   true,
-			wantPatches:   []jsonpatch.JsonPatchOperation{},
+			wantPatches:   []map[string]interface{}{},
 			wantResultMsg: "Fail-safe label detected",
 		},
 		{
@@ -91,11 +90,11 @@ func TestNodeTainter_Handle(t *testing.T) {
 				},
 			},
 			wantAllowed: true,
-			wantPatches: []jsonpatch.JsonPatchOperation{
+			wantPatches: []map[string]interface{}{
 				{
-					Operation: "add",
-					Path:      "/spec/taints/1",
-					Value: map[string]interface{}{
+					"op":   "add",
+					"path": "/spec/taints/-",
+					"value": map[string]interface{}{
 						"effect": string(constants.StartupTaintEffect),
 						"key":    constants.StartupTaintKey,
 						"value":  constants.StartupTaintValue,
@@ -116,11 +115,11 @@ func TestNodeTainter_Handle(t *testing.T) {
 				},
 			},
 			wantAllowed: true,
-			wantPatches: []jsonpatch.JsonPatchOperation{
+			wantPatches: []map[string]interface{}{
 				{
-					Operation: "add",
-					Path:      "/spec/taints/3",
-					Value: map[string]interface{}{
+					"op":   "add",
+					"path": "/spec/taints/-",
+					"value": map[string]interface{}{
 						"effect": string(constants.StartupTaintEffect),
 						"key":    constants.StartupTaintKey,
 						"value":  constants.StartupTaintValue,
@@ -164,17 +163,23 @@ func TestNodeTainter_Handle(t *testing.T) {
 			}
 
 			if len(tc.wantPatches) > 0 {
-				if len(resp.Patches) != len(tc.wantPatches) {
-					t.Fatalf("Got %d patches, want %d", len(resp.Patches), len(tc.wantPatches))
+				var gotPatches []map[string]interface{}
+				if len(resp.Patch) > 0 {
+					if err := json.Unmarshal(resp.Patch, &gotPatches); err != nil {
+						t.Fatalf("Failed to unmarshal patch response: %v", err)
+					}
 				}
-				for i, patch := range resp.Patches {
+				if len(gotPatches) != len(tc.wantPatches) {
+					t.Fatalf("Got %d patches, want %d", len(gotPatches), len(tc.wantPatches))
+				}
+				for i, patch := range gotPatches {
 					if diff := cmp.Diff(tc.wantPatches[i], patch); diff != "" {
 						t.Errorf("Patch[%d] mismatch (-want +got):\n%s", i, diff)
 					}
 				}
 			} else {
-				if len(resp.Patches) > 0 {
-					t.Errorf("Expected NO patches, got %v", resp.Patches)
+				if len(resp.Patch) > 0 && string(resp.Patch) != "null" && string(resp.Patch) != "[]" {
+					t.Errorf("Expected NO patches, got %s", string(resp.Patch))
 				}
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR fixes a critical data-loss issue in the node_taint admission webhook. Previously, the webhook utilized PatchResponseFromRaw to compute a diff against an unmarshaled corev1.Node struct. Because the Go struct does not track unknown/custom fields, this approach silently stripped out any unrecognized fields or annotations from the raw JSON payload cluster-wide.

The webhook now explicitly constructs targeted JSON patches ([]map[string]interface{}) and relies on the native corev1.Taint struct to safely append or initialize the startup taint without modifying or dropping any other fields on the Node.

Which issue(s) this PR fixes:
N/A

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
