### PR TITLE
Bump gcp-compute-persistent-disk-csi-driver image to v1.26.0 in stable-master overlay

### DIFF
--- a/deploy/kubernetes/images/stable-master/image.yaml
+++ b/deploy/kubernetes/images/stable-master/image.yaml
@@ -46,6 +46,6 @@ imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   # pdImagePlaceholder in test/k8s-integration/main.go is updated automatically with the newTag
   newName: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.17.4"
+  newTag: "v1.26.0"
 ---
 


### PR DESCRIPTION
# Motivation

The `stable-master` controller template ships the `taint-controller` container running `--run-taint-controller`, but this overlay's image transformer pins `gcp-compute-persistent-disk-csi-driver` to `v1.17.4`, which lacks that flag — so `kustomize build deploy/kubernetes/overlays/stable-master` produces a controller that crashloops with `flag provided but not defined: -run-taint-controller`. Every other image in this `image.yaml` is current; this bumps the driver to `v1.26.0` (latest release, promoted to registry.k8s.io, supports the flag).

```release-note
NONE
```