### PR TITLE
Add CreateVolume idempotency test

### DIFF
--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -380,6 +380,43 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		Entry("on pd-ssd", ssdDiskType),
 	)
 
+	DescribeTable("Should succeed calling CreateVolume twice",
+		func(diskType string, diskSize int64) {
+			testContext := getRandomTestContext()
+
+			p, z, _ := testContext.Instance.GetIdentity()
+			client := testContext.Client
+
+			disk := typeToDisk[diskType]
+			volName := testNamePrefix + string(uuid.NewUUID())
+
+			// First CreateVolume call
+			vol1, err := client.CreateVolume(volName, disk.params, diskSize, nil, nil)
+			Expect(err).To(BeNil(), "First CreateVolume call failed")
+			Expect(vol1).ToNot(BeNil())
+
+			defer func() {
+				// Delete Disk
+				err := client.DeleteVolume(vol1.VolumeId)
+				Expect(err).To(BeNil(), "DeleteVolume failed")
+
+				// Validate Disk Deleted
+				_, err = computeService.Disks.Get(p, z, volName).Do()
+				Expect(gce.IsGCEError(err, "notFound")).To(BeTrue(), "Expected disk to not be found")
+			}()
+
+			// Second CreateVolume call with identical parameters
+			vol2, err := client.CreateVolume(volName, disk.params, diskSize, nil, nil)
+			Expect(err).To(BeNil(), "Second CreateVolume call failed")
+			Expect(vol2).ToNot(BeNil())
+			Expect(vol2.VolumeId).To(Equal(vol1.VolumeId), "Expected volume IDs to match for idempotent CreateVolume calls")
+		},
+		Entry("on pd-ssd", ssdDiskType, defaultSizeGb),
+		Entry("on hyperdisk-balanced", hdbDiskType, defaultHdBSizeGb),
+		Entry("on hyperdisk-extreme", hdxDiskType, defaultHdXSizeGb),
+		Entry("on hyperdisk-throughput", hdtDiskType, defaultHdTSizeGb),
+	)
+
 	DescribeTable("[NVMe] Should complete publish/unpublish lifecycle with underspecified volume ID and missing volume",
 		func(diskType string) {
 			testContext := getRandomTestContext()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds tests to catch CreateVolume idempotency problems. Needs #2360 to pass hyperdisk throughput and hyperdisk extreme scenarios

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
