### PR TITLE
Fix unchecked type assertion panic in execPipeCommand

### DIFF
--- a/pkg/common/runcmd.go
+++ b/pkg/common/runcmd.go
@@ -63,9 +63,10 @@ func execPipeCommand(pipeCmd string, pipeCmdArg []string, execCmd1 *exec.Cmd) ([
 	execPipeCmd.Stdin = stdoutPipe
 	output, err := execPipeCmd.CombinedOutput()
 	if err != nil {
-		// Some commands (such as grep) will return an error with exit status of 1
-		if len(output) == 0 && err.(*exec.ExitError).ExitCode() == 1 {
-			return output, nil
+		if len(output) == 0 {
+			if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+				return output, nil
+			}
 		}
 		err = checkError(err, *execPipeCmd)
 		return nil, fmt.Errorf("%s failed: %w; output: %s", execPipeCmd, err, string(output))

--- a/pkg/common/runcmd_test.go
+++ b/pkg/common/runcmd_test.go
@@ -1,0 +1,21 @@
+package common
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRunCommand_UncheckedTypeAssertionPanic(t *testing.T) {
+	// Call RunCommand with a pipe destination that does not exist
+	// This will cause execPipeCmd.CombinedOutput() to return an *exec.Error,
+	// which is NOT an *exec.ExitError. This will trigger the panic.
+	_, err := RunCommand("non-existent-command-12345", nil, "echo", "hello")
+	if err == nil {
+		t.Fatalf("expected error running non-existent pipe command, got nil")
+	}
+
+	// We expect the command to return an error, not panic.
+	if !strings.Contains(err.Error(), "executable file not found") {
+		t.Errorf("expected executable file not found error, got: %v", err)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Fixes a panic bug 

**Which issue(s) this PR fixes**:
Unexpected panic resulting in the crash and restart of the CSI driver node pod. If triggered consistently under heavy load or resource-constrained environments, this worsens node stability and delays volume provisioning operations.

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

