### PR TITLE
Fix: improve default SC rollback handler resiliency and support standard container mode

### DIFF
--- a/cmd/default-sc-rollback-handler/main.go
+++ b/cmd/default-sc-rollback-handler/main.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"flag"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -32,6 +34,7 @@ func main() {
 
 	flag.StringVar(&config.StorageClassName, "storageclass-name", "standard-rwo", "Target StorageClass to restore default annotation for")
 	flag.DurationVar(&config.APITimeout, "api-timeout", 30*time.Second, "Maximum time to wait for API server readiness")
+	flag.DurationVar(&config.AccessTimeout, "access-timeout", 5*time.Minute, "Maximum time to wait for StorageClass read/patch access")
 
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -39,8 +42,25 @@ func main() {
 	klog.InfoS("Starting MAP default storageclass rollback handler")
 
 	restorer := scdefaultrestorer.New(config)
-	if err := restorer.Run(context.Background()); err != nil {
+	err := restorer.Run(context.Background())
+	if err != nil {
 		klog.ErrorS(err, "Failed to restore storage class defaults")
+	} else {
+		klog.InfoS("Successfully restored storage class defaults")
+	}
+
+	// Block here to prevent container from exiting and triggering restart loops
+	// in long-running pods (restartPolicy: Always).
+	klog.InfoS("Holding container active to satisfy restartPolicy")
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+
+	// Block until a signal is received
+	<-sigCh
+	klog.InfoS("Received shutdown signal, exiting gracefully")
+
+	if err != nil {
 		os.Exit(1)
 	}
 }

--- a/pkg/scdefaultrestorer/restorer.go
+++ b/pkg/scdefaultrestorer/restorer.go
@@ -42,6 +42,7 @@ const (
 type Config struct {
 	StorageClassName string
 	APITimeout       time.Duration
+	AccessTimeout    time.Duration
 }
 
 type Restorer struct {
@@ -90,16 +91,58 @@ func (r *Restorer) waitForAPIServer(ctx context.Context, client kubernetes.Inter
 	return nil
 }
 
-func (r *Restorer) restoreDefaultAnnotation(ctx context.Context, client kubernetes.Interface) error {
+// waitForStorageClassAccess waits for the RBAC permissions required to access the
+// StorageClass to be fully applied.
+// Note: This restorer is only used to update pre-existing storage classes. We are
+// only concerned with resolving RBAC race conditions during cluster updates, not
+// waiting for resource creation. Therefore, if the StorageClass does not exist
+// (NotFound error), this function exits immediately rather than retrying.
+func (r *Restorer) waitForStorageClassAccess(ctx context.Context, client kubernetes.Interface, targetSCName string) (bool, error) {
 	scClient := client.StorageV1().StorageClasses()
+	var exists bool
+
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, r.config.AccessTimeout, true, func(ctx context.Context) (bool, error) {
+		_, err := scClient.Get(ctx, targetSCName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				exists = false
+				return true, nil // Stop polling, it definitely doesn't exist
+			}
+			if apierrors.IsForbidden(err) {
+				klog.Warningf("Permission denied when getting StorageClass %s, waiting for access/RBAC to be applied: %v", targetSCName, err)
+				return false, nil // Keep retrying, waiting for Addon Manager
+			}
+			return false, err // Stop on other fatal errors
+		}
+		exists = true
+		return true, nil // Success! Permissions are good and SC exists
+	})
+
+	if err != nil {
+		return false, fmt.Errorf("failed while waiting for StorageClass %s access: %w", targetSCName, err)
+	}
+
+	return exists, nil
+}
+
+func (r *Restorer) restoreDefaultAnnotation(ctx context.Context, client kubernetes.Interface) error {
 	targetSCName := r.config.StorageClassName
 
+	// Wait for permissions and check existence
+	exists, err := r.waitForStorageClassAccess(ctx, client, targetSCName)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		klog.Warningf("StorageClass not found, skipping restoration: %s", targetSCName)
+		return nil
+	}
+
+	// Clear to proceed, get the actual object
+	scClient := client.StorageV1().StorageClasses()
 	targetSC, err := scClient.Get(ctx, targetSCName, metav1.GetOptions{})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			klog.Warningf("StorageClass not found, skipping restoration: %s", targetSCName)
-			return nil
-		}
 		return fmt.Errorf("failed to get StorageClass %s: %w", targetSCName, err)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
The `default-sc-rollback-handler` was originally introduced to handle storage class defaults, but running it early in the pod lifecycle exposed a race condition: the controller could boot before the Addon Manager finished applying the necessary RBAC permissions for `StorageClass` access. This led to a `Forbidden` (403) error. 

Furthermore, if we use an `initContainer` and simply wait/retry for RBAC, it blocks the main PD CSI driver from starting and responding to RPCs. 

To resolve this, this PR adapts the rollback handler to run safely as a standard sidecar container:
1. **Adds RBAC Retries:** Introduces a retry loop when fetching the storage class, allowing the container to gracefully wait for RBAC application instead of failing fatally.
2. **Idles on Success:** Adds a blocking OS signal channel at the end of the handler's execution. This ensures that when it runs as a standard container, it enters a zero-CPU idle state upon success rather than exiting and triggering an endless `CrashLoopBackOff`.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
