### PR TITLE
Remove service account credentials from taint-controller in noauth overlay

### DIFF
--- a/deploy/kubernetes/overlays/noauth/noauth.yaml
+++ b/deploy/kubernetes/overlays/noauth/noauth.yaml
@@ -16,6 +16,16 @@ spec:
               name: cloud-sa-volume
               readOnly: true
               mountPath: "/etc/cloud-sa"
+        - name: taint-controller
+          env:
+            - $patch: delete
+              name: GOOGLE_APPLICATION_CREDENTIALS
+              value: "/etc/cloud-sa/cloud-sa.json"
+          volumeMounts:
+            - $patch: delete
+              name: cloud-sa-volume
+              readOnly: true
+              mountPath: "/etc/cloud-sa"
       volumes:
         - $patch: delete
           name: cloud-sa-volume


### PR DESCRIPTION
Update the noauth overlay to delete the GOOGLE_APPLICATION_CREDENTIALS environment variable and cloud-sa-volume volume mount from the taint-controller container.

This is to fix error: "csi-gce-pd-controller" is invalid: spec.template.spec.containers[5].volumeMounts[0].name: Not found: "cloud-sa-volume"

Fixes: #2303



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fixed noauth mode error: "csi-gce-pd-controller" is invalid: spec.template.spec.containers[5].volumeMounts[0].name: Not found: "cloud-sa-volume"

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2303

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE
```release-note
Fixed noauth mode error: "csi-gce-pd-controller" is invalid: spec.template.spec.containers[5].volumeMounts[0].name: Not found: "cloud-sa-volume"
```
