### PR TITLE
Handle access mode correctly for Hyperdisk Balanced and Throughput during retried CreateVolume()

### DIFF
--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -476,6 +476,9 @@ func validAccessMode(want, got string) bool {
 		return true
 	}
 	switch want {
+	case "":
+		// Empty string defaults to RWO
+		return got == constants.GCEReadWriteOnceAccessMode
 	case constants.GCEReadOnlyManyAccessMode, constants.GCEReadWriteOnceAccessMode:
 		return got == constants.GCEReadWriteManyAccessMode
 	// For RWX, no other access mode is valid.

--- a/pkg/gce-cloud-provider/compute/gce-compute_test.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute_test.go
@@ -238,6 +238,40 @@ func TestValidateExistingDisk(t *testing.T) {
 			diskType: hyperdisk,
 			wantErr:  true,
 		},
+		{
+			name:       "valid hyperdisk with empty requested access mode config - RWO allowed",
+			accessMode: "",
+			disk: &computebeta.Disk{
+				AccessMode: constants.GCEReadWriteOnceAccessMode,
+			},
+			diskType: hyperdisk,
+		},
+		{
+			name:       "valid hyperdisk with empty requested access mode config - empty existing access mode allowed",
+			accessMode: "",
+			disk: &computebeta.Disk{
+				AccessMode: "",
+			},
+			diskType: hyperdisk,
+		},
+		{
+			name:       "invalid hyperdisk with empty requested access mode config - ROX disallowed",
+			accessMode: "",
+			disk: &computebeta.Disk{
+				AccessMode: constants.GCEReadOnlyManyAccessMode,
+			},
+			diskType: hyperdisk,
+			wantErr:  true,
+		},
+		{
+			name:       "invalid hyperdisk with empty requested access mode config - RWX disallowed",
+			accessMode: "",
+			disk: &computebeta.Disk{
+				AccessMode: constants.GCEReadWriteManyAccessMode,
+			},
+			diskType: hyperdisk,
+			wantErr:  true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// Bootstrap correct disk
@@ -253,6 +287,121 @@ func TestValidateExistingDisk(t *testing.T) {
 			err := ValidateExistingDisk(context.Background(), CloudDiskFromBeta(tc.disk), params, tc.reqBytes, tc.limBytes, tc.multiWriter, tc.accessMode)
 			if gotErr := err != nil; gotErr != tc.wantErr {
 				t.Errorf("want error: %v, got error: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestValidAccessMode(t *testing.T) {
+	testCases := []struct {
+		name string
+		want string
+		got  string
+		exp  bool
+	}{
+		{
+			name: "empty want and empty got",
+			want: "",
+			got:  "",
+			exp:  true,
+		},
+		{
+			name: "empty want and RWO got",
+			want: "",
+			got:  constants.GCEReadWriteOnceAccessMode,
+			exp:  true,
+		},
+		{
+			name: "empty want and ROX got",
+			want: "",
+			got:  constants.GCEReadOnlyManyAccessMode,
+			exp:  false,
+		},
+		{
+			name: "empty want and RWX got",
+			want: "",
+			got:  constants.GCEReadWriteManyAccessMode,
+			exp:  false,
+		},
+		{
+			name: "RWO want and RWO got",
+			want: constants.GCEReadWriteOnceAccessMode,
+			got:  constants.GCEReadWriteOnceAccessMode,
+			exp:  true,
+		},
+		{
+			name: "RWO want and RWX got",
+			want: constants.GCEReadWriteOnceAccessMode,
+			got:  constants.GCEReadWriteManyAccessMode,
+			exp:  true,
+		},
+		{
+			name: "RWO want and ROX got",
+			want: constants.GCEReadWriteOnceAccessMode,
+			got:  constants.GCEReadOnlyManyAccessMode,
+			exp:  false,
+		},
+		{
+			name: "RWO want and empty got",
+			want: constants.GCEReadWriteOnceAccessMode,
+			got:  "",
+			exp:  false,
+		},
+		{
+			name: "ROX want and ROX got",
+			want: constants.GCEReadOnlyManyAccessMode,
+			got:  constants.GCEReadOnlyManyAccessMode,
+			exp:  true,
+		},
+		{
+			name: "ROX want and RWX got",
+			want: constants.GCEReadOnlyManyAccessMode,
+			got:  constants.GCEReadWriteManyAccessMode,
+			exp:  true,
+		},
+		{
+			name: "ROX want and RWO got",
+			want: constants.GCEReadOnlyManyAccessMode,
+			got:  constants.GCEReadWriteOnceAccessMode,
+			exp:  false,
+		},
+		{
+			name: "RWX want and RWX got",
+			want: constants.GCEReadWriteManyAccessMode,
+			got:  constants.GCEReadWriteManyAccessMode,
+			exp:  true,
+		},
+		{
+			name: "RWX want and RWO got",
+			want: constants.GCEReadWriteManyAccessMode,
+			got:  constants.GCEReadWriteOnceAccessMode,
+			exp:  false,
+		},
+		{
+			name: "RWX want and ROX got",
+			want: constants.GCEReadWriteManyAccessMode,
+			got:  constants.GCEReadOnlyManyAccessMode,
+			exp:  false,
+		},
+		{
+			name: "invalid want matching invalid got",
+			want: "UNKNOWN",
+			got:  "UNKNOWN",
+			exp:  true,
+		},
+		{
+			name: "invalid want not matching got",
+			want: "UNKNOWN",
+			got:  constants.GCEReadWriteOnceAccessMode,
+			exp:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := validAccessMode(tc.want, tc.got)
+			if got != tc.exp {
+				t.Errorf("validAccessMode(%q, %q) = %v, want %v", tc.want, tc.got, got, tc.exp)
 			}
 		})
 	}

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -687,8 +687,10 @@ func getAccessMode(req *csi.CreateVolumeRequest, params parameters.DiskParameter
 			// Disallow multi-attach for HdT and HdE. These checks were done in `createVolumeInternal`,
 			// but repeating them here future-proves us from possible refactors.
 			if am != constants.GCEReadWriteOnceAccessMode {
-				return "", status.Errorf(codes.Internal, "")
+				return "", status.Errorf(codes.InvalidArgument, "Hyperdisk Throughput and Extreme disks only support ReadWriteOnce access mode")
 			}
+			// Return empty string to indicate the default ReadWriteOnce access mode
+			return "", nil
 		} else {
 			return am, nil
 		}

--- a/pkg/gce-pd-csi-driver/utils_test.go
+++ b/pkg/gce-pd-csi-driver/utils_test.go
@@ -25,6 +25,8 @@ import (
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/constants"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/parameters"
 )
@@ -908,5 +910,136 @@ func TestIsDataCacheEnabledNodePool(t *testing.T) {
 		if gotDataCacheEnabled != tc.wantDataCacheEnabled {
 			t.Errorf("want %t, got %t", tc.wantDataCacheEnabled, gotDataCacheEnabled)
 		}
+	}
+}
+
+func TestGetAccessMode(t *testing.T) {
+	testCases := []struct {
+		name        string
+		req         *csi.CreateVolumeRequest
+		diskType    string
+		want        string
+		wantErrCode codes.Code
+	}{
+		{
+			name: "Hyperdisk Balanced RWO capability",
+			req: &csi.CreateVolumeRequest{
+				VolumeCapabilities: createVolumeCapabilities(csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+			},
+			diskType:    "hyperdisk-balanced",
+			want:        constants.GCEReadWriteOnceAccessMode,
+			wantErrCode: codes.OK,
+		},
+		{
+			name: "Hyperdisk Balanced ROX capability",
+			req: &csi.CreateVolumeRequest{
+				VolumeCapabilities: createVolumeCapabilities(csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY),
+			},
+			diskType:    "hyperdisk-balanced",
+			want:        constants.GCEReadOnlyManyAccessMode,
+			wantErrCode: codes.OK,
+		},
+		{
+			name: "Hyperdisk Balanced RWX capability",
+			req: &csi.CreateVolumeRequest{
+				VolumeCapabilities: createVolumeCapabilities(csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER),
+			},
+			diskType:    "hyperdisk-balanced",
+			want:        constants.GCEReadWriteManyAccessMode,
+			wantErrCode: codes.OK,
+		},
+		{
+			name: "Hyperdisk Balanced unsupported capability SINGLE_NODE_READER_ONLY",
+			req: &csi.CreateVolumeRequest{
+				VolumeCapabilities: createVolumeCapabilities(csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY),
+			},
+			diskType:    "hyperdisk-balanced",
+			want:        "",
+			wantErrCode: codes.Unknown,
+		},
+		{
+			name: "Hyperdisk Extreme RWO capability",
+			req: &csi.CreateVolumeRequest{
+				VolumeCapabilities: createVolumeCapabilities(csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+			},
+			diskType:    "hyperdisk-extreme",
+			want:        "",
+			wantErrCode: codes.OK,
+		},
+		{
+			name: "Hyperdisk Extreme ROX capability (unsupported multi-attach)",
+			req: &csi.CreateVolumeRequest{
+				VolumeCapabilities: createVolumeCapabilities(csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY),
+			},
+			diskType:    "hyperdisk-extreme",
+			want:        "",
+			wantErrCode: codes.InvalidArgument,
+		},
+		{
+			name: "Hyperdisk Extreme RWX capability (unsupported multi-attach)",
+			req: &csi.CreateVolumeRequest{
+				VolumeCapabilities: createVolumeCapabilities(csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER),
+			},
+			diskType:    "hyperdisk-extreme",
+			want:        "",
+			wantErrCode: codes.InvalidArgument,
+		},
+		{
+			name: "Hyperdisk Throughput RWO capability",
+			req: &csi.CreateVolumeRequest{
+				VolumeCapabilities: createVolumeCapabilities(csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+			},
+			diskType:    "hyperdisk-throughput",
+			want:        "",
+			wantErrCode: codes.OK,
+		},
+		{
+			name: "Hyperdisk Throughput ROX capability (unsupported multi-attach)",
+			req: &csi.CreateVolumeRequest{
+				VolumeCapabilities: createVolumeCapabilities(csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY),
+			},
+			diskType:    "hyperdisk-throughput",
+			want:        "",
+			wantErrCode: codes.InvalidArgument,
+		},
+		{
+			name: "Non-Hyperdisk PD balanced RWO capability",
+			req: &csi.CreateVolumeRequest{
+				VolumeCapabilities: createVolumeCapabilities(csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER),
+			},
+			diskType:    "pd-balanced",
+			want:        "",
+			wantErrCode: codes.OK,
+		},
+		{
+			name: "Non-Hyperdisk PD balanced ROX capability (not in modifiable list)",
+			req: &csi.CreateVolumeRequest{
+				VolumeCapabilities: createVolumeCapabilities(csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY),
+			},
+			diskType:    "pd-balanced",
+			want:        "",
+			wantErrCode: codes.OK,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := getAccessMode(tc.req, parameters.DiskParameters{DiskType: tc.diskType})
+			if err != nil {
+				if tc.wantErrCode == codes.OK {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if status.Code(err) != tc.wantErrCode {
+					t.Fatalf("expected error code %v, got %v (error: %v)", tc.wantErrCode, status.Code(err), err)
+				}
+				return
+			}
+			if tc.wantErrCode != codes.OK {
+				t.Fatalf("expected error code %v, but got no error", tc.wantErrCode)
+			}
+			if got != tc.want {
+				t.Fatalf("expected access mode %q, got %q", tc.want, got)
+			}
+		})
 	}
 }

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -380,6 +380,43 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		Entry("on pd-ssd", ssdDiskType),
 	)
 
+	DescribeTable("Should succeed calling CreateVolume twice",
+		func(diskType string, diskSize int64) {
+			testContext := getRandomTestContext()
+
+			p, z, _ := testContext.Instance.GetIdentity()
+			client := testContext.Client
+
+			disk := typeToDisk[diskType]
+			volName := testNamePrefix + string(uuid.NewUUID())
+
+			// First CreateVolume call
+			vol1, err := client.CreateVolume(volName, disk.params, diskSize, nil, nil)
+			Expect(err).To(BeNil(), "First CreateVolume call failed")
+			Expect(vol1).ToNot(BeNil())
+
+			defer func() {
+				// Delete Disk
+				err := client.DeleteVolume(vol1.VolumeId)
+				Expect(err).To(BeNil(), "DeleteVolume failed")
+
+				// Validate Disk Deleted
+				_, err = computeService.Disks.Get(p, z, volName).Do()
+				Expect(gce.IsGCEError(err, "notFound")).To(BeTrue(), "Expected disk to not be found")
+			}()
+
+			// Second CreateVolume call with identical parameters
+			vol2, err := client.CreateVolume(volName, disk.params, diskSize, nil, nil)
+			Expect(err).To(BeNil(), "Second CreateVolume call failed")
+			Expect(vol2).ToNot(BeNil())
+			Expect(vol2.VolumeId).To(Equal(vol1.VolumeId), "Expected volume IDs to match for idempotent CreateVolume calls")
+		},
+		Entry("on pd-ssd", ssdDiskType, defaultSizeGb),
+		Entry("on hyperdisk-balanced", hdbDiskType, defaultHdBSizeGb),
+		Entry("on hyperdisk-extreme", hdxDiskType, defaultHdXSizeGb),
+		Entry("on hyperdisk-throughput", hdtDiskType, defaultHdTSizeGb),
+	)
+
 	DescribeTable("[NVMe] Should complete publish/unpublish lifecycle with underspecified volume ID and missing volume",
 		func(diskType string) {
 			testContext := getRandomTestContext()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Retain the existing behavior for using "" as the default RWO access mode for HdT and HdE disk types to match with PD.

The fix modifies the ValidateExistingDisk() function to handle the "" case for Hyperdisk types and enforces that the disk's access mode is RWO.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix issue where creating a Hyperdisk Throughput or Extreme disk from a large snapshot fails with access mode mismatch 
```
