### PR TITLE
fix: add attach limits for n4d/n4a

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -472,6 +472,10 @@ func GetHyperdiskAttachLimit(machineTypePrefix string, vCPUs int64) int64 {
 		limitMap = constants.C4DMachineHyperdiskAttachLimitMap
 	case "n4":
 		limitMap = constants.N4MachineHyperdiskAttachLimitMap
+	case "n4d":
+		limitMap = constants.N4DMachineHyperdiskAttachLimitMap
+	case "n4a":
+		limitMap = constants.N4AMachineHyperdiskAttachLimitMap
 	case "c4a":
 		limitMap = constants.C4AMachineHyperdiskAttachLimitMap
 	case "a4x":

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -121,12 +121,24 @@ var N4MachineHyperdiskAttachLimitMap = []MachineHyperdiskLimit{
 	{Max: 80, Value: 31},
 }
 
+// N4D Machine Types - Hyperdisk Balanced Limits
+var N4DMachineHyperdiskAttachLimitMap = []MachineHyperdiskLimit{
+	{Max: 8, Value: 15},
+	{Max: 96, Value: 31},
+}
+
 // C4A Machine Types - Hyperdisk Balanced Limits
 var C4AMachineHyperdiskAttachLimitMap = []MachineHyperdiskLimit{
 	{Max: 2, Value: 7},
 	{Max: 8, Value: 15},
 	{Max: 48, Value: 31},
 	{Max: 72, Value: 63},
+}
+
+// N4A Machine Types - Hyperdisk Balanced Limits
+var N4AMachineHyperdiskAttachLimitMap = []MachineHyperdiskLimit{
+	{Max: 8, Value: 15},
+	{Max: 64, Value: 31},
 }
 
 // A4X Machine Types - Hyperdisk Balanced Limits. The max here is actually the GPU count (not CPU, like the others).

--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -949,7 +949,7 @@ func (ns *GCENodeServer) getVolumeLimits(ctx context.Context, node *corev1.Node)
 	}
 
 	// Process gen4 machine attach limits which include vCPUs in the machine type
-	gen4MachineTypesPrefix := []string{"c4a-", "c4-", "n4-", "c4d-"}
+	gen4MachineTypesPrefix := []string{"c4a-", "c4-", "n4-", "c4d-", "n4d-", "n4a-"}
 	for _, gen4Prefix := range gen4MachineTypesPrefix {
 		if strings.HasPrefix(machineType, gen4Prefix) {
 			machineTypeSlice := strings.Split(machineType, "-")

--- a/pkg/gce-pd-csi-driver/node_test.go
+++ b/pkg/gce-pd-csi-driver/node_test.go
@@ -326,6 +326,56 @@ func TestNodeGetVolumeLimits(t *testing.T) {
 			expVolumeLimit: 31,
 		},
 		{
+			name:           "n4a-standard-4",
+			machineType:    "n4a-standard-4",
+			expVolumeLimit: 15,
+		},
+		{
+			name:           "n4a-standard-8",
+			machineType:    "n4a-standard-8",
+			expVolumeLimit: 15,
+		},
+		{
+			name:           "n4a-standard-32",
+			machineType:    "n4a-standard-32",
+			expVolumeLimit: 31,
+		},
+		{
+			name:           "n4a-standard-64",
+			machineType:    "n4a-standard-64",
+			expVolumeLimit: 31,
+		},
+		{
+			name:           "n4d-standard-2",
+			machineType:    "n4d-standard-2",
+			expVolumeLimit: 15,
+		},
+		{
+			name:           "n4d-standard-4",
+			machineType:    "n4d-standard-4",
+			expVolumeLimit: 15,
+		},
+		{
+			name:           "n4d-standard-8",
+			machineType:    "n4d-standard-8",
+			expVolumeLimit: 15,
+		},
+		{
+			name:           "n4d-standard-16",
+			machineType:    "n4d-standard-16",
+			expVolumeLimit: 31,
+		},
+		{
+			name:           "n4d-standard-32",
+			machineType:    "n4d-standard-32",
+			expVolumeLimit: 31,
+		},
+		{
+			name:           "n4d-standard-96",
+			machineType:    "n4d-standard-96",
+			expVolumeLimit: 31,
+		},
+		{
 			name:           "invalid gen4 machine type",
 			machineType:    "n4-highcpu-4xyz",
 			expVolumeLimit: volumeLimitBig,


### PR DESCRIPTION
This change adds explicit attach limits for n4a and n4d machine types. Before this change, these defaulted to the max attach limit value of 127.

Note this uses the hyperdisk-balanced limits for each machine type.

See the attach limits here: https://docs.cloud.google.com/compute/docs/general-purpose-machines

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This fixes the attach limit evaluation for n4d/n4a machine types.

**Which issue(s) this PR fixes**:

Fixes #2351

**Special notes for your reviewer**: N/A

**Does this PR introduce a user-facing change?**:

```release-note
Fixed attach limit evaluation for N4A and N4D machine types.
```
