### PR TITLE
Fix host PID exhaustion via zombie process leak in piped command

### DIFF
--- a/pkg/common/runcmd.go
+++ b/pkg/common/runcmd.go
@@ -52,12 +52,15 @@ func execPipeCommand(pipeCmd string, pipeCmdArg []string, execCmd1 *exec.Cmd) ([
 	execPipeCmd := exec.Command(pipeCmd, pipeCmdArg...)
 	stdoutPipe, err := execCmd1.StdoutPipe()
 	if err != nil {
-		klog.Errorf("failed command %v: got error:%v", execCmd1, err)
+		return nil, fmt.Errorf("failed to get stdout pipe for %v: %w", execCmd1, err)
 	}
 	err = execCmd1.Start()
 	if err != nil {
-		klog.Infof("errored running command %v; error %v; ", execCmd1, err)
+		return nil, fmt.Errorf("failed to start command %v: %w", execCmd1, err)
 	}
+	defer func() {
+		_ = execCmd1.Wait() // Reclaim zombie process resources
+	}()
 	defer stdoutPipe.Close()
 
 	execPipeCmd.Stdin = stdoutPipe


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
zombie process leak occurs due to not calling Wait() on upstream commands in execPipeCommand. This can lead to PID exhaustion

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
