### PR TITLE
Cherry-Pick PR#2355 to 1.26

### DIFF
--- a/pkg/gce-pd-csi-driver/cache.go
+++ b/pkg/gce-pd-csi-driver/cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -50,6 +51,20 @@ func fetchRAIDedLocalSsdPath() (string, error) {
 	return infoSlice[1], nil
 }
 
+func getVgUuid(vgName string) (string, error) {
+	args := []string{
+		"--noheadings",
+		"-o",
+		"vg_uuid",
+		vgName,
+	}
+	output, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgs", args...)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
 func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId string) (string, error) {
 
 	// The device path may have changed after rebooting, so we need to fetch the path again
@@ -60,13 +75,36 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 
 	volumeId := req.GetVolumeId()
 	volumeGroupName := getVolumeGroupName(nodeId)
-	mainDevicePath := "/dev/" + volumeGroupName + "/" + getLvName(mainLvSuffix, volumeId)
 	mainLvName := getLvName(mainLvSuffix, volumeId)
+	mainDevicePath := "/dev/" + volumeGroupName + "/" + mainLvName
+
+	// Refresh LVM device cache to ensure newly attached GCE PD is fully scanned (Comment: Refresh LVM cache)
+	_, _ = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "pvscan", []string{"--cache"}...)
+	_, _ = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgscan", []string{"--cache"}...)
+
+	// Resolve any stale duplicate Volume Group name conflicts from preemption events
+	hasConflict, staleVgUuid, err := detectPreemptionVgConflict(volumeGroupName, devicePath)
+	if err != nil {
+		klog.Errorf("Failed to check duplicate VG conflict for PV %v: %v", devicePath, err)
+	}
+	if hasConflict {
+		err = recoverPreemptionVgConflict(volumeGroupName, mainLvName, devicePath, staleVgUuid)
+		if err != nil {
+			return "", err
+		}
+	}
+
 	klog.V(4).Infof("Volume group available on node %v ", volumeGroupName)
 	vgExists := checkVgExists(volumeGroupName)
 	if vgExists {
 		// Clean up Volume Group before adding the PD
 		reduceVolumeGroup(volumeGroupName, true)
+
+		// Ensure the local SSD cache PV is registered in the Volume Group
+		err = ensureLocalSsdInVolumeGroup(volumeGroupName, raidedLocalSsdPath)
+		if err != nil {
+			return mainDevicePath, err
+		}
 	} else {
 		err := createVg(volumeGroupName, raidedLocalSsdPath)
 		if err != nil {
@@ -75,67 +113,27 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 	}
 
 	// Check if the Physical Volume(PV) is part of some other volume group
-	args := []string{
-		"--select",
-		"pv_name=" + devicePath,
-		"-o",
-		"vg_name",
-	}
-	info, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "pvs", args...)
+	vgNameForPv, _, err := getVgInfoForPv(devicePath)
 	if err != nil {
-		klog.Errorf("errored while checking physical volume details %v: %s", err, info)
-		// On error info contains the error message which we cannot use for further steps
-		info = nil
+		return "", fmt.Errorf("failed to get VG name for PV %s: %w", devicePath, err)
 	}
-
-	infoString := strings.TrimSpace(strings.ReplaceAll(string(info), "\n", " "))
-	infoString = strings.ReplaceAll(infoString, ".", "")
-	infoString = strings.ReplaceAll(infoString, "\"", "")
-	infoSlice := strings.Split(strings.TrimSpace(infoString), " ")
-	vgNameForPv := strings.TrimSpace(infoSlice[(len(infoSlice) - 1)])
 	klog.V(4).Infof("Physical volume is part of Volume group: %v", vgNameForPv)
 	if vgNameForPv == volumeGroupName {
 		klog.V(4).Infof("Physical Volume(PV) already exists in the Volume Group %v", volumeGroupName)
-	} else if vgNameForPv != "VG" && vgNameForPv != "" {
-
-		info, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgchange", []string{"-an", vgNameForPv}...)
+	} else if vgNameForPv != "" {
+		err = mergeStaleVgIntoHost(vgNameForPv, volumeGroupName, mainLvName)
 		if err != nil {
-			klog.Errorf("Errored while deactivating VG %v: err: %v: %s", vgNameForPv, err, info)
+			return "", err
 		}
-		// CLean up volume group to remove any dangling PV refrences
-		reduceVolumeGroup(vgNameForPv, false)
-		_, isCached := isCachingSetup(mainLvName)
-		// We will continue to uncache even if it errors to check caching as it is not a terminal issue.
-
-		if isCached {
-			// Uncache LV
-			args = []string{
-				"--uncache",
-				vgNameForPv + "/" + mainLvName,
-				"--force",
-				"-y", // force remove cache without flushing data
-			}
-			info, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvconvert", args...)
-			if err != nil {
-				return "", fmt.Errorf("errored while uncaching main LV. %v: %s", err, info)
-			}
-			// CLean up volume group to remove any dangling PV refrences
-			reduceVolumeGroup(vgNameForPv, false)
-		}
-		info, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgmerge", []string{volumeGroupName, vgNameForPv}...)
-		if err != nil {
-			return "", fmt.Errorf("Errored while merging the PV Volume group %s into %s %v: %s", vgNameForPv, volumeGroupName, err, info)
-		}
-
 	} else {
-		info, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgextend", []string{volumeGroupName, devicePath}...)
+		_, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgextend", []string{volumeGroupName, devicePath}...)
 		if err != nil {
-			return "", fmt.Errorf("Errored while extending Volume group to add PV %v, error: %v: %s", devicePath, err, info)
+			return "", fmt.Errorf("Errored while extending Volume group to add PV %v, error: %w", devicePath, err)
 		}
 	}
 
 	// Create LV if not already created
-	args = []string{
+	args := []string{
 		"--select",
 		"vg_name=" + volumeGroupName,
 		"-o",
@@ -143,7 +141,7 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 	}
 	lvList, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvs", args...)
 	if err != nil {
-		return mainDevicePath, fmt.Errorf("Errored while checking logical volume for the device %s %w: %s", devicePath, err, info)
+		return mainDevicePath, fmt.Errorf("Errored while checking logical volume for the device %s %w", devicePath, err)
 	}
 	if !strings.Contains(string(lvList), mainLvName) {
 		args = []string{
@@ -155,9 +153,9 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 			volumeGroupName,
 			devicePath,
 		}
-		info, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvcreate", args...)
+		_, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvcreate", args...)
 		if err != nil {
-			return mainDevicePath, fmt.Errorf("Errored setting up logical volume for the volume %s %w: %s", devicePath, err, info)
+			return mainDevicePath, fmt.Errorf("Errored setting up logical volume for the volume %s %w", devicePath, err)
 		}
 
 	}
@@ -185,7 +183,16 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 			}
 		}
 		// Check if LV exists
-		info, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvs", args...)
+		args = []string{
+			"--select",
+			"vg_name=" + volumeGroupName,
+			"-o",
+			"lv_name",
+		}
+		info, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvs", args...)
+		if err != nil {
+			return mainDevicePath, fmt.Errorf("Errored while checking logical volume list %w", err)
+		}
 		lvExists := strings.Contains(string(info), cacheLvName)
 		if !lvExists {
 			args = []string{
@@ -198,12 +205,12 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 				volumeGroupName,
 				raidedLocalSsdPath,
 			}
-			info, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvcreate", args...)
+			_, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvcreate", args...)
 			if err != nil {
 				if strings.Contains(err.Error(), "insufficient free space") {
 					return mainDevicePath, status.Error(codes.InvalidArgument, fmt.Sprintf("Error setting up cache: %v", err.Error()))
 				}
-				return mainDevicePath, fmt.Errorf("Errored while creating cache %w: %s", err, info)
+				return mainDevicePath, fmt.Errorf("Errored while creating cache %w", err)
 			}
 		}
 
@@ -214,7 +221,7 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 			"--cachevol",
 			cacheLvName,
 			"--zero",
-			"y",
+			"n",
 			"--cachemode",
 			req.GetPublishContext()[constants.ContextDataCacheMode],
 			volumeGroupName + "/" + mainLvName,
@@ -223,19 +230,143 @@ func setupCaching(devicePath string, req *csi.NodeStageVolumeRequest, nodeId str
 			"--force",
 			"-y",
 		}
-		info, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvconvert", args...)
+		_, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvconvert", args...)
 		if err != nil {
-			return mainDevicePath, fmt.Errorf("Errored while setting up caching for volume %s %w: %s", devicePath, err, info)
+			return mainDevicePath, fmt.Errorf("Errored while setting up caching for volume %s %w", devicePath, err)
 		}
 	}
 
 	// activate all the LVs in the Volume group
-	info, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgchange", []string{"-ay", volumeGroupName}...)
+	_, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgchange", []string{"-ay", volumeGroupName}...)
 	if err != nil {
 		// The logical volumes would not be accessible if the group is not activated
-		return mainDevicePath, fmt.Errorf("Failed to activate volume group %v %v:%s", volumeGroupName, err, info)
+		return mainDevicePath, fmt.Errorf("Failed to activate volume group %v %w", volumeGroupName, err)
 	}
 	return mainDevicePath, nil
+}
+
+// detectPreemptionVgConflict checks if a stale duplicate Volume Group name conflict exists on the GCE PD.
+// A conflict occurs when a worker node is preempted and replaced: the GCE PD retains the old VG metadata/name,
+// which matches the new VG name initialized on the replacement node's local SSDs, but has a different VG UUID.
+// Returns true, the stale VG UUID, and nil if a conflict is detected; false, "", and nil/error otherwise.
+func detectPreemptionVgConflict(volumeGroupName, devicePath string) (bool, string, error) {
+	vgNameForPv, vgUuidForPv, err := getVgInfoForPv(devicePath)
+	if err != nil {
+		return false, "", err
+	}
+	if vgNameForPv != volumeGroupName || vgUuidForPv == "" {
+		klog.V(4).Infof("No duplicate VG name conflict detected for %s on PV %s", volumeGroupName, devicePath)
+		return false, "", nil
+	}
+
+	// Get the active VG UUID on the host to distinguish same-node reattachments from true conflicts
+	activeVgUuid, activeVgErr := getVgUuid(volumeGroupName)
+	if activeVgErr != nil {
+		klog.V(4).Infof("Failed to get active VG UUID for %s (it might not exist yet): %v. Proceeding with duplicate VG recovery.", volumeGroupName, activeVgErr)
+	}
+	if activeVgUuid == vgUuidForPv {
+		klog.Infof("No duplicate VG conflict: GCE PD's VG UUID %s matches the active host VG UUID. Skipping recovery.", vgUuidForPv)
+		return false, "", nil
+	}
+
+	return true, vgUuidForPv, nil
+}
+
+// recoverPreemptionVgConflict resolves the duplicate Volume Group name conflict on the GCE PD.
+// It isolates LVM commands to the GCE PD using a device filter, deactivates the stale VG,
+// dissociates the cache pool, prunes missing PV references, renames the stale VG, and
+// regenerates its UUID to completely break the conflict.
+func recoverPreemptionVgConflict(volumeGroupName, mainLvName, devicePath, staleVgUuid string) error {
+	klog.Infof("Resolving duplicate VG name conflict for %s using stale VG UUID %s", volumeGroupName, staleVgUuid)
+	configFilter := fmt.Sprintf("devices { filter = [ \"a|%s|\", \"r|.*|\" ] }", devicePath)
+
+	// Step 1: Deactivate the stale VG first under the device filter.
+	// If the GCE PD was automatically activated upon attachment, LVM will reject metadata edits
+	// because the logical volumes are "open" or "in use" (kernel-active). Deactivating them takes them offline safely.
+	klog.Infof("Step 1: Deactivating stale VG %s using device filter", volumeGroupName)
+	if err := deactivateVolumeGroup(volumeGroupName, configFilter); err != nil {
+		klog.Warningf("Failed to deactivate stale VG %s: %v. Attempting to proceed with recovery.", volumeGroupName, err)
+	}
+
+	// Step 2: Cleanly decouple (uncache) the caching layout first, BEFORE running vgreduce.
+	// WARNING: If we run vgreduce --removemissing first on a partial cached LV (missing local SSD),
+	// LVM will forcefully destroy/delete the entire logical volume, resulting in complete data loss!
+	// Dissociating the cache first preserves the origin volume (and user data) intact on the GCE PD.
+	isCached, err := isLvCachedOnDevice(volumeGroupName, mainLvName, devicePath)
+	if err != nil {
+		klog.Errorf("Failed to check if stale volume %s/%s is cached: %v", volumeGroupName, mainLvName, err)
+	}
+	if isCached {
+		klog.Infof("Step 2: Dissociating (uncaching) stale volume %s/%s using device filter to preserve data", volumeGroupName, mainLvName)
+		if err := uncacheLogicalVolume(volumeGroupName, mainLvName, configFilter); err != nil {
+			return fmt.Errorf("failed to uncache stale volume %s/%s during preemption recovery: %w", volumeGroupName, mainLvName, err)
+		}
+	} else {
+		klog.Infof("Stale volume %s/%s is not cached, skipping uncache step during preemption recovery", volumeGroupName, mainLvName)
+	}
+
+	// Step 3: Clean up missing PVs on the stale VG using the device filter.
+	// Since the cache has been dissociated, this safely removes the missing local SSD references from the VG metadata.
+	klog.Infof("Step 3: Cleaning up missing PVs on duplicate VG %s using device filter", volumeGroupName)
+	if err := reduceStaleVolumeGroup(volumeGroupName, configFilter); err != nil {
+		return fmt.Errorf("failed to reduce stale VG %s during preemption recovery: %w", volumeGroupName, err)
+	}
+
+	// Compute unique temporary name for the stale VG.
+	shortUuid := staleVgUuid
+	if len(shortUuid) > 8 {
+		shortUuid = shortUuid[:8]
+	}
+	tempVgName := fmt.Sprintf("csi-vg-stale-%s", shortUuid)
+
+	// Step 4: Rename the stale VG using the device filter to resolve the duplicate name conflict.
+	klog.Infof("Step 4: Renaming stale VG %s to %s using device filter", volumeGroupName, tempVgName)
+	if err := renameVolumeGroup(volumeGroupName, tempVgName, configFilter); err != nil {
+		return fmt.Errorf("failed to rename stale VG %s to %s during preemption recovery: %w", volumeGroupName, tempVgName, err)
+	}
+
+	// Step 5: Regenerate the UUID of the renamed VG to break the duplicate VGID conflict.
+	klog.Infof("Step 5: Regenerating UUID for stale VG %s to resolve duplicate VGID conflict", tempVgName)
+	if err := regenerateVolumeGroupUuid(tempVgName, configFilter); err != nil {
+		klog.Warningf("Failed to regenerate UUID for stale VG %s: %v. Continuing recovery.", tempVgName, err)
+	}
+
+	return nil
+}
+
+// deactivateVolumeGroup deactivates the Volume Group under the specified device filter to release kernel locks.
+func deactivateVolumeGroup(vgName, configFilter string) error {
+	deactivateArgs := []string{"-an", vgName, "--config", configFilter}
+	_, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgchange", deactivateArgs...)
+	return err
+}
+
+// uncacheLogicalVolume dissociates (uncaches) the cache pool from the logical volume under the specified device filter.
+func uncacheLogicalVolume(vgName, lvName, configFilter string) error {
+	uncacheArgs := []string{"--uncache", vgName + "/" + lvName, "--force", "-y", "--config", configFilter}
+	_, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvconvert", uncacheArgs...)
+	return err
+}
+
+// reduceStaleVolumeGroup prunes missing physical volumes (references to local SSDs) from the VG metadata under the specified device filter.
+func reduceStaleVolumeGroup(vgName, configFilter string) error {
+	reduceArgs := []string{"--removemissing", vgName, "--force", "--config", configFilter}
+	_, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgreduce", reduceArgs...)
+	return err
+}
+
+// renameVolumeGroup renames the Volume Group under the specified device filter to resolve the duplicate naming conflict.
+func renameVolumeGroup(oldName, newName, configFilter string) error {
+	renameArgs := []string{oldName, newName, "--config", configFilter}
+	_, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgrename", renameArgs...)
+	return err
+}
+
+// regenerateVolumeGroupUuid regenerates the Volume Group UUID under the specified device filter to resolve the duplicate VGID conflict.
+func regenerateVolumeGroupUuid(vgName, configFilter string) error {
+	vgchangeArgs := []string{"-u", vgName, "--config", configFilter}
+	_, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgchange", vgchangeArgs...)
+	return err
 }
 
 func ValidateDataCacheConfig(dataCacheMode string, dataCacheSize string, ctx context.Context) error {
@@ -328,6 +459,7 @@ func FetchAllLssds() ([]string, error) {
 		return nil, fmt.Errorf("errored while fetching NVME disks info: %v; err:%v", info, err)
 	}
 	infoList := strings.Split(strings.TrimSpace(string(info)), "\n")
+	// Compile regex to match GCE Local SSD model names (e.g., "nvme_card" or "nvme_card1")
 	re, err := regexp.Compile("nvme_card([0-9]+)?$")
 	if err != nil {
 		klog.V(4).ErrorS(err, "Errored while compiling to check PD or LSSD")
@@ -426,6 +558,122 @@ func getVolumeGroupName(nodePath string) string {
 	return fmt.Sprintf("csi-vg-%s", nodeHash)
 }
 
+// getVgInfoForPv queries LVM metadata for the physical volume (PV) path under a device-specific filter.
+// It returns the associated Volume Group (VG) name, VG UUID, and any error.
+func getVgInfoForPv(pvPath string) (string, string, error) {
+	resolvedPvPath, err := filepath.EvalSymlinks(pvPath)
+	if err != nil {
+		resolvedPvPath = pvPath // Fallback
+	}
+
+	configFilter := fmt.Sprintf("devices { filter = [ \"a|%s|\", \"r|.*|\" ] }", resolvedPvPath)
+	args := []string{
+		"--noheadings",
+		"-o",
+		"vg_name,vg_uuid,pv_name",
+		"--config",
+		configFilter,
+	}
+	info, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "pvs", args...)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to run pvs: %w", err)
+	}
+	lines := strings.Split(string(info), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		// The fields slice must contain at least 3 elements representing:
+		// fields[0] = vg_name, fields[1] = vg_uuid, fields[2] = pv_name
+		if len(fields) >= 3 {
+			resolvedFieldName, err := filepath.EvalSymlinks(fields[2])
+			if err != nil {
+				resolvedFieldName = fields[2]
+			}
+			if resolvedFieldName == resolvedPvPath {
+				vgName := fields[0]
+				vgUuid := fields[1]
+				if vgName == "" || vgName == "-" {
+					vgName = ""
+				}
+				if vgUuid == "" || vgUuid == "-" {
+					vgUuid = ""
+				}
+				return vgName, vgUuid, nil
+			}
+		}
+	}
+	return "", "", nil
+}
+
+// isLvCachedOnDevice checks if the logical volume (LV) in the volume group (VG) is cached.
+// It queries LVM using 'lvs' with a custom field selection, returning true if the volume
+// is associated with a cache pool ('csi-fast'), and false otherwise.
+func isLvCachedOnDevice(vgName, lvName, pvPath string) (bool, error) {
+	resolvedPvPath, err := filepath.EvalSymlinks(pvPath)
+	if err != nil {
+		resolvedPvPath = pvPath
+	}
+
+	configFilter := fmt.Sprintf("devices { filter = [ \"a|%s|\", \"r|.*|\" ] }", resolvedPvPath)
+	args := []string{
+		"--noheadings",
+		"--select", "lv_name=" + lvName + " && vg_name=" + vgName,
+		"-o", "pool_lv",
+		"--config", configFilter,
+	}
+	output, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvs", args...)
+	if err != nil {
+		// If lvs exits with a warning/error (which it always does when a PV is missing),
+		// we still want to parse the output. If the VG/LV genuinely doesn't exist,
+		// the output will be empty and we will correctly return false.
+		klog.V(4).Infof("lvs returned warning/error while checking cache on %s: %v. Parsing output anyway.", pvPath, err)
+	}
+	return strings.Contains(string(output), "csi-fast"), nil
+}
+
+// mergeStaleVgIntoHost deactivates, uncaches, and reduces a stale Volume Group on the GCE PD,
+// and merges its physical volume into the host's active Volume Group pool.
+// Encapsulates stale VG merging logic.
+func mergeStaleVgIntoHost(vgNameForPv, volumeGroupName, mainLvName string) error {
+	klog.Infof("Stale VG %s found on GCE PD. Activating it first to perform cleanup.", vgNameForPv)
+	// Ensure the stale VG is active so we can modify its metadata (Comment: Activate stale VG for cleanup)
+	_, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgchange", []string{"-ay", vgNameForPv}...)
+	if err != nil {
+		klog.Errorf("Errored while activating stale VG %v: err: %v", vgNameForPv, err)
+	}
+
+	_, isCached := isCachingSetup(mainLvName)
+	if isCached {
+		klog.Infof("Stale volume %s/%s is cached. Dissociating (uncaching) cache pool to preserve data.", vgNameForPv, mainLvName)
+		args := []string{
+			"--uncache",
+			vgNameForPv + "/" + mainLvName,
+			"--force",
+			"-y", // force remove cache without flushing data
+		}
+		_, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "lvconvert", args...)
+		if err != nil {
+			return fmt.Errorf("errored while uncaching main LV: %w", err)
+		}
+	}
+
+	// Clean up the stale Volume Group to remove the missing local SSD PV references while it is active
+	reduceVolumeGroup(vgNameForPv, true)
+
+	// Deactivate ONLY the source VG to release its locks before running vgmerge (Comment: Release locks on source VG only)
+	klog.Infof("Deactivating source VG %s to release locks before merging...", vgNameForPv)
+	_, _ = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgchange", []string{"-an", vgNameForPv}...)
+
+	// Merge the GCE PD's VG into the host's VG (destination VG remains active/in-use!)
+	_, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgmerge", []string{volumeGroupName, vgNameForPv}...)
+	if err != nil {
+		return fmt.Errorf("Errored while merging the PV Volume group %s into %s %w", vgNameForPv, volumeGroupName, err)
+	}
+	return nil
+}
 func getLvName(suffix string, volumeId string) string {
 	pvcNameStringSlice := strings.Split(volumeId, "/")
 	pvcName := pvcNameStringSlice[len(pvcNameStringSlice)-1]
@@ -450,6 +698,23 @@ func createVg(volumeGroupName string, raidedLocalSsds string) error {
 	info, err = common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgscan", args...)
 	if err != nil {
 		klog.Errorf("Failed to scan for volume group post creation, continuing: %v: %s", err, info)
+	}
+	return nil
+}
+
+// ensureLocalSsdInVolumeGroup checks if the local SSD cache physical volume is registered
+// in the host Volume Group, and extends the VG to add it back if it is missing (e.g. after a node preemption reset).
+func ensureLocalSsdInVolumeGroup(volumeGroupName, raidedLocalSsdPath string) error {
+	ssdVgName, _, err := getVgInfoForPv(raidedLocalSsdPath)
+	if err != nil {
+		klog.Warningf("Local SSD PV %s is not registered in LVM (it might have been wiped): %v. Re-adding it to Volume Group %s.", raidedLocalSsdPath, err, volumeGroupName)
+	}
+	if ssdVgName != volumeGroupName {
+		klog.Infof("Extending Volume Group %s to include local SSD cache PV %s", volumeGroupName, raidedLocalSsdPath)
+		info, err := common.RunCommand("" /* pipedCmd */, nil /* pipedCmdArg */, "vgextend", []string{volumeGroupName, raidedLocalSsdPath}...)
+		if err != nil {
+			return fmt.Errorf("failed to extend VG %s with local SSD PV %s: %w (output: %s)", volumeGroupName, raidedLocalSsdPath, err, string(info))
+		}
 	}
 	return nil
 }

--- a/test/e2e/tests/multi_zone_e2e_test.go
+++ b/test/e2e/tests/multi_zone_e2e_test.go
@@ -1578,9 +1578,8 @@ func testMount(volID string, volName string, instance *remote.InstanceInfo, clie
 
 	unpublish := func() {
 		// Unpublish Disk
-		err = client.NodeUnpublishVolume(volID, publishDir)
-		if err != nil {
-			klog.Errorf("Failed to unpublish volume: %v", err)
+		if unpubErr := client.NodeUnpublishVolume(volID, publishDir); unpubErr != nil {
+			klog.Errorf("Failed to unpublish volume: %v", unpubErr)
 		}
 	}
 

--- a/test/e2e/tests/setup_e2e_test.go
+++ b/test/e2e/tests/setup_e2e_test.go
@@ -85,7 +85,7 @@ func TestE2E(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	var err error
-	numberOfInstancesPerZone := 2
+	numberOfInstancesPerZone := 3
 	zones := strings.Split(*zones, ",")
 
 	rand.Seed(time.Now().UnixNano())
@@ -251,7 +251,8 @@ func NewTestContext(zone, minCpuPlatform, machineType string, instanceNumber str
 
 func getRandomTestContext() *remote.TestContext {
 	Expect(testContexts).ToNot(BeEmpty())
-	rn := rand.Intn(len(testContexts))
+	// Exclude the last instance which is dedicated and isolated for the preemption deadlock test
+	rn := rand.Intn(len(testContexts) - 1)
 	return testContexts[rn]
 }
 func getRandomMwTestContext() *remote.TestContext {

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -1500,6 +1500,105 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		Expect(err).To(BeNil(), "Failed to go through volume lifecycle")
 
 	})
+	It("Should successfully recover from hard preemption and duplicate VG name conflict on same node", func() {
+		Expect(testContexts).ToNot(BeEmpty())
+		// Select the last instance in the pool which is isolated and reserved for this test case
+		testContextForVm := testContexts[len(testContexts)-1]
+		if testContextForVm.Instance.GetLocalSSD() == 0 {
+			Skip("Skipping Data Cache preemption test as isolated VM instance does not have local SSD")
+		}
+
+		p, z, _ := testContextForVm.Instance.GetIdentity()
+		client := testContextForVm.Client
+		instance := testContextForVm.Instance
+
+		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, standardDiskType)
+		defer deleteVolumeOrError(client, volID)
+
+		defer func() {
+			klog.Infof("Cleaning up preemption test resources on VM %s...", instance.GetName())
+			// Force-detach GCE PD using controller API
+			_ = client.ControllerUnpublishVolume(volID, instance.GetNodeID())
+			klog.Infof("Cleanup completed.")
+		}()
+
+		attachMountArgs := attachAndMountArgs{
+			readOnly:       false,
+			useBlock:       false,
+			forceAttach:    false,
+			setupDataCache: true,
+		}
+
+		// 1. Stage and Mount the volume with Data Cache enabled on the VM
+		klog.Infof("Step 1: Staging and mounting Data Cache volume %s on VM %s", volName, instance.GetName())
+		err, _, args := testAttachAndMount(volID, volName, instance, client, attachMountArgs)
+		Expect(err).To(BeNil(), "Failed to stage and mount volume on VM")
+
+		// 2. Write a verification file to prove data persistence on the VM
+		klog.Infof("Step 2: Writing verification file to volume on VM")
+		writeVerifyFunc, readVerifyFunc := testWriteAndReadFile(instance, false /* readOnly */)
+		err = writeVerifyFunc(args)
+		Expect(err).To(BeNil(), "Failed to write verification file to mounted volume on VM")
+
+		// Verify we can read the file back immediately on VM before preemption
+		err = readVerifyFunc(args)
+		Expect(err).To(BeNil(), "Failed to read verification file back on VM before preemption")
+
+		// Flush filesystem page cache to physical GCE PD before force-detaching!
+		_, err = instance.SSHNoSudo("sync")
+		Expect(err).To(BeNil(), "Failed to run sync command on VM")
+		time.Sleep(10 * time.Second)
+
+		// 3. Simulate hard preemption: Force-detach the GCE PD from the VM WITHOUT unstaging!
+		klog.Infof("Step 3: Simulating preemption by force-detaching the disk from VM without unstaging...")
+		err = instance.DetachDisk(volName)
+		Expect(err).To(BeNil(), "Failed to force-detach disk from VM to simulate preemption")
+
+		// Emulate a node reset/reboot on the same VM instance:
+		// We deactivate and wipe the host's Volume Group and Physical Volume from the local SSD.
+		// When the GCE PD is attached back and staged, the driver will recreate the host VG with a new UUID,
+		// triggering the duplicate VG name conflict deadlock!
+		nodeHash := common.ShortString(instance.GetName())
+		volumeGroupName := fmt.Sprintf("csi-vg-%s", nodeHash)
+		klog.Infof("Step 3.5: Emulating node reset by wiping host VG %s and local SSD on VM...", volumeGroupName)
+		mountDir := filepath.Join("/tmp/", volName, "mount")
+		stageDirLocal := filepath.Join("/tmp/", volName, "stage")
+
+		// Force-release kernel locks using lazy unmounts (ignoring errors if not mounted)
+		_, _ = instance.SSH("umount", "-l", mountDir)
+		_, _ = instance.SSH("umount", "-l", stageDirLocal)
+
+		// Wipe LVM state and log results
+		_, _ = instance.SSH("vgreduce", "--removemissing", "--force", volumeGroupName)
+		out1, err1 := instance.SSH("vgchange", "-an", volumeGroupName)
+		klog.Infof("vgchange -an: out=%s, err=%v", out1, err1)
+		out2, err2 := instance.SSH("vgremove", "-y", volumeGroupName)
+		klog.Infof("vgremove -y: out=%s, err=%v", out2, err2)
+		out3, err3 := instance.SSH("pvremove", "-y", "/dev/md127")
+		klog.Infof("pvremove -y: out=%s, err=%v", out3, err3)
+
+		// Wait a few seconds for the GCE control plane to register the detach
+		time.Sleep(10 * time.Second)
+
+		// 4. Attach and Stage the GCE PD back to the same VM.
+		klog.Infof("Step 4: Attaching the disk back to the same VM %s...", instance.GetName())
+		var stageDir string
+		err, _, stageDir = testAttach(volID, volName, instance, client, attachMountArgs)
+		Expect(err).To(BeNil(), "Failed to attach disk back to VM after simulated preemption")
+
+		// 5. Run NodeStage and NodePublish back on the VM.
+		// The driver must detect the duplicate VG conflict, rename the PD's VG, and merge it safely!
+		klog.Infof("Step 5: Staging and mounting back on VM (recovering from duplicate VG conflict)...")
+		err, _, args = testMount(volID, volName, instance, client, attachMountArgs, stageDir)
+		Expect(err).To(BeNil(), "Failed to recover and mount volume back on VM after simulated preemption")
+
+		// 6. Verify data integrity: Read the verification file back on the VM!
+		klog.Infof("Step 6: Verifying data integrity after preemption recovery on VM")
+		_, readVerifyFunc = testWriteAndReadFile(instance, false /* readOnly */)
+		err = readVerifyFunc(args)
+		Expect(err).To(BeNil(), "Data integrity verification failed on VM after preemption recovery! Potential data loss.")
+		klog.Infof("Success: Volume successfully recovered and verified with zero data loss on VM after preemption!")
+	})
 	It("Should create->attach->setup caching->write->detach->attach to different node->mount->read", func() {
 		Expect(testContexts).ToNot(BeEmpty())
 		zoneToContext := map[string][]*remote.TestContext{}


### PR DESCRIPTION
**What type of PR is this?**
kind bug

**What this PR does / why we need it**:
When running on Spot VMs, sudden preemptions can prevent volume unmounting from terminating cleanly, leaving the disk in a broken LVM state.
based on https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/2355

**Which issue(s) this PR fixes**:
Fixes two issues. 

Bug 1: Duplicate VG Name Collision (Preemption Deadlock)

Abrupt node preemption leaves stale LVM Volume Group metadata (csi-vg-<node-hash>) on the GCE PD, causing a name collision when the volume is rescheduled on a replacement node with the same name. The baseline driver lacked LVM command isolation, and its duplicate detection logic failed to trigger due to a CLI output-parsing bug. We resolved this by implementing a robust metadata parser (getVgInfoForPv) that queries the GCE PD under a strict LVM device filter to retrieve the stale VG's name and UUID. The driver now isolates LVM commands to the GCE PD, prunes the missing SSD references, and renames the conflicting VG to a unique temporary name, cleanly breaking the deadlock.

Bug 2: Unconditional Cache Purge (Linear Volume Corruption Risk)

During preemption recovery, the driver unconditionally executed lvconvert --uncache to detach the missing local SSD cache pool from the volume group. If the volume was a standard linear (uncached) volume, running this command was invalid and risked LVM metadata corruption, filesystem errors, and data loss. We resolved this by introducing a dynamic volume layout check (isLvCachedOnDevice) that queries the volume's cache state before executing recovery. The driver now runs the uncache operation only on cached volumes and safely bypasses it for linear volumes, protecting standard Persistent Volumes from corruption.

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
