### PR TITLE
Updated e2e suite so per-machine type validation is smoother

### DIFF
--- a/test/e2e/tests/multi_zone_e2e_test.go
+++ b/test/e2e/tests/multi_zone_e2e_test.go
@@ -97,12 +97,12 @@ var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 	It("Should attach ROX 'multi-zone' PV instances to two separate VMs", func() {
 		checkSkipMultiZoneTests()
 
-		Expect(hyperdiskTestContexts).NotTo(BeEmpty())
+		Expect(mwTestContexts).NotTo(BeEmpty())
 
 		zoneToContext := map[string]*remote.TestContext{}
 		zones := []string{}
 
-		for _, tc := range hyperdiskTestContexts {
+		for _, tc := range mwTestContexts {
 			_, z, _ := tc.Instance.GetIdentity()
 			// Zone hasn't been seen before
 			if _, ok := zoneToContext[z]; !ok {
@@ -189,12 +189,12 @@ var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 	It("Should create RWO 'multi-zone' PV instances from a previously created disk", func() {
 		checkSkipMultiZoneTests()
 
-		Expect(hyperdiskTestContexts).NotTo(BeEmpty())
+		Expect(mwTestContexts).NotTo(BeEmpty())
 
 		zoneToContext := map[string]*remote.TestContext{}
 		zones := []string{}
 
-		for _, tc := range hyperdiskTestContexts {
+		for _, tc := range mwTestContexts {
 			_, z, _ := tc.Instance.GetIdentity()
 			// Zone hasn't been seen before
 			if _, ok := zoneToContext[z]; !ok {
@@ -288,12 +288,12 @@ var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 	It("Should create ROX 'multi-zone' PV from existing snapshot", func() {
 		checkSkipMultiZoneTests()
 
-		Expect(hyperdiskTestContexts).NotTo(BeEmpty())
+		Expect(mwTestContexts).NotTo(BeEmpty())
 
 		zoneToContext := map[string]*remote.TestContext{}
 		zones := []string{}
 
-		for _, tc := range hyperdiskTestContexts {
+		for _, tc := range mwTestContexts {
 			_, z, _ := tc.Instance.GetIdentity()
 			// Zone hasn't been seen before
 			if _, ok := zoneToContext[z]; !ok {
@@ -436,12 +436,12 @@ var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 	It("Should create ROX 'multi-zone' PV from existing snapshot with no topology", func() {
 		checkSkipMultiZoneTests()
 
-		Expect(hyperdiskTestContexts).NotTo(BeEmpty())
+		Expect(mwTestContexts).NotTo(BeEmpty())
 
 		zoneToContext := map[string]*remote.TestContext{}
 		zones := []string{}
 
-		for _, tc := range hyperdiskTestContexts {
+		for _, tc := range mwTestContexts {
 			_, z, _ := tc.Instance.GetIdentity()
 			// Zone hasn't been seen before
 			if _, ok := zoneToContext[z]; !ok {
@@ -575,12 +575,12 @@ var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 	It("Should create ROX 'multi-zone' PV from existing disk image", func() {
 		checkSkipMultiZoneTests()
 
-		Expect(hyperdiskTestContexts).NotTo(BeEmpty())
+		Expect(mwTestContexts).NotTo(BeEmpty())
 
 		zoneToContext := map[string]*remote.TestContext{}
 		zones := []string{}
 
-		for _, tc := range hyperdiskTestContexts {
+		for _, tc := range mwTestContexts {
 			_, z, _ := tc.Instance.GetIdentity()
 			// Zone hasn't been seen before
 			if _, ok := zoneToContext[z]; !ok {
@@ -720,12 +720,12 @@ var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 		checkSkipMultiZoneTests()
 
 		// Create new driver and client
-		Expect(hyperdiskTestContexts).NotTo(BeEmpty())
+		Expect(mwTestContexts).NotTo(BeEmpty())
 
 		zoneToContext := map[string]*remote.TestContext{}
 		zones := []string{}
 
-		for _, tc := range hyperdiskTestContexts {
+		for _, tc := range mwTestContexts {
 			_, z, _ := tc.Instance.GetIdentity()
 			// Zone hasn't been seen before
 			if _, ok := zoneToContext[z]; !ok {
@@ -836,12 +836,12 @@ var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 	It("Should create ROX 'multi-zone' PV that has empty disks in RWO mode", func() {
 		checkSkipMultiZoneTests()
 
-		Expect(hyperdiskTestContexts).NotTo(BeEmpty())
+		Expect(mwTestContexts).NotTo(BeEmpty())
 
 		zoneToContext := map[string]*remote.TestContext{}
 		zones := []string{}
 
-		for _, tc := range hyperdiskTestContexts {
+		for _, tc := range mwTestContexts {
 			_, z, _ := tc.Instance.GetIdentity()
 			// Zone hasn't been seen before
 			if _, ok := zoneToContext[z]; !ok {
@@ -949,12 +949,12 @@ var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 	})
 
 	It("Should create ROX 'single-zone' PV that has empty disks in RWO mode", func() {
-		Expect(hyperdiskTestContexts).NotTo(BeEmpty())
+		Expect(mwTestContexts).NotTo(BeEmpty())
 
 		zoneToContext := map[string]*remote.TestContext{}
 		zones := []string{}
 
-		for _, tc := range hyperdiskTestContexts {
+		for _, tc := range mwTestContexts {
 			_, z, _ := tc.Instance.GetIdentity()
 			// Zone hasn't been seen before
 			if _, ok := zoneToContext[z]; !ok {
@@ -1236,12 +1236,12 @@ var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 
 	It("Should successfully run through entire lifecycle of a HdHA volume on instances in 2 zones", func() {
 		// Create new driver and client
-		Expect(hyperdiskTestContexts).NotTo(BeEmpty())
+		Expect(mwTestContexts).NotTo(BeEmpty())
 
 		zoneToContext := map[string]*remote.TestContext{}
 		zones := []string{}
 
-		for _, tc := range hyperdiskTestContexts {
+		for _, tc := range mwTestContexts {
 			_, z, _ := tc.Instance.GetIdentity()
 			// Zone hasn't been seen before
 			if _, ok := zoneToContext[z]; !ok {
@@ -1322,12 +1322,12 @@ var _ = Describe("GCE PD CSI Driver Multi-Zone", func() {
 	})
 
 	It("Should create a HdHA instance, write to it, force-attach it to another instance, and read the same data", func() {
-		Expect(hyperdiskTestContexts).NotTo(BeEmpty())
+		Expect(mwTestContexts).NotTo(BeEmpty())
 
 		zoneToContext := map[string]*remote.TestContext{}
 		zones := []string{}
 
-		for _, tc := range hyperdiskTestContexts {
+		for _, tc := range mwTestContexts {
 			_, z, _ := tc.Instance.GetIdentity()
 			// Zone hasn't been seen before
 			if _, ok := zoneToContext[z]; !ok {

--- a/test/e2e/tests/setup_e2e_test.go
+++ b/test/e2e/tests/setup_e2e_test.go
@@ -49,8 +49,11 @@ var (
 	architecture              = flag.String("arch", "amd64", "Architecture pd csi driver build on")
 	minCpuPlatform            = flag.String("min-cpu-platform", "AMD Rome", "Minimum CPU architecture")
 	mwMinCpuPlatform          = flag.String("min-cpu-platform-mw", "Intel Sapphire Rapids", "Minimum CPU architecture for multiwriter tests")
-	zones                     = flag.String("zones", "us-east4-a,us-east4-c", "Zones to run tests in. If there are multiple zones, separate each by comma")
+	zonesFlag                 = flag.String("zones", "us-east4-a,us-east4-c", "Zones to run tests in. If there are multiple zones, separate each by comma")
+	subnetwork                = flag.String("subnetwork", "", "Subnetwork to use. Must already exist in the region of a zone used for an instance. Ignored if empty")
 	machineType               = flag.String("machine-type", "n2d-standard-4", "Type of machine to provision instance on")
+	diskTypeDefault           = flag.String("disk-type-default", "pd-balanced", "Default disk type to use for --machine-type if not specified by the test.")
+	supportedDiskTypesFlag    = flag.String("supported-disk-types", "pd-standard,pd-balanced,pd-extreme,pd-ssd", "Supported disk types for --machine-type (comma-separated)")
 	imageURL                  = flag.String("image-url", "projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2404-lts-amd64", "OS image url to get image from")
 	runInProw                 = flag.Bool("run-in-prow", false, "If true, use a Boskos loaned project and special CI service accounts and ssh keys")
 	deleteInstances           = flag.Bool("delete-instances", false, "Delete the instances after tests run")
@@ -59,18 +62,20 @@ var (
 	enableConfidentialCompute = flag.Bool("enable-confidential-compute", false, "Create VMs with confidential compute mode. This uses NVMe devices")
 	// Multi-writer is only supported on M3, C3, and N4
 	// https://cloud.google.com/compute/docs/disks/sharing-disks-between-vms#hd-multi-writer
-	hdMachineType    = flag.String("hyperdisk-machine-type", "c3-standard-4", "Type of machine to provision instance on, or `none' to skip")
-	hdMinCpuPlatform = flag.String("hyperdisk-min-cpu-platform", "Intel Sapphire Rapids", "Minimum CPU architecture")
+	mwMachineType = flag.String("machine-type-mw", "c3-standard-4", "Type of multiwriter machine to provision instance on, or `none' to skip")
 
 	// Some architectures don't have local ssd. Give way to opt out of tests like datacache.
 	skipLocalSsdTests = flag.Bool("skip-local-ssd-tests", false, "Skip local ssd tests like datacache")
 
-	testContexts          []*remote.TestContext
-	hyperdiskTestContexts []*remote.TestContext
-	computeService        *compute.Service
-	computeAlphaService   *computealpha.Service
-	computeBetaService    *computebeta.Service
-	kmsClient             *cloudkms.KeyManagementClient
+	testContexts        []*remote.TestContext
+	mwTestContexts      []*remote.TestContext
+	computeService      *compute.Service
+	computeAlphaService *computealpha.Service
+	computeBetaService  *computebeta.Service
+	kmsClient           *cloudkms.KeyManagementClient
+
+	zones              []string
+	supportedDiskTypes []string
 )
 
 func init() {
@@ -86,7 +91,8 @@ func TestE2E(t *testing.T) {
 var _ = BeforeSuite(func() {
 	var err error
 	numberOfInstancesPerZone := 3
-	zones := strings.Split(*zones, ",")
+	zones = strings.Split(*zonesFlag, ",")
+	supportedDiskTypes = strings.Split(*supportedDiskTypesFlag, ",")
 
 	rand.Seed(time.Now().UnixNano())
 
@@ -113,8 +119,8 @@ var _ = BeforeSuite(func() {
 	klog.Infof("Running in project %v with service account %v", *project, *serviceAccount)
 
 	testContexts = make([]*remote.TestContext, numberOfInstancesPerZone*len(zones))
-	if *hdMachineType != noMachineType {
-		hyperdiskTestContexts = make([]*remote.TestContext, len(zones))
+	if *mwMachineType != noMachineType {
+		mwTestContexts = make([]*remote.TestContext, len(zones))
 	}
 	var wg sync.WaitGroup
 	setupContext := func(idx int, zone string) {
@@ -130,13 +136,13 @@ var _ = BeforeSuite(func() {
 				klog.Infof("Added TestContext for node %s at %d", tc.Instance.GetName(), k)
 			}(zone, j)
 		}
-		if hyperdiskTestContexts != nil {
+		if mwTestContexts != nil {
 			wg.Add(1)
 			go func(curZone string) {
 				defer GinkgoRecover()
 				defer wg.Done()
-				tc := NewTestContext(curZone, *hdMinCpuPlatform, *hdMachineType, "0")
-				hyperdiskTestContexts[idx] = tc
+				tc := NewTestContext(curZone, *mwMinCpuPlatform, *mwMachineType, 0, "0")
+				mwTestContexts[idx] = tc
 				klog.Infof("Added hyperdisk TestContext for node %s at %d", tc.Instance.GetName(), idx)
 			}(zone)
 		}
@@ -156,7 +162,7 @@ var _ = AfterSuite(func() {
 			tc.Instance.DeleteInstance()
 		}
 	}
-	for _, mwTc := range hyperdiskTestContexts {
+	for _, mwTc := range mwTestContexts {
 		err := remote.TeardownDriverAndClient(mwTc)
 		Expect(err).To(BeNil(), "Multiwriter Teardown Driver and Client failed with error")
 		if *deleteInstances {
@@ -172,22 +178,27 @@ func notEmpty(v string) bool {
 func getDriverConfig() testutils.DriverConfig {
 	return testutils.DriverConfig{
 		ExtraFlags: slices.Filter(nil, strings.Split(*extraDriverFlags, ","), notEmpty),
-		Zones:      strings.Split(*zones, ","),
+		Zones:      zones,
 	}
 }
 
-func NewDefaultTestContext(zone string, instanceNumber string) *remote.TestContext {
-	return NewTestContext(zone, *minCpuPlatform, *machineType, instanceNumber)
-}
-
+// getLocalSsdCount returns the local ssd count to use for the test configuration.
+// If the machine type used for the test has a fixed number of local ssds (eg, the
+// gen4 *-lssd types), this will be ignored.
 func getLocalSsdCount() int64 {
 	if *skipLocalSsdTests {
 		return 0
 	}
+	// If in the future we want to test variable local ssd counts, this would be the
+	// place to plumb it through.
 	return constants.LocalSSDCountForDataCache
 }
 
-func NewTestContext(zone, minCpuPlatform, machineType string, instanceNumber string) *remote.TestContext {
+func NewDefaultTestContext(zone string, instanceNumber string) *remote.TestContext {
+	return NewTestContext(zone, *minCpuPlatform, *machineType, getLocalSsdCount(), instanceNumber)
+}
+
+func NewTestContext(zone, minCpuPlatform, machineType string, localSsdCount int64, instanceNumber string) *remote.TestContext {
 	nodeID := fmt.Sprintf("%s-%s-%s-%s", *vmNamePrefix, zone, machineType, instanceNumber)
 	klog.Infof("Setting up node %s", nodeID)
 
@@ -198,18 +209,17 @@ func NewTestContext(zone, minCpuPlatform, machineType string, instanceNumber str
 		Zone:                      zone,
 		Name:                      nodeID,
 		MachineType:               machineType,
+		DiskTypeDefault:           *diskTypeDefault,
+		SupportedDiskTypes:        supportedDiskTypes,
 		ServiceAccount:            *serviceAccount,
 		ImageURL:                  *imageURL,
 		CloudtopHost:              *cloudtopHost,
 		EnableConfidentialCompute: *enableConfidentialCompute,
 		ComputeService:            computeService,
-		LocalSSDCount:             getLocalSsdCount(),
+		LocalSSDCount:             localSsdCount,
+		Subnetwork:                *subnetwork,
 	}
 
-	if machineType == *hdMachineType {
-		// Machine type is defaulted to c3-standard-2 which doesn't support LSSD and we don't need LSSD for HdHA test context
-		instanceConfig.LocalSSDCount = 0
-	}
 	i, err := remote.SetupInstance(instanceConfig)
 	if err != nil {
 		klog.Fatalf("Failed to setup instance %v: %v", nodeID, err)
@@ -244,6 +254,7 @@ func NewTestContext(zone, minCpuPlatform, machineType string, instanceNumber str
 	if err != nil {
 		klog.Fatalf("Failed to set up TestContext for instance %v: %v", i.GetName(), err)
 	}
+	tc.TestZones = zones
 
 	klog.Infof("Finished creating TestContext for node %s", tc.Instance.GetName())
 	return tc
@@ -255,8 +266,9 @@ func getRandomTestContext() *remote.TestContext {
 	rn := rand.Intn(len(testContexts) - 1)
 	return testContexts[rn]
 }
+
 func getRandomMwTestContext() *remote.TestContext {
-	Expect(hyperdiskTestContexts).ToNot(BeEmpty())
-	rn := rand.Intn(len(hyperdiskTestContexts))
-	return hyperdiskTestContexts[rn]
+	Expect(mwTestContexts).ToNot(BeEmpty())
+	rn := rand.Intn(len(mwTestContexts))
+	return mwTestContexts[rn]
 }

--- a/test/e2e/tests/single_zone_e2e_test.go
+++ b/test/e2e/tests/single_zone_e2e_test.go
@@ -60,6 +60,7 @@ const (
 	invalidSizeGb                       int64 = 66000
 	readyState                                = "READY"
 	standardDiskType                          = "pd-standard"
+	balancedDiskType                          = "pd-balanced"
 	ssdDiskType                               = "pd-ssd"
 	extremeDiskType                           = "pd-extreme"
 	hdbDiskType                               = "hyperdisk-balanced"
@@ -67,6 +68,7 @@ const (
 	hdtDiskType                               = "hyperdisk-throughput"
 	hdmlDiskType                              = "hyperdisk-ml"
 	hdhaDiskType                              = "hyperdisk-balanced-high-availability"
+	regionalReplication                       = "regional-pd"
 	provisionedIOPSOnCreate                   = "12345"
 	provisionedIOPSOnCreateInt                = int64(12345)
 	provisionedIOPSOnCreateDefaultInt         = int64(100000)
@@ -80,6 +82,12 @@ const (
 	provisionedThroughputOnCreateHdbInt       = int64(150)
 	defaultEpsilon                            = 500000000 // 500M
 )
+
+func checkSkipDiskType(tc *remote.TestContext, diskType string) {
+	if !tc.Instance.SupportsDiskType(diskType) {
+		Skip(fmt.Sprintf("%s does not support %s", tc.Instance.MachineType(), diskType))
+	}
+}
 
 var _ = Describe("GCE PD CSI Driver", func() {
 	It("Should get reasonable volume limits from nodes with NodeGetInfo", func() {
@@ -98,7 +106,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		instance := testContext.Instance
 
 		// Create Disk
-		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, standardDiskType)
+		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, instance.DefaultDiskType())
 
 		defer func() {
 			// Delete Disk
@@ -123,7 +131,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		instance := testContext.Instance
 
 		// Create Disk
-		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, standardDiskType)
+		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, instance.DefaultDiskType())
 
 		defer func() {
 			// Delete Disk
@@ -195,7 +203,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		instance := testContext.Instance
 
 		// Create Disk
-		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, standardDiskType)
+		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, instance.DefaultDiskType())
 
 		defer func() {
 			// Delete Disk
@@ -263,9 +271,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 
 		p, _, _ := testContext.Instance.GetIdentity()
 
-		zones := []string{"us-central1-c", "us-central1-b", "us-central1-a"}
-
-		for _, zone := range zones {
+		for _, zone := range testContext.TestZones {
 			volName := testNamePrefix + string(uuid.NewUUID())
 			topReq := &csi.TopologyRequirement{
 				Requisite: []*csi.Topology{
@@ -274,7 +280,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 					},
 				},
 			}
-			volume, err := testContext.Client.CreateVolume(volName, nil, defaultSizeGb, topReq, nil)
+			volume, err := testContext.CreateVolumeForInstance(volName, nil, defaultSizeGb, topReq, nil)
 			Expect(err).To(BeNil(), "Failed to create volume")
 			defer func() {
 				err = testContext.Client.DeleteVolume(volume.VolumeId)
@@ -292,65 +298,66 @@ var _ = Describe("GCE PD CSI Driver", func() {
 
 		volName := testNamePrefix + string(uuid.NewUUID())
 		params := map[string]string{
-			"type": hdbDiskType,
 			// Required to enable the disk topology feature.
 			"use-allowed-disk-topology": "true",
 		}
 
+		zone := testContext.TestZones[0]
 		topReq := &csi.TopologyRequirement{
 			Requisite: []*csi.Topology{
 				{
-					Segments: map[string]string{constants.TopologyKeyZone: "us-central1-c"},
+					Segments: map[string]string{constants.TopologyKeyZone: zone},
 				},
 			},
 		}
 
-		volume, err := testContext.Client.CreateVolume(volName, params, defaultSizeGb, topReq, nil)
+		volume, err := testContext.CreateVolumeForInstance(volName, params, defaultSizeGb, topReq, nil)
 		Expect(err).To(BeNil(), "Failed to create volume")
 		defer func() {
 			err = testContext.Client.DeleteVolume(volume.VolumeId)
 			Expect(err).To(BeNil(), "Failed to delete volume")
 		}()
 
+		diskType, found := params[parameters.ParameterKeyType]
+		Expect(found).To(BeTrue())
+
 		// Confirm that the topologies include a disk support label
 		Expect(volume.AccessibleTopology).ToNot(BeEmpty(), "Volume should have accessible topologies")
 		Expect(volume.AccessibleTopology).To(HaveLen(1), "Expected exactly one accessible topology") // Zonal clusters have a single Topology.
 		segments := volume.AccessibleTopology[0].Segments
-		Expect(segments).To(HaveKeyWithValue(constants.TopologyKeyZone, "us-central1-c"), "Topology should include zone segment with value 'us-central1-c'")
-		Expect(segments).To(HaveKeyWithValue(common.DiskTypeLabelKey(hdbDiskType), "true"), "Topology should include disk type label with value 'true'")
+		Expect(segments).To(HaveKeyWithValue(constants.TopologyKeyZone, zone), "Topology should include zone segment with value 'us-central1-c'")
+		Expect(segments).To(HaveKeyWithValue(common.DiskTypeLabelKey(diskType), "true"), "Topology should include disk type label with value 'true'")
 	})
 
-	// TODO(hime): Enable this test once all release branches contain the fix from PR#1708.
-	// It("Should return InvalidArgument when disk size exceeds limit", func() {
-	// 	// If this returns a different error code (like Unknown), the error wrapping logic in #1708 has regressed.
-	// 	Expect(testContexts).ToNot(BeEmpty())
-	// 	testContext := getRandomTestContext()
+	It("Should return InvalidArgument when disk size exceeds limit", func() {
+		Expect(testContexts).ToNot(BeEmpty())
+		testContext := getRandomTestContext()
 
-	// 	zones := []string{"us-central1-c", "us-central1-b", "us-central1-a"}
-
-	// 	for _, zone := range zones {
-	// 		volName := testNamePrefix + string(uuid.NewUUID())
-	// 		topReq := &csi.TopologyRequirement{
-	// 			Requisite: []*csi.Topology{
-	// 				{
-	// 					Segments: map[string]string{constants.TopologyKeyZone: zone},
-	// 				},
-	// 			},
-	// 		}
-	// 		volume, err := testContext.Client.CreateVolume(volName, nil, invalidSizeGb, topReq, nil)
-	// 		Expect(err).ToNot(BeNil(), "Failed to fetch error from create volume.")
-	// 		Expect(err.Error()).To(ContainSubstring("InvalidArgument"), "Failed to verify error code matches InvalidArgument.")
-	// 		defer func() {
-	// 			if volume != nil {
-	// 				testContext.Client.DeleteVolume(volume.VolumeId)
-	// 			}
-	// 		}()
-	// 	}
-	// })
+		for _, zone := range testContext.TestZones {
+			volName := testNamePrefix + string(uuid.NewUUID())
+			topReq := &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{
+						Segments: map[string]string{constants.TopologyKeyZone: zone},
+					},
+				},
+			}
+			volume, err := testContext.CreateVolumeForInstance(volName, nil, invalidSizeGb, topReq, nil)
+			Expect(err).ToNot(BeNil(), "Failed to fetch error from create volume.")
+			// If this returns a different error code (like Unknown), the error wrapping logic in #1708 has regressed.
+			Expect(err.Error()).To(ContainSubstring("InvalidArgument"), "Failed to verify error code matches InvalidArgument.")
+			defer func() {
+				if volume != nil {
+					testContext.Client.DeleteVolume(volume.VolumeId)
+				}
+			}()
+		}
+	})
 
 	DescribeTable("Should complete entire disk lifecycle with underspecified volume ID",
 		func(diskType string) {
 			testContext := getRandomTestContext()
+			checkSkipDiskType(testContext, diskType)
 
 			p, z, _ := testContext.Instance.GetIdentity()
 			client := testContext.Client
@@ -420,6 +427,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 	DescribeTable("[NVMe] Should complete publish/unpublish lifecycle with underspecified volume ID and missing volume",
 		func(diskType string) {
 			testContext := getRandomTestContext()
+			checkSkipDiskType(testContext, diskType)
 
 			p, z, _ := testContext.Instance.GetIdentity()
 			client := testContext.Client
@@ -458,19 +466,19 @@ var _ = Describe("GCE PD CSI Driver", func() {
 	It("Should successfully create RePD in two zones in the drivers region when none are specified", func() {
 		Expect(testContexts).ToNot(BeEmpty())
 		testContext := getRandomTestContext()
+		checkSkipDiskType(testContext, balancedDiskType)
 
 		controllerInstance := testContext.Instance
 		controllerClient := testContext.Client
 
-		p, z, _ := controllerInstance.GetIdentity()
-
-		region, err := common.GetRegionFromZones([]string{z})
-		Expect(err).To(BeNil(), "Failed to get region from zones")
+		p, _, _ := controllerInstance.GetIdentity()
+		region := controllerInstance.GetRegion()
 
 		// Create Disk
 		volName := testNamePrefix + string(uuid.NewUUID())
 		volume, err := controllerClient.CreateVolume(volName, map[string]string{
-			parameters.ParameterKeyReplicationType: "regional-pd",
+			parameters.ParameterKeyType:            balancedDiskType,
+			parameters.ParameterKeyReplicationType: regionalReplication,
 		}, defaultRepdSizeGb, nil, nil)
 		Expect(err).To(BeNil(), "CreateVolume failed with error: %v", err)
 
@@ -503,6 +511,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		func(diskType string) {
 			Expect(testContexts).ToNot(BeEmpty())
 			testContext := getRandomTestContext()
+			checkSkipDiskType(testContext, diskType)
 
 			p, z, _ := testContext.Instance.GetIdentity()
 			client := testContext.Client
@@ -546,6 +555,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		func(diskType string) {
 			Expect(testContexts).ToNot(BeEmpty())
 			testContext := getRandomTestContext()
+			checkSkipDiskType(testContext, diskType)
 
 			p, z, _ := testContext.Instance.GetIdentity()
 			client := testContext.Client
@@ -588,6 +598,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		func(diskType string) {
 			Expect(testContexts).ToNot(BeEmpty())
 			testContext := getRandomTestContext()
+			checkSkipDiskType(testContext, diskType)
 
 			p, z, _ := testContext.Instance.GetIdentity()
 			client := testContext.Client
@@ -641,7 +652,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		p, z, _ := testContext.Instance.GetIdentity()
 		client := testContext.Client
 
-		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, standardDiskType)
+		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, testContext.Instance.DefaultDiskType())
 
 		// Create Snapshot
 		snapshotName := testNamePrefix + string(uuid.NewUUID())
@@ -694,6 +705,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 			ctx := context.Background()
 			Expect(testContexts).ToNot(BeEmpty())
 			testContext := getRandomTestContext()
+			checkSkipDiskType(testContext, diskType)
 
 			controllerInstance := testContext.Instance
 			controllerClient := testContext.Client
@@ -817,10 +829,10 @@ var _ = Describe("GCE PD CSI Driver", func() {
 
 		nodeID := testContext.Instance.GetNodeID()
 
-		_, volID := createAndValidateUniqueZonalDisk(client, p, z, standardDiskType)
+		_, volID := createAndValidateUniqueZonalDisk(client, p, z, testContext.Instance.DefaultDiskType())
 		defer deleteVolumeOrError(client, volID)
 
-		_, secondVolID := createAndValidateUniqueZonalDisk(client, p, z, standardDiskType)
+		_, secondVolID := createAndValidateUniqueZonalDisk(client, p, z, testContext.Instance.DefaultDiskType())
 		defer deleteVolumeOrError(client, secondVolID)
 
 		// Attach volID to current instance
@@ -841,19 +853,19 @@ var _ = Describe("GCE PD CSI Driver", func() {
 	It("Should create and delete snapshot for RePD in two zones ", func() {
 		Expect(testContexts).ToNot(BeEmpty())
 		testContext := getRandomTestContext()
+		checkSkipDiskType(testContext, balancedDiskType)
 
 		controllerInstance := testContext.Instance
 		controllerClient := testContext.Client
 
-		p, z, _ := controllerInstance.GetIdentity()
-
-		region, err := common.GetRegionFromZones([]string{z})
-		Expect(err).To(BeNil(), "Failed to get region from zones")
+		p, _, _ := controllerInstance.GetIdentity()
+		region := controllerInstance.GetRegion()
 
 		// Create Disk
 		volName := testNamePrefix + string(uuid.NewUUID())
 		volume, err := controllerClient.CreateVolume(volName, map[string]string{
-			parameters.ParameterKeyReplicationType: "regional-pd",
+			parameters.ParameterKeyType:            balancedDiskType,
+			parameters.ParameterKeyReplicationType: regionalReplication,
 		}, defaultRepdSizeGb, nil, nil)
 		Expect(err).To(BeNil(), "CreateVolume failed with error: %v", err)
 
@@ -918,7 +930,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		client := testContext.Client
 		instance := testContext.Instance
 
-		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, standardDiskType)
+		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, instance.DefaultDiskType())
 
 		defer func() {
 			// Delete Disk
@@ -955,7 +967,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		client := testContext.Client
 		instance := testContext.Instance
 
-		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, standardDiskType)
+		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, instance.DefaultDiskType())
 
 		defer func() {
 			// Delete Disk
@@ -1052,6 +1064,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		func(diskType string) {
 			Expect(testContexts).ToNot(BeEmpty())
 			testContext := getRandomTestContext()
+			checkSkipDiskType(testContext, diskType)
 
 			controllerInstance := testContext.Instance
 			controllerClient := testContext.Client
@@ -1105,14 +1118,12 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		client := testContext.Client
 
 		// Create Disk
-		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, standardDiskType)
+		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, testContext.Instance.DefaultDiskType())
 
 		// Create Snapshot
 		snapshotName := testNamePrefix + string(uuid.NewUUID())
 
-		// Convert GCP zone to region, e.g. us-central1-a => us-central1
-		// This is safe because we hardcode the zones.
-		snapshotLocation := z[:len(z)-2]
+		snapshotLocation := testContext.Instance.GetRegion()
 
 		snapshotParams := map[string]string{
 			parameters.ParameterKeyStorageLocations:          snapshotLocation,
@@ -1170,7 +1181,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		client := testContext.Client
 
 		// Create Disk
-		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, standardDiskType)
+		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, testContext.Instance.DefaultDiskType())
 
 		// Create Snapshot
 		snapshotName := testNamePrefix + string(uuid.NewUUID())
@@ -1235,7 +1246,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		p, z, _ := controllerInstance.GetIdentity()
 
 		// Create Source Disk
-		_, srcVolID := createAndValidateUniqueZonalDisk(controllerClient, p, z, standardDiskType)
+		_, srcVolID := createAndValidateUniqueZonalDisk(controllerClient, p, z, testContext.Instance.DefaultDiskType())
 
 		// Create Disk
 		volName := testNamePrefix + string(uuid.NewUUID())
@@ -1284,14 +1295,13 @@ var _ = Describe("GCE PD CSI Driver", func() {
 	It("Should successfully create RePD from a zonal PD VolumeContentSource", func() {
 		Expect(testContexts).ToNot(BeEmpty())
 		testContext := getRandomTestContext()
+		checkSkipDiskType(testContext, balancedDiskType)
 
 		controllerInstance := testContext.Instance
 		controllerClient := testContext.Client
 
-		p, z, _ := controllerInstance.GetIdentity()
-
-		region, err := common.GetRegionFromZones([]string{z})
-		Expect(err).To(BeNil(), "Failed to get region from zones")
+		p, _, _ := controllerInstance.GetIdentity()
+		region := controllerInstance.GetRegion()
 
 		// Create Source Disk
 		srcVolName := testNamePrefix + string(uuid.NewUUID())
@@ -1301,7 +1311,8 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		// Create Disk
 		volName := testNamePrefix + string(uuid.NewUUID())
 		volume, err := controllerClient.CreateVolume(volName, map[string]string{
-			parameters.ParameterKeyReplicationType: "regional-pd",
+			parameters.ParameterKeyType:            balancedDiskType,
+			parameters.ParameterKeyReplicationType: regionalReplication,
 		}, defaultRepdSizeGb, nil,
 			&csi.VolumeContentSource{
 				Type: &csi.VolumeContentSource_Volume{
@@ -1349,24 +1360,25 @@ var _ = Describe("GCE PD CSI Driver", func() {
 	It("Should successfully create RePD from a RePD VolumeContentSource", func() {
 		Expect(testContexts).ToNot(BeEmpty())
 		testContext := getRandomTestContext()
+		checkSkipDiskType(testContext, balancedDiskType)
 
 		controllerInstance := testContext.Instance
 		controllerClient := testContext.Client
 
-		p, z, _ := controllerInstance.GetIdentity()
-
-		region, err := common.GetRegionFromZones([]string{z})
-		Expect(err).To(BeNil(), "Failed to get region from zones")
+		p, _, _ := controllerInstance.GetIdentity()
+		region := controllerInstance.GetRegion()
 
 		// Create Source Disk
 		srcVolName := testNamePrefix + string(uuid.NewUUID())
 		srcVolume, err := controllerClient.CreateVolume(srcVolName, map[string]string{
-			parameters.ParameterKeyReplicationType: "regional-pd",
+			parameters.ParameterKeyType:            balancedDiskType,
+			parameters.ParameterKeyReplicationType: regionalReplication,
 		}, defaultRepdSizeGb, nil, nil)
 		// Create Disk
 		volName := testNamePrefix + string(uuid.NewUUID())
 		volume, err := controllerClient.CreateVolume(volName, map[string]string{
-			parameters.ParameterKeyReplicationType: "regional-pd",
+			parameters.ParameterKeyType:            balancedDiskType,
+			parameters.ParameterKeyReplicationType: regionalReplication,
 		}, defaultRepdSizeGb, nil,
 			&csi.VolumeContentSource{
 				Type: &csi.VolumeContentSource_Volume{
@@ -1444,7 +1456,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		instance := testContext.Instance
 
 		// Create Disk
-		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, standardDiskType)
+		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, instance.DefaultDiskType())
 
 		defer func() {
 			// Delete Disk
@@ -1522,14 +1534,14 @@ var _ = Describe("GCE PD CSI Driver", func() {
 	It("Should create disks, attach them to instance with local ssd, setup caching between LSSD->detach->reattach to same instance", func() {
 		Expect(testContexts).ToNot(BeEmpty())
 		testContext := getRandomTestContext()
-		if testContext.Instance.GetLocalSSD() == 0 {
-			Skip("Skipping data cache as no local ssd in context")
+		if *skipLocalSsdTests || !testContext.Instance.HasLocalSSD() {
+			Skip("Skipping data cache as no local ssd in context or tests disabled")
 		}
 
 		p, z, _ := testContext.Instance.GetIdentity()
 		client := testContext.Client
 		instance := testContext.Instance
-		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, standardDiskType)
+		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, instance.DefaultDiskType())
 		defer deleteVolumeOrError(client, volID)
 
 		// Attach Disk
@@ -1541,7 +1553,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		Expect(testContexts).ToNot(BeEmpty())
 		// Select the last instance in the pool which is isolated and reserved for this test case
 		testContextForVm := testContexts[len(testContexts)-1]
-		if testContextForVm.Instance.GetLocalSSD() == 0 {
+		if *skipLocalSsdTests || testContextForVm.Instance.HasLocalSSD() {
 			Skip("Skipping Data Cache preemption test as isolated VM instance does not have local SSD")
 		}
 
@@ -1549,7 +1561,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		client := testContextForVm.Client
 		instance := testContextForVm.Instance
 
-		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, standardDiskType)
+		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, balancedDiskType)
 		defer deleteVolumeOrError(client, volID)
 
 		defer func() {
@@ -1662,7 +1674,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		client := testContextForVm1.Client
 		firstInstance := testContextForVm1.Instance
 
-		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, standardDiskType)
+		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, firstInstance.DefaultDiskType())
 		defer deleteVolumeOrError(client, volID)
 
 		testContextForVm2 := testZoneContexts[1]
@@ -1736,7 +1748,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		instance := testContext.Instance
 
 		// Create Disk
-		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, standardDiskType)
+		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, instance.DefaultDiskType())
 
 		defer func() {
 			// Delete Disk
@@ -1814,9 +1826,9 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		err := instance.DisableUdev()
 		Expect(err).To(BeNil(), "Failed to disable udev")
 
-		// Create Disk
-		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, standardDiskType)
-		vol2Name, vol2ID := createAndValidateUniqueZonalDisk(client, p, z, standardDiskType)
+		// Create Disk9
+		volName, volID := createAndValidateUniqueZonalDisk(client, p, z, instance.DefaultDiskType())
+		vol2Name, vol2ID := createAndValidateUniqueZonalDisk(client, p, z, instance.DefaultDiskType())
 
 		defer func() {
 			// Delete Disks
@@ -1903,6 +1915,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 		func(cfg multiZoneTestConfig) {
 			Expect(testContexts).ToNot(BeEmpty())
 			testContext := getRandomTestContext()
+			checkSkipDiskType(testContext, cfg.diskType)
 
 			controllerInstance := testContext.Instance
 			controllerClient := testContext.Client
@@ -1956,6 +1969,7 @@ var _ = Describe("GCE PD CSI Driver", func() {
 			}
 			Expect(testContexts).ToNot(BeEmpty())
 			testContext := getRandomTestContext()
+			checkSkipDiskType(testContext, diskType)
 
 			client := testContext.Client
 			instance := testContext.Instance

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -20,6 +20,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -50,13 +51,44 @@ type DriverConfig struct {
 	Zones           []string
 }
 
+// getPackageRoot starts in the current working directory and searches upwards
+// through parent directories until it finds the first directory containing "go.mod".
+// It returns the absolute path of that directory.
+func getPackageRoot() (string, error) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current working directory: %w", err)
+	}
+
+	for {
+		goModPath := filepath.Join(currentDir, "go.mod")
+		info, err := os.Stat(goModPath)
+		if err == nil && !info.IsDir() {
+			return currentDir, nil
+		}
+		parentDir := filepath.Dir(currentDir)
+		if parentDir == currentDir {
+			break
+		}
+		currentDir = parentDir
+	}
+
+	return "", fmt.Errorf("Could not find package root: go.mod not found in current or any parent directories")
+}
+
 func GCEClientAndDriverSetup(instance *remote.InstanceInfo, driverConfig DriverConfig) (*remote.TestContext, error) {
 	port := fmt.Sprintf("%v", 1024+rand.Intn(10000))
+	var pkgPath string
 	goPath, ok := os.LookupEnv("GOPATH")
-	if !ok {
-		return nil, fmt.Errorf("Could not find environment variable GOPATH")
+	if ok {
+		pkgPath = path.Join(goPath, "src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/")
+	} else {
+		var err error
+		if pkgPath, err = getPackageRoot(); err != nil {
+			return nil, err
+		}
 	}
-	pkgPath := path.Join(goPath, "src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/")
+
 	binPath := path.Join(pkgPath, "bin/gce-pd-csi-driver")
 
 	endpoint := fmt.Sprintf("tcp://localhost:%s", port)
@@ -77,7 +109,7 @@ func GCEClientAndDriverSetup(instance *remote.InstanceInfo, driverConfig DriverC
 	}
 
 	extra_flags = append(extra_flags, fmt.Sprintf("--node-name=%s", constants.TestNode))
-	if instance.GetLocalSSD() > 0 {
+	if instance.HasLocalSSD() {
 		extra_flags = append(extra_flags, "--enable-data-cache")
 	}
 	extra_flags = append(extra_flags, fmt.Sprintf("--compute-endpoint=%s", driverConfig.ComputeEndpoint))
@@ -279,7 +311,7 @@ func MkdirAll(instance *remote.InstanceInfo, dir string) error {
 }
 
 func CopyFile(instance *remote.InstanceInfo, src, dest string) error {
-	output, err := instance.SSH("cp", src, dest)
+	output, err := instance.SSH("cp", "-f", src, dest)
 	if err != nil {
 		return fmt.Errorf("failed to copy %s to %s. Output: %v, errror: %v", src, dest, output, err.Error())
 	}
@@ -288,11 +320,11 @@ func CopyFile(instance *remote.InstanceInfo, src, dest string) error {
 
 func InstallDependencies(instance *remote.InstanceInfo, pkgs []string) error {
 	_, _ = instance.SSH("apt-get", "update")
-	for _, pkg := range pkgs {
-		output, err := instance.SSH("apt-get", "install", "-y", pkg)
-		if err != nil {
-			return fmt.Errorf("failed to install package %s. Output: %v, errror: %v", pkg, output, err.Error())
-		}
+	cmdline := []string{"apt-get", "install", "-y"}
+	cmdline = append(cmdline, pkgs...)
+	output, err := instance.SSH(cmdline...)
+	if err != nil {
+		return fmt.Errorf("failed to install package %v. Output: %v, errror: %v", pkgs, output, err.Error())
 	}
 	return nil
 }

--- a/test/remote/archiver.go
+++ b/test/remote/archiver.go
@@ -53,13 +53,14 @@ func CreateDriverArchive(archiveName, architecture, pkgPath, binPath string) (st
 }
 
 func setupBinaries(architecture, tarDir, pkgPath, binPath string) error {
-	klog.V(4).Infof("Making binaries and copying to temp dir...")
+	klog.V(4).Infof("Setting up binaries at %s", binPath)
 	out, err := exec.Command("make", "-C", pkgPath, "GOARCH="+architecture).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("Failed to make at %s: %v: %v", pkgPath, string(out), err.Error())
 	}
 
 	// Copy binaries
+	klog.V(4).Infof("Copying binaries...")
 	if _, err := os.Stat(binPath); err != nil {
 		return fmt.Errorf("failed to locate test binary %s: %v", binPath, err.Error())
 	}

--- a/test/remote/client-wrappers.go
+++ b/test/remote/client-wrappers.go
@@ -112,6 +112,7 @@ func (c *CsiClient) CreateVolumeWithCaps(volName string, params map[string]strin
 	capRange := &csipb.CapacityRange{
 		RequiredBytes: common.GbToBytes(sizeInGb),
 	}
+
 	cvr := &csipb.CreateVolumeRequest{
 		Name:               volName,
 		VolumeCapabilities: caps,

--- a/test/remote/instance.go
+++ b/test/remote/instance.go
@@ -23,9 +23,11 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"time"
 
+	csipb "github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/oauth2/google"
 	computealpha "google.golang.org/api/compute/v0.alpha"
 	computebeta "google.golang.org/api/compute/v0.beta"
@@ -36,6 +38,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/common"
 	gce "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/gce-cloud-provider/compute"
+	"sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/pkg/parameters"
 )
 
 const (
@@ -52,6 +55,8 @@ type InstanceConfig struct {
 	Zone                      string
 	Name                      string
 	MachineType               string
+	DiskTypeDefault           string
+	SupportedDiskTypes        []string
 	ServiceAccount            string
 	ImageURL                  string
 	CloudtopHost              bool
@@ -60,6 +65,7 @@ type InstanceConfig struct {
 	EnableConfidentialCompute bool
 	LocalSSDCount             int64
 	EnableDataCache           bool
+	Subnetwork                string
 }
 
 type InstanceInfo struct {
@@ -72,6 +78,19 @@ func (i *InstanceInfo) GetIdentity() (string, string, string) {
 	return i.cfg.Project, i.cfg.Zone, i.cfg.Name
 }
 
+func (i *InstanceInfo) GetRegion() string {
+	idx := strings.LastIndex(i.cfg.Zone, "-")
+
+	// If '-' is not found (idx == -1),
+	// or it's at the very beginning (idx == 0 -> empty prefix),
+	// or it's at the very end (idx == len-1 -> empty suffix)
+	if idx <= 0 || idx == len(i.cfg.Zone)-1 {
+		return ""
+	}
+
+	return i.cfg.Zone[:idx]
+}
+
 func (i *InstanceInfo) GetName() string {
 	return i.cfg.Name
 }
@@ -80,8 +99,32 @@ func (i *InstanceInfo) GetNodeID() string {
 	return common.CreateNodeID(i.cfg.Project, i.cfg.Zone, i.cfg.Name)
 }
 
-func (i *InstanceInfo) GetLocalSSD() int64 {
-	return i.cfg.LocalSSDCount
+func (i *InstanceInfo) HasLocalSSD() bool {
+	if isAutoLocalSSDMachineType(i.cfg.MachineType) {
+		return true
+	}
+	return i.cfg.LocalSSDCount > 0
+}
+
+func (i *InstanceInfo) MachineType() string {
+	return i.cfg.MachineType
+}
+
+func (i *InstanceInfo) DefaultDiskType() string {
+	if i.cfg.DiskTypeDefault != "" {
+		return i.cfg.DiskTypeDefault
+	}
+	if len(i.cfg.SupportedDiskTypes) > 0 {
+		return i.cfg.SupportedDiskTypes[0]
+	}
+	return "unknown-disk-type" // Will cause an error downstream
+}
+
+func (i *InstanceInfo) SupportsDiskType(diskType string) bool {
+	if len(i.cfg.SupportedDiskTypes) > 0 {
+		return slices.Contains(i.cfg.SupportedDiskTypes, diskType)
+	}
+	return diskType == i.cfg.DiskTypeDefault
 }
 
 func machineTypeMismatch(curInst *compute.Instance, newInst *compute.Instance) bool {
@@ -108,8 +151,22 @@ func machineTypeMismatch(curInst *compute.Instance, newInst *compute.Instance) b
 	return false
 }
 
+func isAutoLocalSSDMachineType(machineType string) bool {
+	if strings.HasSuffix(machineType, "-lssd") {
+		return true
+	}
+
+	fixedSSDFamilies := []string{"z3", "a4", "a3", "a2"}
+	for _, family := range fixedSSDFamilies {
+		if strings.HasPrefix(machineType, family) {
+			return true
+		}
+	}
+	return false
+}
+
 // Provision a gce instance using image
-func (i *InstanceInfo) CreateOrGetInstance(localSSDCount int) error {
+func (i *InstanceInfo) CreateOrGetInstance() error {
 	var err error
 	var instance *compute.Instance
 	klog.V(4).Infof("Creating instance: %v", i.cfg.Name)
@@ -148,6 +205,10 @@ func (i *InstanceInfo) CreateOrGetInstance(localSSDCount int) error {
 		MinCpuPlatform: i.cfg.MinCpuPlatform,
 	}
 
+	if i.cfg.Subnetwork != "" {
+		newInst.NetworkInterfaces[0].Subnetwork = fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/subnetworks/%s", i.cfg.Project, i.GetRegion(), i.cfg.Subnetwork)
+	}
+
 	if i.cfg.EnableConfidentialCompute {
 		newInst.ConfidentialInstanceConfig = &compute.ConfidentialInstanceConfig{
 			EnableConfidentialCompute: true,
@@ -163,7 +224,13 @@ func (i *InstanceInfo) CreateOrGetInstance(localSSDCount int) error {
 		Interface:  "NVME",
 	}
 
-	for i := 0; i < localSSDCount; i++ {
+	// See https://docs.cloud.google.com/compute/docs/disks/add-local-ssd#create_local_ssd
+	// for details. Machines with automatically attached local ssds skip this step.
+	ssdCount := i.cfg.LocalSSDCount
+	if isAutoLocalSSDMachineType(i.cfg.MachineType) {
+		ssdCount = 0
+	}
+	for i := int64(0); i < ssdCount; i++ {
 		newInst.Disks = append(newInst.Disks, localSSDConfig)
 	}
 	saObj := &compute.ServiceAccount{
@@ -350,6 +417,16 @@ func (i *InstanceInfo) createDefaultFirewallRule() error {
 		klog.V(4).Infof("Default firewall rule %v already exists, skipping creation", defaultFirewallRule)
 	}
 	return nil
+}
+
+// CreateVolumeForInstance calls Client.CreateVolume, using the instance default disk type if it's not already specified in params.
+func (tc *TestContext) CreateVolumeForInstance(volName string, params map[string]string, sizeInGb int64, topReq *csipb.TopologyRequirement, volContentSrc *csipb.VolumeContentSource) (*csipb.Volume, error) {
+	if tc.Instance.cfg.DiskTypeDefault != "" {
+		if _, found := params[parameters.ParameterKeyType]; !found {
+			params[parameters.ParameterKeyType] = tc.Instance.cfg.DiskTypeDefault
+		}
+	}
+	return tc.Client.CreateVolume(volName, params, sizeInGb, topReq, volContentSrc)
 }
 
 func GetComputeClient() (*compute.Service, error) {

--- a/test/remote/runner.go
+++ b/test/remote/runner.go
@@ -32,7 +32,7 @@ func (i *InstanceInfo) UploadAndRun(archivePath, remoteWorkspace, driverRunCmd s
 	klog.V(4).Infof("Staging test binaries on %q", i.cfg.Name)
 
 	// Do not sudo here, so that we can use scp to copy test archive to the directdory.
-	if output, err := i.SSHNoSudo("mkdir", remoteWorkspace); err != nil {
+	if output, err := i.SSHNoSudo("mkdir", "-p", remoteWorkspace); err != nil {
 		// Exit failure with the error
 		return -1, fmt.Errorf("failed to create remoteWorkspace directory %q on instance %q: %v output: %q", remoteWorkspace, i.cfg.Name, err.Error(), output)
 	}

--- a/test/remote/setup-teardown.go
+++ b/test/remote/setup-teardown.go
@@ -27,9 +27,10 @@ import (
 // TestContext holds the CSI Client handle to a remotely connected Driver
 // as well as a handle to the Instance that the driver is running on
 type TestContext struct {
-	Instance *InstanceInfo
-	Client   *CsiClient
-	proc     *processes
+	Instance  *InstanceInfo
+	Client    *CsiClient
+	TestZones []string
+	proc      *processes
 }
 
 // ClientConfig contains all the parameters required to package a new
@@ -59,7 +60,7 @@ func SetupInstance(cfg InstanceConfig) (*InstanceInfo, error) {
 		cfg: cfg,
 	}
 
-	err := instance.CreateOrGetInstance(int(cfg.LocalSSDCount))
+	err := instance.CreateOrGetInstance()
 	if err != nil {
 		return nil, err
 	}

--- a/test/run-e2e-local.sh
+++ b/test/run-e2e-local.sh
@@ -4,7 +4,7 @@ set -o nounset
 set -o errexit
 set -x
 
-echo Using GOPATH $GOPATH
+echo Using GOPATH ${GOPATH:-}
 
 readonly PKGDIR=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 
@@ -16,4 +16,4 @@ if hostname | grep -q c.googlers.com ; then
   CLOUDTOP_HOST=--cloudtop-host
 fi
 
-ginkgo --v "test/e2e/tests" -- --project "${PROJECT}" --service-account "${IAM_NAME}" "${CLOUDTOP_HOST}" --v=6 --logtostderr $@
+ginkgo --v "./test/e2e/tests" -- --project "${PROJECT}" --service-account "${IAM_NAME}" "${CLOUDTOP_HOST}" --v=6 --logtostderr $@


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
