### PR TITLE
Fix concurrent map read/write in ListVolumes and ListSnapshots (b/511…

### DIFF
--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -54,9 +55,11 @@ type GCEControllerServer struct {
 
 	volumeEntries     []*csi.ListVolumesResponse_Entry
 	volumeEntriesSeen map[string]int
+	listVolumesLock   sync.Mutex
 
-	snapshots      []*csi.ListSnapshotsResponse_Entry
-	snapshotTokens map[string]int
+	snapshots         []*csi.ListSnapshotsResponse_Entry
+	snapshotTokens    map[string]int
+	listSnapshotsLock sync.Mutex
 
 	// A map storing all volumes with ongoing operations so that additional
 	// operations for that same volume (as defined by Volume Key) return an
@@ -1644,17 +1647,24 @@ func (gceCS *GCEControllerServer) ListVolumes(ctx context.Context, req *csi.List
 			"ListVolumes got max entries request %v. GCE only supports values >0", req.MaxEntries)
 	}
 
-	offsetLow := 0
-	var ok bool
+	var volumeEntries []*csi.ListVolumesResponse_Entry
+	var err error
 	if req.StartingToken == "" {
-		volumeEntries, err := gceCS.listVolumeEntries(ctx)
+		volumeEntries, err = gceCS.listVolumeEntries(ctx)
 		if err != nil {
 			if gce.IsGCEInvalidError(err) {
 				return nil, status.Errorf(codes.Aborted, "ListVolumes error with invalid request: %v", err.Error())
 			}
 			return nil, common.LoggedError("Failed to list volumes: ", err)
 		}
+	}
 
+	gceCS.listVolumesLock.Lock()
+	defer gceCS.listVolumesLock.Unlock()
+
+	offsetLow := 0
+	var ok bool
+	if req.StartingToken == "" {
 		gceCS.volumeEntries = volumeEntries
 		gceCS.volumeEntriesSeen = map[string]int{}
 	} else {
@@ -1678,8 +1688,11 @@ func (gceCS *GCEControllerServer) ListVolumes(ctx context.Context, req *csi.List
 		offsetHigh = len(gceCS.volumeEntries)
 	}
 
+	entriesCopy := make([]*csi.ListVolumesResponse_Entry, offsetHigh-offsetLow)
+	copy(entriesCopy, gceCS.volumeEntries[offsetLow:offsetHigh])
+
 	return &csi.ListVolumesResponse{
-		Entries:   gceCS.volumeEntries[offsetLow:offsetHigh],
+		Entries:   entriesCopy,
 		NextToken: nextToken,
 	}, nil
 }
@@ -2098,18 +2111,26 @@ func (gceCS *GCEControllerServer) ListSnapshots(ctx context.Context, req *csi.Li
 			"ListSnapshots got max entries request %v. GCE only supports values >0", maxEntries)
 	}
 
-	var offset int
-	var length int
-	var ok bool
-	var nextToken string
+	var snapshotList []*csi.ListSnapshotsResponse_Entry
+	var err error
 	if req.StartingToken == "" {
-		snapshotList, err := gceCS.getSnapshots(ctx, req)
+		snapshotList, err = gceCS.getSnapshots(ctx, req)
 		if err != nil {
 			if gce.IsGCEInvalidError(err) {
 				return nil, status.Errorf(codes.Aborted, "ListSnapshots error with invalid request: %v", err.Error())
 			}
 			return nil, common.LoggedError("Failed to list snapshots: ", err)
 		}
+	}
+
+	gceCS.listSnapshotsLock.Lock()
+	defer gceCS.listSnapshotsLock.Unlock()
+
+	var offset int
+	var length int
+	var ok bool
+	var nextToken string
+	if req.StartingToken == "" {
 		gceCS.snapshots = snapshotList
 		gceCS.snapshotTokens = map[string]int{}
 	} else {
@@ -2130,8 +2151,11 @@ func (gceCS *GCEControllerServer) ListSnapshots(ctx context.Context, req *csi.Li
 		length = len(gceCS.snapshots) - offset
 	}
 
+	entriesCopy := make([]*csi.ListSnapshotsResponse_Entry, length)
+	copy(entriesCopy, gceCS.snapshots[offset:offset+length])
+
 	return &csi.ListSnapshotsResponse{
-		Entries:   gceCS.snapshots[offset : offset+length],
+		Entries:   entriesCopy,
 		NextToken: nextToken,
 	}, nil
 }

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -6221,4 +6222,117 @@ func mergeParameters(a map[string]string, b map[string]string) map[string]string
 		merged[k] = v
 	}
 	return merged
+}
+
+func TestListVolumes_Concurrent(t *testing.T) {
+	var d []*gce.CloudDisk
+	for i := 0; i < 50; i++ {
+		name := fmt.Sprintf("disk-%v", i)
+		d = append(d, gce.CloudDiskFromV1(&compute.Disk{
+			Name:     name,
+			SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/disks/%s", project, zone, name),
+		}))
+	}
+	fakeCloudProvider, err := gce.CreateFakeCloudProvider(project, zone, d)
+	if err != nil {
+		t.Fatalf("Failed to create fake cloud provider: %v", err)
+	}
+
+	gceDriver := initGCEDriverWithCloudProvider(t, fakeCloudProvider, &GCEControllerServerArgs{})
+
+	concurrency := 20
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		go func(id int) {
+			defer wg.Done()
+			req := &csi.ListVolumesRequest{
+				MaxEntries: 10,
+			}
+			resp, err := gceDriver.cs.ListVolumes(context.TODO(), req)
+			if err != nil {
+				t.Errorf("worker %d: unexpected error: %v", id, err)
+				return
+			}
+			if resp.NextToken != "" {
+				req2 := &csi.ListVolumesRequest{
+					MaxEntries:    10,
+					StartingToken: resp.NextToken,
+				}
+				_, err2 := gceDriver.cs.ListVolumes(context.TODO(), req2)
+				if err2 != nil {
+					if !strings.Contains(err2.Error(), "invalid startingToken") {
+						t.Errorf("worker %d: unexpected error on page 2: %v", id, err2)
+					}
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+func TestListSnapshots_Concurrent(t *testing.T) {
+	// Create source disks in mock provider
+	var d []*gce.CloudDisk
+	for i := 0; i < 50; i++ {
+		name := fmt.Sprintf("disk-%v", i)
+		d = append(d, gce.CloudDiskFromV1(&compute.Disk{
+			Name:     name,
+			SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/disks/%s", project, zone, name),
+		}))
+	}
+	fakeCloudProvider, err := gce.CreateFakeCloudProvider(project, zone, d)
+	if err != nil {
+		t.Fatalf("Failed to create fake cloud provider: %v", err)
+	}
+
+	gceDriver := initGCEDriverWithCloudProvider(t, fakeCloudProvider, &GCEControllerServerArgs{})
+
+	for i := 0; i < 50; i++ {
+		name := fmt.Sprintf("snapshot-%v", i)
+		volumeID := fmt.Sprintf("projects/%s/zones/%s/disks/disk-%d", project, zone, i)
+		createReq := &csi.CreateSnapshotRequest{
+			Name:           name,
+			SourceVolumeId: volumeID,
+			Parameters:     map[string]string{parameters.ParameterKeySnapshotType: parameters.DiskSnapshotType},
+		}
+		_, err := gceDriver.cs.CreateSnapshot(context.Background(), createReq)
+		if err != nil {
+			t.Fatalf("failed to create snapshot: %v", err)
+		}
+	}
+
+	concurrency := 20
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		go func(id int) {
+			defer wg.Done()
+			req := &csi.ListSnapshotsRequest{
+				MaxEntries: 10,
+			}
+			resp, err := gceDriver.cs.ListSnapshots(context.TODO(), req)
+			if err != nil {
+				t.Errorf("worker %d: unexpected error: %v", id, err)
+				return
+			}
+			if resp.NextToken != "" {
+				req2 := &csi.ListSnapshotsRequest{
+					MaxEntries:    10,
+					StartingToken: resp.NextToken,
+				}
+				_, err2 := gceDriver.cs.ListSnapshots(context.TODO(), req2)
+				if err2 != nil {
+					if !strings.Contains(err2.Error(), "invalid startingToken") {
+						t.Errorf("worker %d: unexpected error on page 2: %v", id, err2)
+					}
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes a concurrent access issue, that causes panic

**Which issue(s) this PR fixes**:
A data race condition in ListVolumes and ListSnapshots functions can cause the CSI Controller process to crash due to concurrent map access, leading to a Denial of Service. The issue is reproducible by sending concurrent ListVolumes gRPC requests. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```