### PR TITLE
e2e: add Basic Provisioning test suite for type=dynamic disk selection

### DIFF
--- a/test/e2e/tests/dynamic_volume_e2e_test.go
+++ b/test/e2e/tests/dynamic_volume_e2e_test.go
@@ -26,20 +26,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// ============================================================================
-// Basic Provisioning Test Suite
-// ============================================================================
-
-// HD Node Dynamic Provisioning
-//
-// Verifies that when type=dynamic is used on a hyperdisk-capable node (c3-standard-4),
-// the driver resolves the disk type to hyperdisk-balanced instead of leaving it as "dynamic".
-//
-// Test flow:
-//  1. Pick a c3-standard-4 VM — supports hyperdisk-balanced
-//  2. Call CreateVolume with type=dynamic, pd-type=pd-balanced, hyperdisk-type=hyperdisk-balanced
-//  3. Verify via GCE API that the created disk is hyperdisk-balanced (not pd-balanced or "dynamic")
-//  4. Cleanup: DeleteVolume and confirm disk is gone
 var _ = Describe("GCE PD CSI Driver Dynamic Volumes HD Node Provisioning", func() {
 
 	It("Should provision hyperdisk-balanced on HD-capable node when type=dynamic", func() {
@@ -56,8 +42,7 @@ var _ = Describe("GCE PD CSI Driver Dynamic Volumes HD Node Provisioning", func(
 			parameters.ParameterPDType:  "pd-balanced",
 		}
 
-		// Preferred topology explicitly includes hyperdisk-balanced disk-type label so the
-		// test behaves consistently on both GKE and OSS clusters.
+		// Preferred topology includes hyperdisk-balanced label for GKE/OSS compatibility.
 		volume, err := client.CreateVolume(volName, params, defaultHdBSizeGb,
 			&csi.TopologyRequirement{
 				Requisite: []*csi.Topology{
@@ -100,17 +85,6 @@ var _ = Describe("GCE PD CSI Driver Dynamic Volumes HD Node Provisioning", func(
 
 })
 
-// PD Fallback Provisioning
-//
-// Verifies that when type=dynamic is used on a PD-only node (n2d-standard-4),
-// the driver falls back to pd-balanced instead of hyperdisk-balanced.
-//
-// Test flow:
-//  1. Pick an n2d-standard-4 VM — does NOT support hyperdisk
-//  2. Call CreateVolume with type=dynamic, pd-type=pd-balanced, hyperdisk-type=hyperdisk-balanced
-//     with Preferred topology carrying pd-only disk-type labels (no hyperdisk label)
-//  3. Verify via GCE API that the created disk is pd-balanced (not hyperdisk-balanced or "dynamic")
-//  4. Cleanup: DeleteVolume and confirm disk is gone
 var _ = Describe("GCE PD CSI Driver Dynamic Volumes PD Fallback Provisioning", func() {
 
 	It("Should fall back to pd-balanced on PD-only node when type=dynamic", func() {
@@ -127,10 +101,7 @@ var _ = Describe("GCE PD CSI Driver Dynamic Volumes PD Fallback Provisioning", f
 			parameters.ParameterPDType:  "pd-balanced",
 		}
 
-		// Preferred topology includes pd-only disk-type labels (no hyperdisk-balanced label).
-		// This simulates what GKE's node labeler stamps on n2d (PD-only) nodes, causing
-		// selectDiskTypeFromTopologies() to pick pd-balanced over hyperdisk-balanced.
-		// Works consistently on both GKE and OSS clusters.
+		// Preferred topology has only pd-* labels (no hyperdisk), simulating a PD-only node.
 		volume, err := client.CreateVolume(volName, params, defaultSizeGb,
 			&csi.TopologyRequirement{
 				Requisite: []*csi.Topology{
@@ -175,18 +146,6 @@ var _ = Describe("GCE PD CSI Driver Dynamic Volumes PD Fallback Provisioning", f
 
 })
 
-// Default Parameters Provisioning
-//
-// Verifies that when type=dynamic is used without specifying pd-type or hyperdisk-type,
-// the driver uses the built-in defaults: hyperdisk-balanced on HD-capable nodes
-// and pd-balanced on PD-only nodes.
-//
-// Test flow:
-//  1. On HD-capable node (c3-standard-4): CreateVolume with only type=dynamic
-//     → verify disk created as hyperdisk-balanced (default HD type)
-//  2. On PD-only node (n2d-standard-4): CreateVolume with only type=dynamic
-//     → verify disk created as pd-balanced (default PD type)
-//  3. Cleanup: DeleteVolume for both and confirm disks are gone
 var _ = Describe("GCE PD CSI Driver Dynamic Volumes Default Parameters Provisioning", func() {
 
 	It("Should use built-in default disk types when no pd-type or hyperdisk-type is specified", func() {
@@ -196,12 +155,11 @@ var _ = Describe("GCE PD CSI Driver Dynamic Volumes Default Parameters Provision
 		hdProject, hdZone, _ := hdContext.Instance.GetIdentity()
 		pdProject, pdZone, _ := pdContext.Instance.GetIdentity()
 
-		// Only type=dynamic — no pd-type or hyperdisk-type specified
+		// Only type=dynamic — no pd-type or hyperdisk-type specified.
 		params := map[string]string{
 			parameters.ParameterKeyType: parameters.DynamicVolumeType,
 		}
 
-		// --- HD-capable node: expect default hyperdisk-balanced ---
 		hdVolName := testNamePrefix + string(uuid.NewUUID())
 		hdVolume, err := hdContext.Client.CreateVolume(hdVolName, params, defaultHdBSizeGb,
 			&csi.TopologyRequirement{
@@ -236,7 +194,6 @@ var _ = Describe("GCE PD CSI Driver Dynamic Volumes Default Parameters Provision
 		Expect(hdDisk.Type).To(ContainSubstring("hyperdisk-balanced"),
 			"Expected default hyperdisk-balanced on HD node but got: %s", hdDisk.Type)
 
-		// --- PD-only node: expect default pd-balanced ---
 		pdVolName := testNamePrefix + string(uuid.NewUUID())
 		pdVolume, err := pdContext.Client.CreateVolume(pdVolName, params, defaultSizeGb,
 			&csi.TopologyRequirement{
@@ -275,18 +232,6 @@ var _ = Describe("GCE PD CSI Driver Dynamic Volumes Default Parameters Provision
 
 })
 
-// Volume Lifecycle (Create and Delete)
-//
-// Verifies the full lifecycle of a dynamic volume:
-//   - CreateVolume resolves "dynamic" to the correct disk type (hyperdisk-balanced on HD node)
-//   - The GCE disk is created in READY state with a valid volume ID
-//   - DeleteVolume removes the disk completely with no orphaned resources
-//
-// Test flow:
-//  1. CreateVolume with type=dynamic on an HD-capable node (c3-standard-4)
-//  2. Verify GCE disk exists, is READY, and has correct type (hyperdisk-balanced)
-//  3. DeleteVolume via CSI RPC
-//  4. Verify GCE disk is fully gone (notFound) — no orphaned resources
 var _ = Describe("GCE PD CSI Driver Dynamic Volumes Lifecycle", func() {
 
 	It("Should create a dynamic volume with correct disk type and delete it with no orphaned resources", func() {
@@ -303,7 +248,6 @@ var _ = Describe("GCE PD CSI Driver Dynamic Volumes Lifecycle", func() {
 			parameters.ParameterPDType:  "pd-balanced",
 		}
 
-		// Step 1: Create volume via CSI RPC
 		volume, err := client.CreateVolume(volName, params, defaultHdBSizeGb,
 			&csi.TopologyRequirement{
 				Requisite: []*csi.Topology{
@@ -325,7 +269,6 @@ var _ = Describe("GCE PD CSI Driver Dynamic Volumes Lifecycle", func() {
 			}, nil)
 		Expect(err).To(BeNil(), "CreateVolume failed: %v", err)
 
-		// Step 2: Verify volume ID is valid and GCE disk exists in READY state
 		Expect(volume.VolumeId).NotTo(BeEmpty(), "VolumeId should not be empty")
 
 		project, key, err := common.VolumeIDToKey(volume.VolumeId)
@@ -340,11 +283,10 @@ var _ = Describe("GCE PD CSI Driver Dynamic Volumes Lifecycle", func() {
 		Expect(cloudDisk.Type).To(ContainSubstring("hyperdisk-balanced"),
 			"Expected hyperdisk-balanced but got: %s", cloudDisk.Type)
 
-		// Step 3: Delete volume via CSI RPC
 		err = client.DeleteVolume(volume.VolumeId)
 		Expect(err).To(BeNil(), "DeleteVolume failed: %v", err)
 
-		// Step 4: Verify disk is fully gone — no orphaned resources
+		// Verify no orphaned resources remain.
 		_, err = computeService.Disks.Get(project, key.Zone, key.Name).Do()
 		Expect(gce.IsGCEError(err, "notFound")).To(BeTrue(),
 			"Expected disk to be fully deleted but it still exists")

--- a/test/e2e/tests/dynamic_volume_e2e_test.go
+++ b/test/e2e/tests/dynamic_volume_e2e_test.go
@@ -26,6 +26,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// ============================================================================
+// Basic Provisioning Test Suite
+// ============================================================================
+
 // HD Node Dynamic Provisioning
 //
 // Verifies that when type=dynamic is used on a hyperdisk-capable node (c3-standard-4),
@@ -92,6 +96,81 @@ var _ = Describe("GCE PD CSI Driver Dynamic Volumes HD Node Provisioning", func(
 		klog.Infof("Dynamic volume resolved to disk type: %s on HD-capable node %s", cloudDisk.Type, z)
 		Expect(cloudDisk.Type).To(ContainSubstring("hyperdisk-balanced"),
 			"Expected hyperdisk-balanced on HD-capable c3 node but got: %s", cloudDisk.Type)
+	})
+
+})
+
+// PD Fallback Provisioning
+//
+// Verifies that when type=dynamic is used on a PD-only node (n2d-standard-4),
+// the driver falls back to pd-balanced instead of hyperdisk-balanced.
+//
+// Test flow:
+//  1. Pick an n2d-standard-4 VM — does NOT support hyperdisk
+//  2. Call CreateVolume with type=dynamic, pd-type=pd-balanced, hyperdisk-type=hyperdisk-balanced
+//     with Preferred topology carrying pd-only disk-type labels (no hyperdisk label)
+//  3. Verify via GCE API that the created disk is pd-balanced (not hyperdisk-balanced or "dynamic")
+//  4. Cleanup: DeleteVolume and confirm disk is gone
+var _ = Describe("GCE PD CSI Driver Dynamic Volumes PD Fallback Provisioning", func() {
+
+	It("Should fall back to pd-balanced on PD-only node when type=dynamic", func() {
+		testContext := getRandomTestContext()
+
+		p, z, _ := testContext.Instance.GetIdentity()
+		client := testContext.Client
+
+		volName := testNamePrefix + string(uuid.NewUUID())
+
+		params := map[string]string{
+			parameters.ParameterKeyType: parameters.DynamicVolumeType,
+			parameters.ParameterHDType:  "hyperdisk-balanced",
+			parameters.ParameterPDType:  "pd-balanced",
+		}
+
+		// Preferred topology includes pd-only disk-type labels (no hyperdisk-balanced label).
+		// This simulates what GKE's node labeler stamps on n2d (PD-only) nodes, causing
+		// selectDiskTypeFromTopologies() to pick pd-balanced over hyperdisk-balanced.
+		// Works consistently on both GKE and OSS clusters.
+		volume, err := client.CreateVolume(volName, params, defaultSizeGb,
+			&csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							"topology.gke.io/zone": z,
+						},
+					},
+				},
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							"topology.gke.io/zone":                 z,
+							common.DiskTypeLabelKey("pd-balanced"): "true",
+							common.DiskTypeLabelKey("pd-standard"): "true",
+							common.DiskTypeLabelKey("pd-ssd"):      "true",
+							common.DiskTypeLabelKey("pd-extreme"):  "true",
+						},
+					},
+				},
+			}, nil)
+		Expect(err).To(BeNil(), "CreateVolume failed: %v", err)
+
+		defer func() {
+			err := client.DeleteVolume(volume.VolumeId)
+			Expect(err).To(BeNil(), "DeleteVolume failed")
+			project, key, err := common.VolumeIDToKey(volume.VolumeId)
+			Expect(err).To(BeNil(), "Failed to parse volume ID")
+			_, err = computeService.Disks.Get(project, key.Zone, key.Name).Do()
+			Expect(gce.IsGCEError(err, "notFound")).To(BeTrue(), "Expected disk to be deleted")
+		}()
+
+		cloudDisk, err := computeService.Disks.Get(p, z, volName).Do()
+		Expect(err).To(BeNil(), "Could not get disk from GCE API")
+		Expect(cloudDisk.Status).To(Equal(readyState), "Disk not in READY state")
+		Expect(cloudDisk.Name).To(Equal(volName))
+
+		klog.Infof("Dynamic volume resolved to disk type: %s on PD-only node %s", cloudDisk.Type, z)
+		Expect(cloudDisk.Type).To(ContainSubstring("pd-balanced"),
+			"Expected pd-balanced fallback on PD-only n2d node but got: %s", cloudDisk.Type)
 	})
 
 })

--- a/test/e2e/tests/dynamic_volume_e2e_test.go
+++ b/test/e2e/tests/dynamic_volume_e2e_test.go
@@ -274,3 +274,82 @@ var _ = Describe("GCE PD CSI Driver Dynamic Volumes Default Parameters Provision
 	})
 
 })
+
+// Volume Lifecycle (Create and Delete)
+//
+// Verifies the full lifecycle of a dynamic volume:
+//   - CreateVolume resolves "dynamic" to the correct disk type (hyperdisk-balanced on HD node)
+//   - The GCE disk is created in READY state with a valid volume ID
+//   - DeleteVolume removes the disk completely with no orphaned resources
+//
+// Test flow:
+//  1. CreateVolume with type=dynamic on an HD-capable node (c3-standard-4)
+//  2. Verify GCE disk exists, is READY, and has correct type (hyperdisk-balanced)
+//  3. DeleteVolume via CSI RPC
+//  4. Verify GCE disk is fully gone (notFound) — no orphaned resources
+var _ = Describe("GCE PD CSI Driver Dynamic Volumes Lifecycle", func() {
+
+	It("Should create a dynamic volume with correct disk type and delete it with no orphaned resources", func() {
+		testContext := getRandomMwTestContext()
+
+		p, z, _ := testContext.Instance.GetIdentity()
+		client := testContext.Client
+
+		volName := testNamePrefix + string(uuid.NewUUID())
+
+		params := map[string]string{
+			parameters.ParameterKeyType: parameters.DynamicVolumeType,
+			parameters.ParameterHDType:  "hyperdisk-balanced",
+			parameters.ParameterPDType:  "pd-balanced",
+		}
+
+		// Step 1: Create volume via CSI RPC
+		volume, err := client.CreateVolume(volName, params, defaultHdBSizeGb,
+			&csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							"topology.gke.io/zone": z,
+						},
+					},
+				},
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							"topology.gke.io/zone":                        z,
+							common.DiskTypeLabelKey("hyperdisk-balanced"): "true",
+							common.DiskTypeLabelKey("pd-balanced"):        "true",
+						},
+					},
+				},
+			}, nil)
+		Expect(err).To(BeNil(), "CreateVolume failed: %v", err)
+
+		// Step 2: Verify volume ID is valid and GCE disk exists in READY state
+		Expect(volume.VolumeId).NotTo(BeEmpty(), "VolumeId should not be empty")
+
+		project, key, err := common.VolumeIDToKey(volume.VolumeId)
+		Expect(err).To(BeNil(), "Failed to parse volume ID: %v", err)
+
+		cloudDisk, err := computeService.Disks.Get(p, z, volName).Do()
+		Expect(err).To(BeNil(), "GCE disk not found after CreateVolume: %v", err)
+		Expect(cloudDisk.Status).To(Equal(readyState), "Disk not in READY state")
+		Expect(cloudDisk.Name).To(Equal(volName), "Disk name mismatch")
+
+		klog.Infof("Dynamic volume created: name=%s type=%s zone=%s", cloudDisk.Name, cloudDisk.Type, z)
+		Expect(cloudDisk.Type).To(ContainSubstring("hyperdisk-balanced"),
+			"Expected hyperdisk-balanced but got: %s", cloudDisk.Type)
+
+		// Step 3: Delete volume via CSI RPC
+		err = client.DeleteVolume(volume.VolumeId)
+		Expect(err).To(BeNil(), "DeleteVolume failed: %v", err)
+
+		// Step 4: Verify disk is fully gone — no orphaned resources
+		_, err = computeService.Disks.Get(project, key.Zone, key.Name).Do()
+		Expect(gce.IsGCEError(err, "notFound")).To(BeTrue(),
+			"Expected disk to be fully deleted but it still exists")
+
+		klog.Infof("Dynamic volume deleted successfully: name=%s — no orphaned resources", volName)
+	})
+
+})

--- a/test/e2e/tests/dynamic_volume_e2e_test.go
+++ b/test/e2e/tests/dynamic_volume_e2e_test.go
@@ -174,3 +174,103 @@ var _ = Describe("GCE PD CSI Driver Dynamic Volumes PD Fallback Provisioning", f
 	})
 
 })
+
+// Default Parameters Provisioning
+//
+// Verifies that when type=dynamic is used without specifying pd-type or hyperdisk-type,
+// the driver uses the built-in defaults: hyperdisk-balanced on HD-capable nodes
+// and pd-balanced on PD-only nodes.
+//
+// Test flow:
+//  1. On HD-capable node (c3-standard-4): CreateVolume with only type=dynamic
+//     → verify disk created as hyperdisk-balanced (default HD type)
+//  2. On PD-only node (n2d-standard-4): CreateVolume with only type=dynamic
+//     → verify disk created as pd-balanced (default PD type)
+//  3. Cleanup: DeleteVolume for both and confirm disks are gone
+var _ = Describe("GCE PD CSI Driver Dynamic Volumes Default Parameters Provisioning", func() {
+
+	It("Should use built-in default disk types when no pd-type or hyperdisk-type is specified", func() {
+		hdContext := getRandomMwTestContext()
+		pdContext := getRandomTestContext()
+
+		hdProject, hdZone, _ := hdContext.Instance.GetIdentity()
+		pdProject, pdZone, _ := pdContext.Instance.GetIdentity()
+
+		// Only type=dynamic — no pd-type or hyperdisk-type specified
+		params := map[string]string{
+			parameters.ParameterKeyType: parameters.DynamicVolumeType,
+		}
+
+		// --- HD-capable node: expect default hyperdisk-balanced ---
+		hdVolName := testNamePrefix + string(uuid.NewUUID())
+		hdVolume, err := hdContext.Client.CreateVolume(hdVolName, params, defaultHdBSizeGb,
+			&csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{Segments: map[string]string{"topology.gke.io/zone": hdZone}},
+				},
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							"topology.gke.io/zone":                          hdZone,
+							common.DiskTypeLabelKey("hyperdisk-balanced"):   "true",
+							common.DiskTypeLabelKey("hyperdisk-throughput"): "true",
+							common.DiskTypeLabelKey("pd-balanced"):          "true",
+						},
+					},
+				},
+			}, nil)
+		Expect(err).To(BeNil(), "CreateVolume (HD) failed: %v", err)
+		defer func() {
+			err := hdContext.Client.DeleteVolume(hdVolume.VolumeId)
+			Expect(err).To(BeNil(), "DeleteVolume (HD) failed")
+			project, key, err := common.VolumeIDToKey(hdVolume.VolumeId)
+			Expect(err).To(BeNil())
+			_, err = computeService.Disks.Get(project, key.Zone, key.Name).Do()
+			Expect(gce.IsGCEError(err, "notFound")).To(BeTrue(), "Expected HD disk to be deleted")
+		}()
+
+		hdDisk, err := computeService.Disks.Get(hdProject, hdZone, hdVolName).Do()
+		Expect(err).To(BeNil(), "Could not get HD disk from GCE API")
+		Expect(hdDisk.Status).To(Equal(readyState))
+		klog.Infof("Default dynamic volume on HD node resolved to: %s", hdDisk.Type)
+		Expect(hdDisk.Type).To(ContainSubstring("hyperdisk-balanced"),
+			"Expected default hyperdisk-balanced on HD node but got: %s", hdDisk.Type)
+
+		// --- PD-only node: expect default pd-balanced ---
+		pdVolName := testNamePrefix + string(uuid.NewUUID())
+		pdVolume, err := pdContext.Client.CreateVolume(pdVolName, params, defaultSizeGb,
+			&csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{Segments: map[string]string{"topology.gke.io/zone": pdZone}},
+				},
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							"topology.gke.io/zone":                 pdZone,
+							common.DiskTypeLabelKey("pd-balanced"): "true",
+							common.DiskTypeLabelKey("pd-standard"): "true",
+							common.DiskTypeLabelKey("pd-ssd"):      "true",
+							common.DiskTypeLabelKey("pd-extreme"):  "true",
+						},
+					},
+				},
+			}, nil)
+		Expect(err).To(BeNil(), "CreateVolume (PD) failed: %v", err)
+		defer func() {
+			err := pdContext.Client.DeleteVolume(pdVolume.VolumeId)
+			Expect(err).To(BeNil(), "DeleteVolume (PD) failed")
+			project, key, err := common.VolumeIDToKey(pdVolume.VolumeId)
+			Expect(err).To(BeNil())
+			_, err = computeService.Disks.Get(project, key.Zone, key.Name).Do()
+			Expect(gce.IsGCEError(err, "notFound")).To(BeTrue(), "Expected PD disk to be deleted")
+		}()
+
+		pdDisk, err := computeService.Disks.Get(pdProject, pdZone, pdVolName).Do()
+		Expect(err).To(BeNil(), "Could not get PD disk from GCE API")
+		Expect(pdDisk.Status).To(Equal(readyState))
+		klog.Infof("Default dynamic volume on PD-only node resolved to: %s", pdDisk.Type)
+		Expect(pdDisk.Type).To(ContainSubstring("pd-balanced"),
+			"Expected default pd-balanced on PD-only node but got: %s", pdDisk.Type)
+	})
+
+})

--- a/test/e2e/tests/dynamic_volume_e2e_test.go
+++ b/test/e2e/tests/dynamic_volume_e2e_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
+	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/parameters"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// HD Node Dynamic Provisioning
+//
+// Verifies that when type=dynamic is used on a hyperdisk-capable node (c3-standard-4),
+// the driver resolves the disk type to hyperdisk-balanced instead of leaving it as "dynamic".
+//
+// Test flow:
+//  1. Pick a c3-standard-4 VM — supports hyperdisk-balanced
+//  2. Call CreateVolume with type=dynamic, pd-type=pd-balanced, hyperdisk-type=hyperdisk-balanced
+//  3. Verify via GCE API that the created disk is hyperdisk-balanced (not pd-balanced or "dynamic")
+//  4. Cleanup: DeleteVolume and confirm disk is gone
+var _ = Describe("GCE PD CSI Driver Dynamic Volumes HD Node Provisioning", func() {
+
+	It("Should provision hyperdisk-balanced on HD-capable node when type=dynamic", func() {
+		testContext := getRandomMwTestContext()
+
+		p, z, _ := testContext.Instance.GetIdentity()
+		client := testContext.Client
+
+		volName := testNamePrefix + string(uuid.NewUUID())
+
+		params := map[string]string{
+			parameters.ParameterKeyType: parameters.DynamicVolumeType,
+			parameters.ParameterHDType:  "hyperdisk-balanced",
+			parameters.ParameterPDType:  "pd-balanced",
+		}
+
+		// Preferred topology explicitly includes hyperdisk-balanced disk-type label so the
+		// test behaves consistently on both GKE and OSS clusters.
+		volume, err := client.CreateVolume(volName, params, defaultHdBSizeGb,
+			&csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							"topology.gke.io/zone": z,
+						},
+					},
+				},
+				Preferred: []*csi.Topology{
+					{
+						Segments: map[string]string{
+							"topology.gke.io/zone":                        z,
+							common.DiskTypeLabelKey("hyperdisk-balanced"): "true",
+							common.DiskTypeLabelKey("pd-balanced"):        "true",
+						},
+					},
+				},
+			}, nil)
+		Expect(err).To(BeNil(), "CreateVolume failed: %v", err)
+
+		defer func() {
+			err := client.DeleteVolume(volume.VolumeId)
+			Expect(err).To(BeNil(), "DeleteVolume failed")
+			project, key, err := common.VolumeIDToKey(volume.VolumeId)
+			Expect(err).To(BeNil(), "Failed to parse volume ID")
+			_, err = computeService.Disks.Get(project, key.Zone, key.Name).Do()
+			Expect(gce.IsGCEError(err, "notFound")).To(BeTrue(), "Expected disk to be deleted")
+		}()
+
+		cloudDisk, err := computeService.Disks.Get(p, z, volName).Do()
+		Expect(err).To(BeNil(), "Could not get disk from GCE API")
+		Expect(cloudDisk.Status).To(Equal(readyState), "Disk not in READY state")
+		Expect(cloudDisk.Name).To(Equal(volName))
+
+		klog.Infof("Dynamic volume resolved to disk type: %s on HD-capable node %s", cloudDisk.Type, z)
+		Expect(cloudDisk.Type).To(ContainSubstring("hyperdisk-balanced"),
+			"Expected hyperdisk-balanced on HD-capable c3 node but got: %s", cloudDisk.Type)
+	})
+
+})

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -73,6 +73,7 @@ func GCEClientAndDriverSetup(instance *remote.InstanceInfo, driverConfig DriverC
 		"--device-in-use-timeout=10s", // Set lower than the usual value to expedite tests
 		fmt.Sprintf("--fallback-requisite-zones=%s", strings.Join(driverConfig.Zones, ",")),
 		"--disk-topology=true",
+		"--dynamic-volumes=true",
 	}
 
 	extra_flags = append(extra_flags, fmt.Sprintf("--node-name=%s", constants.TestNode))


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

---

**What this PR does / why we need it**:

Adds a new E2E test file `test/e2e/tests/dynamic_volume_e2e_test.go` covering the Basic Provisioning suite for the `type=dynamic` disk selection feature. The suite validates that `selectDiskTypeFromTopologies()` correctly resolves `type=dynamic` to a concrete disk type based on node topology labels (`disk-type.gke.io/*`), and that cleanup leaves no orphaned GCE resources.

The four test cases added are:

1. **HD Node Dynamic Provisioning** — Verifies that `type=dynamic` resolves to `hyperdisk-balanced` on a c3-standard-4 (HD-capable) node when the `Preferred` topology carries the `disk-type.gke.io/hyperdisk-balanced=true` label.

2. **PD Fallback Provisioning** — Verifies that `type=dynamic` falls back to `pd-balanced` on an n2d-standard-4 (PD-only) node when the `Preferred` topology has only `disk-type.gke.io/pd-*=true` labels (no hyperdisk label).

3. **Default Parameters Provisioning** — Verifies that omitting `pd-type` and `hyperdisk-type` from StorageClass parameters causes the driver to use its built-in defaults: `hyperdisk-balanced` on HD-capable nodes and `pd-balanced` on PD-only nodes.

4. **Volume Lifecycle (Create and Delete)** — Verifies the full volume lifecycle: `CreateVolume` resolves `dynamic` to the correct type, the GCE disk is created in `READY` state with a valid volume ID, and `DeleteVolume` removes the disk completely with no orphaned resources.

Each test explicitly passes `Preferred` topology segments so results are consistent across both GKE clusters (where the node labeler stamps real labels) and OSS clusters (where no node labels exist).

---

**Which issue(s) this PR fixes**:

```
None
```

---


**Does this PR introduce a user-facing change?**:
```
None
```

/release-note-none
