### PR TITLE
Feature vac annotations

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -87,6 +87,14 @@ const (
 
 	// ClusterIDLabel is the key in disk labels to indicate the cluster identifier of the disk.
 	ClusterIDLabel = "cluster-id-gke-io"
+
+	// Annotations for Disk Type Conversion
+	DiskTypeConversionOperationKey = "pdcsi.gke.io/disk-type-conversion-operation"
+	DiskTypeConvertedFromKey       = "pdcsi.gke.io/disk-type-converted-from"
+	DiskTypeConvertedToKey         = "pdcsi.gke.io/disk-type-converted-to"
+
+	// Conversion States
+	ConversionStatePending = "Pending"
 )
 
 // doc https://cloud.google.com/compute/docs/general-purpose-machines

--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -77,6 +77,14 @@ type ConversionTestParams struct {
 	SlowConversionCalled bool
 	FastConversionCalled bool
 	AttachCallCount      int
+
+	// Disk type conversion (ConvertDiskType).
+	TypeConversionCalled     bool
+	TypeConversionCallCount  int
+	TypeConversionErr        error
+	TypeConversionTargetType string
+	TypeConversionIops       *int64
+	TypeConversionThroughput *int64
 }
 
 var _ GCECompute = &FakeCloudProvider{}
@@ -334,6 +342,33 @@ func (cloud *FakeCloudProvider) DetachDisk(ctx context.Context, project, deviceN
 	}
 	instance.Disks[found] = instance.Disks[len(instance.Disks)-1]
 	instance.Disks = instance.Disks[:len(instance.Disks)-1]
+	return nil
+}
+
+func (cloud *FakeCloudProvider) ConvertDiskType(ctx context.Context, project string, volKey *meta.Key, targetDiskType string, provisionedIops, provisionedThroughput *int64) error {
+	cloud.ConversionTestParams.TypeConversionCalled = true
+	cloud.ConversionTestParams.TypeConversionCallCount++
+	cloud.ConversionTestParams.TypeConversionTargetType = targetDiskType
+	cloud.ConversionTestParams.TypeConversionIops = provisionedIops
+	cloud.ConversionTestParams.TypeConversionThroughput = provisionedThroughput
+
+	if cloud.ConversionTestParams.TypeConversionErr != nil {
+		return cloud.ConversionTestParams.TypeConversionErr
+	}
+
+	// The real API converts asynchronously, but the fake applies the new type
+	// immediately so tests can observe the end state.
+	disk, ok := cloud.disks[volKey.String()]
+	if !ok {
+		return notFoundError()
+	}
+	typeURI := cloud.GetDiskTypeURI(project, volKey, targetDiskType)
+	if disk.disk != nil {
+		disk.disk.Type = typeURI
+	}
+	if disk.betaDisk != nil {
+		disk.betaDisk.Type = typeURI
+	}
 	return nil
 }
 

--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -1004,8 +1004,10 @@ func (cloud *CloudProvider) ConvertDiskType(ctx context.Context, project string,
 	}
 	klog.V(5).Infof("Converting disk %v in zone %v to type %s", volKey.Name, volKey.Zone, targetDiskType)
 
+	// TargetDiskType is the bare disk type name, not a disk type URI. Passing a
+	// URI is rejected with DISK_TYPE_CONVERSION_UNSUPPORTED.
 	params := &computealpha.DiskConvertParams{
-		TargetDiskType: cloud.GetDiskTypeURI(project, volKey, targetDiskType),
+		TargetDiskType: targetDiskType,
 	}
 	if provisionedIops != nil {
 		params.ProvisionedIops = *provisionedIops

--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -118,6 +118,7 @@ type GCECompute interface {
 	AttachDisk(ctx context.Context, project string, volKey *meta.Key, readWrite, diskType, instanceZone, instanceName string, forceAttach bool) error
 	DetachDisk(ctx context.Context, project, deviceName, instanceZone, instanceName string) error
 	ConvertDisk(ctx context.Context, project string, volKey *meta.Key, instanceName, instanceZone string, quickConversionOnly bool) error
+	ConvertDiskType(ctx context.Context, project string, volKey *meta.Key, targetDiskType string, provisionedIops, provisionedThroughput *int64) error
 	SetDiskAccessMode(ctx context.Context, project string, volKey *meta.Key, accessMode string) error
 	SetDiskLabels(ctx context.Context, project string, volKey *meta.Key, disk *CloudDisk, labels map[string]string) error
 	ListCompatibleDiskTypeZones(ctx context.Context, project string, zones []string, diskType string) ([]string, error)
@@ -987,6 +988,37 @@ func (cloud *CloudProvider) ConvertDisk(ctx context.Context, project string, vol
 	if err != nil {
 		return fmt.Errorf("failed while waiting for zonal conversion operation: %w", err)
 	}
+	return nil
+}
+
+// ConvertDiskType converts a disk to targetDiskType in place, optionally
+// applying the provisioned IOPS and throughput the target type should be
+// created with. The disk keeps its name and self link.
+//
+// Conversion can take from minutes to hours depending on disk size, so this
+// only starts the operation and returns as soon as the API accepts it. Callers
+// observe completion by re-reading the disk's type on a later reconcile.
+func (cloud *CloudProvider) ConvertDiskType(ctx context.Context, project string, volKey *meta.Key, targetDiskType string, provisionedIops, provisionedThroughput *int64) error {
+	if volKey.Type() != meta.Zonal {
+		return fmt.Errorf("disk type conversion is not supported for regional disk %s", volKey.Name)
+	}
+	klog.V(5).Infof("Converting disk %v in zone %v to type %s", volKey.Name, volKey.Zone, targetDiskType)
+
+	params := &computealpha.DiskConvertParams{
+		TargetDiskType: cloud.GetDiskTypeURI(project, volKey, targetDiskType),
+	}
+	if provisionedIops != nil {
+		params.ProvisionedIops = *provisionedIops
+	}
+	if provisionedThroughput != nil {
+		params.ProvisionedThroughput = *provisionedThroughput
+	}
+
+	op, err := cloud.alphaService.Disks.Convert(project, volKey.Zone, volKey.Name, &computealpha.DisksConvertRequest{Params: params}).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	klog.V(4).Infof("Started convert operation %s for disk %s to type %s", op.Name, volKey.Name, targetDiskType)
 	return nil
 }
 

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"net/http"
 	neturl "net/url"
 	"sort"
 	"strconv"
@@ -913,16 +914,14 @@ func (gceCS *GCEControllerServer) ControllerModifyVolume(ctx context.Context, re
 		return nil, err
 	}
 
-	// If the VolumeAttributesClass requests a disk type, compare it against the
-	// disk's actual type. A mismatch means a disk type conversion is being
-	// requested, which is not supported yet.
+	// If the VolumeAttributesClass requests a disk type that doesn't match the
+	// disk's actual type, this is a disk type conversion request rather than an
+	// IOPS/throughput update. This must be handled before the checks below,
+	// which are keyed on the disk's current type and would reject types that
+	// are valid conversion sources.
 	diskType := existingDisk.GetPDType()
 	if volumeModifyParams.DiskType != nil && *volumeModifyParams.DiskType != diskType {
-		err = status.Errorf(codes.InvalidArgument,
-			"disk type mismatch for volume %s: disk is %q, VolumeAttributesClass requests %q; disk type conversion is not supported",
-			volumeID, diskType, *volumeModifyParams.DiskType)
-		klog.Errorf("Failed to modify volume %s: %v", volumeID, err)
-		return nil, err
+		return gceCS.convertDiskType(ctx, project, volKey, volumeID, existingDisk, volumeModifyParams)
 	}
 
 	// Check if the disk supports dynamic IOPS/Throughput provisioning
@@ -949,6 +948,59 @@ func (gceCS *GCEControllerServer) ControllerModifyVolume(ctx context.Context, re
 	}
 
 	return &csi.ControllerModifyVolumeResponse{}, nil
+}
+
+// convertDiskType starts an in-place disk type conversion for a volume whose
+// VolumeAttributesClass requests a type different from the disk's current type.
+//
+// The GCE conversion can run for minutes to hours, far longer than a single
+// ModifyVolume call may block, so this returns as soon as the operation has
+// been accepted. The modification stays pending and is retried; once the disk
+// reports the target type, the retry falls through to the regular
+// IOPS/throughput path and the modification completes.
+func (gceCS *GCEControllerServer) convertDiskType(ctx context.Context, project string, volKey *meta.Key, volumeID string, existingDisk *gce.CloudDisk, params parameters.ModifyVolumeParameters) (*csi.ControllerModifyVolumeResponse, error) {
+	targetDiskType := *params.DiskType
+	currentDiskType := existingDisk.GetPDType()
+
+	if !gceCS.EnablePdConversion {
+		return nil, status.Errorf(codes.InvalidArgument, "cannot convert volume %s from %s to %s: disk conversion is not enabled on this driver", volumeID, currentDiskType, targetDiskType)
+	}
+
+	// Regional disks have no conversion API, so this can never succeed.
+	if volKey.Type() != meta.Zonal {
+		return nil, status.Errorf(codes.InvalidArgument, "cannot convert volume %s from %s to %s: disk type conversion is not supported for regional disks", volumeID, currentDiskType, targetDiskType)
+	}
+
+	// Conversion requires the disk to be detached. Report this as retryable so
+	// the conversion starts once the workload using the volume is scaled down.
+	if users := existingDisk.GetUsers(); len(users) > 0 {
+		return nil, status.Errorf(codes.FailedPrecondition, "cannot convert volume %s from %s to %s while it is attached to %v, detach the volume to start the conversion", volumeID, currentDiskType, targetDiskType, users)
+	}
+
+	klog.V(4).Infof("Converting volume %s from %s to %s", volumeID, currentDiskType, targetDiskType)
+	if err := gceCS.CloudProvider.ConvertDiskType(ctx, project, volKey, targetDiskType, params.IOPS, params.Throughput); err != nil {
+		klog.Errorf("Failed to convert volume %s from %s to %s: %v", volumeID, currentDiskType, targetDiskType, err)
+		if isUnsupportedConversionIntentError(err) {
+			return nil, status.Errorf(codes.InvalidArgument, "cannot convert volume %s from %s to %s: %v", volumeID, currentDiskType, targetDiskType, err)
+		}
+		return nil, status.Errorf(codes.Unavailable, "failed to start conversion of volume %s from %s to %s: %v", volumeID, currentDiskType, targetDiskType, err)
+	}
+
+	// The conversion has started but is not finished, so the requested
+	// attributes are not in effect yet.
+	return nil, status.Errorf(codes.Unavailable, "conversion of volume %s from %s to %s is in progress", volumeID, currentDiskType, targetDiskType)
+}
+
+// isUnsupportedConversionIntentError reports whether the conversion can never
+// succeed for the requested target configuration, meaning it should not be
+// retried. Anything else (unmet preconditions, quota and rate limits, failures
+// during execution) is transient and worth retrying.
+func isUnsupportedConversionIntentError(err error) bool {
+	var apiErr *googleapi.Error
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return apiErr.Code == http.StatusBadRequest
 }
 
 func (gceCS *GCEControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"net/http"
 	neturl "net/url"
 	"sort"
 	"strconv"
@@ -924,6 +923,14 @@ func (gceCS *GCEControllerServer) ControllerModifyVolume(ctx context.Context, re
 		return gceCS.convertDiskType(ctx, project, volKey, volumeID, existingDisk, volumeModifyParams)
 	}
 
+	// The disk is already the requested type. If no other attributes were
+	// requested there is nothing left to do, which is also how a completed
+	// conversion is reported as successful on a subsequent retry.
+	if volumeModifyParams.IOPS == nil && volumeModifyParams.Throughput == nil {
+		klog.V(4).Infof("Volume %s already has the requested attributes", volumeID)
+		return &csi.ControllerModifyVolumeResponse{}, nil
+	}
+
 	// Check if the disk supports dynamic IOPS/Throughput provisioning
 	supportsIopsChange := gceCS.diskSupportsIopsChange(diskType)
 	supportsThroughputChange := gceCS.diskSupportsThroughputChange(diskType)
@@ -980,10 +987,15 @@ func (gceCS *GCEControllerServer) convertDiskType(ctx context.Context, project s
 	klog.V(4).Infof("Converting volume %s from %s to %s", volumeID, currentDiskType, targetDiskType)
 	if err := gceCS.CloudProvider.ConvertDiskType(ctx, project, volKey, targetDiskType, params.IOPS, params.Throughput); err != nil {
 		klog.Errorf("Failed to convert volume %s from %s to %s: %v", volumeID, currentDiskType, targetDiskType, err)
-		if isUnsupportedConversionIntentError(err) {
+		switch {
+		case isConversionInProgressError(err):
+			// A conversion started by an earlier attempt is still running.
+			return nil, status.Errorf(codes.Unavailable, "conversion of volume %s from %s to %s is in progress", volumeID, currentDiskType, targetDiskType)
+		case isUnsupportedConversionIntentError(err):
 			return nil, status.Errorf(codes.InvalidArgument, "cannot convert volume %s from %s to %s: %v", volumeID, currentDiskType, targetDiskType, err)
+		default:
+			return nil, status.Errorf(codes.Unavailable, "failed to start conversion of volume %s from %s to %s: %v", volumeID, currentDiskType, targetDiskType, err)
 		}
-		return nil, status.Errorf(codes.Unavailable, "failed to start conversion of volume %s from %s to %s: %v", volumeID, currentDiskType, targetDiskType, err)
 	}
 
 	// The conversion has started but is not finished, so the requested
@@ -991,16 +1003,54 @@ func (gceCS *GCEControllerServer) convertDiskType(ctx context.Context, project s
 	return nil, status.Errorf(codes.Unavailable, "conversion of volume %s from %s to %s is in progress", volumeID, currentDiskType, targetDiskType)
 }
 
+// Reasons returned by the convert API that mean the requested conversion can
+// never succeed. Everything else, including errors that share their HTTP status
+// with these, is treated as transient and retried.
+var terminalConversionReasons = sets.NewString(
+	"DISK_TYPE_CONVERSION_UNSUPPORTED",
+)
+
+// conversionInProgressReason is returned when the disk is busy, which for a
+// conversion request means an earlier conversion is still running.
+const conversionInProgressReason = "resourceNotReady"
+
 // isUnsupportedConversionIntentError reports whether the conversion can never
 // succeed for the requested target configuration, meaning it should not be
-// retried. Anything else (unmet preconditions, quota and rate limits, failures
-// during execution) is transient and worth retrying.
+// retried. Note that the HTTP status alone cannot decide this: an in-progress
+// conversion is also reported as 400.
 func isUnsupportedConversionIntentError(err error) bool {
+	return terminalConversionReasons.Has(conversionErrorReason(err))
+}
+
+// isConversionInProgressError reports whether the error means a conversion of
+// this disk is already running.
+func isConversionInProgressError(err error) bool {
+	return conversionErrorReason(err) == conversionInProgressReason
+}
+
+// conversionErrorReason extracts the machine readable reason from a convert API
+// error, preferring the ErrorInfo detail over the top level error item because
+// the latter only carries generic reasons such as "badRequest".
+func conversionErrorReason(err error) string {
 	var apiErr *googleapi.Error
 	if !errors.As(err, &apiErr) {
-		return false
+		return ""
 	}
-	return apiErr.Code == http.StatusBadRequest
+	for _, detail := range apiErr.Details {
+		detailMap, ok := detail.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if reason, ok := detailMap["reason"].(string); ok && reason != "" {
+			return reason
+		}
+	}
+	for _, errItem := range apiErr.Errors {
+		if errItem.Reason != "" {
+			return errItem.Reason
+		}
+	}
+	return ""
 }
 
 func (gceCS *GCEControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -913,8 +913,19 @@ func (gceCS *GCEControllerServer) ControllerModifyVolume(ctx context.Context, re
 		return nil, err
 	}
 
-	// Check if the disk supports dynamic IOPS/Throughput provisioning
+	// If the VolumeAttributesClass requests a disk type, compare it against the
+	// disk's actual type. A mismatch means a disk type conversion is being
+	// requested, which is not supported yet.
 	diskType := existingDisk.GetPDType()
+	if volumeModifyParams.DiskType != nil && *volumeModifyParams.DiskType != diskType {
+		err = status.Errorf(codes.InvalidArgument,
+			"disk type mismatch for volume %s: disk is %q, VolumeAttributesClass requests %q; disk type conversion is not supported",
+			volumeID, diskType, *volumeModifyParams.DiskType)
+		klog.Errorf("Failed to modify volume %s: %v", volumeID, err)
+		return nil, err
+	}
+
+	// Check if the disk supports dynamic IOPS/Throughput provisioning
 	supportsIopsChange := gceCS.diskSupportsIopsChange(diskType)
 	supportsThroughputChange := gceCS.diskSupportsThroughputChange(diskType)
 	if !supportsIopsChange && !supportsThroughputChange {

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -923,6 +923,14 @@ func (gceCS *GCEControllerServer) ControllerModifyVolume(ctx context.Context, re
 		return gceCS.convertDiskType(ctx, project, volKey, volumeID, existingDisk, volumeModifyParams)
 	}
 
+	if volumeModifyParams.DiskType != nil {
+		// 1. Write the success note (Converted-To)
+		_ = k8sclient.UpdatePVAnnotation(ctx, volKey.Name, constants.DiskTypeConvertedToKey, *volumeModifyParams.DiskType)
+
+		// 2. Erase the "Pending" or "Operation" note by passing "null"
+		_ = k8sclient.UpdatePVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionOperationKey, "null")
+	}
+
 	// The disk is already the requested type. If no other attributes were
 	// requested there is nothing left to do, which is also how a completed
 	// conversion is reported as successful on a subsequent retry.
@@ -981,15 +989,22 @@ func (gceCS *GCEControllerServer) convertDiskType(ctx context.Context, project s
 	// Conversion requires the disk to be detached. Report this as retryable so
 	// the conversion starts once the workload using the volume is scaled down.
 	if users := existingDisk.GetUsers(); len(users) > 0 {
+		err := k8sclient.UpdatePVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionOperationKey, constants.ConversionStatePending)
+		if err != nil {
+			klog.Warningf("Failed to annotate PV %s with Pending state: %v", volKey.Name, err)
+		}
+		// ------------
 		return nil, status.Errorf(codes.FailedPrecondition, "cannot convert volume %s from %s to %s while it is attached to %v, detach the volume to start the conversion", volumeID, currentDiskType, targetDiskType, users)
 	}
 
 	klog.V(4).Infof("Converting volume %s from %s to %s", volumeID, currentDiskType, targetDiskType)
+
 	if err := gceCS.CloudProvider.ConvertDiskType(ctx, project, volKey, targetDiskType, params.IOPS, params.Throughput); err != nil {
 		klog.Errorf("Failed to convert volume %s from %s to %s: %v", volumeID, currentDiskType, targetDiskType, err)
 		switch {
 		case isConversionInProgressError(err):
 			// A conversion started by an earlier attempt is still running.
+			_ = k8sclient.UpdatePVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionOperationKey, constants.ConversionStatePending)
 			return nil, status.Errorf(codes.Unavailable, "conversion of volume %s from %s to %s is in progress", volumeID, currentDiskType, targetDiskType)
 		case isUnsupportedConversionIntentError(err):
 			return nil, status.Errorf(codes.InvalidArgument, "cannot convert volume %s from %s to %s: %v", volumeID, currentDiskType, targetDiskType, err)

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -2594,10 +2594,25 @@ func TestVolumeModifyDiskTypeConversion(t *testing.T) {
 			volumeID:           testVolumeID,
 			mutableParameters:  map[string]string{"type": "hyperdisk-throughput"},
 			enablePdConversion: true,
-			convertErr:         &googleapi.Error{Code: http.StatusBadRequest, Message: "conversion from hyperdisk-balanced to hyperdisk-throughput is not supported"},
+			convertErr:         conversionAPIError(http.StatusBadRequest, "DISK_TYPE_CONVERSION_UNSUPPORTED", "Disk type hyperdisk-balanced does not support conversion to hyperdisk-throughput"),
 			expConvertCalled:   true,
 			expTargetDiskType:  "hyperdisk-throughput",
 			expErrCode:         codes.InvalidArgument,
+		},
+		{
+			// An already running conversion is reported with the same HTTP
+			// status as an unsupported conversion, so it must be told apart by
+			// reason or the modification is wrongly abandoned.
+			name:                "treats an in-progress conversion as retryable",
+			disk:                &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 200},
+			volumeID:            testVolumeID,
+			mutableParameters:   map[string]string{"type": "hyperdisk-balanced"},
+			enablePdConversion:  true,
+			convertErr:          conversionAPIError(http.StatusBadRequest, "resourceNotReady", "The resource is not ready"),
+			expConvertCalled:    true,
+			expTargetDiskType:   "hyperdisk-balanced",
+			expErrCode:          codes.Unavailable,
+			expErrMessageSubstr: "is in progress",
 		},
 		{
 			name:               "treats an unmet precondition as retryable",
@@ -2605,10 +2620,21 @@ func TestVolumeModifyDiskTypeConversion(t *testing.T) {
 			volumeID:           testVolumeID,
 			mutableParameters:  map[string]string{"type": "hyperdisk-balanced"},
 			enablePdConversion: true,
-			convertErr:         &googleapi.Error{Code: http.StatusTooManyRequests, Message: "too many concurrent conversion operations"},
+			convertErr:         conversionAPIError(http.StatusTooManyRequests, "rateLimitExceeded", "too many concurrent conversion operations"),
 			expConvertCalled:   true,
 			expTargetDiskType:  "hyperdisk-balanced",
 			expErrCode:         codes.Unavailable,
+		},
+		{
+			// How a completed conversion is reported as successful: the retry
+			// after the disk reports the new type has nothing left to do.
+			name:               "a completed conversion reports success",
+			disk:               &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "hyperdisk-balanced", SizeGb: 200},
+			volumeID:           testVolumeID,
+			mutableParameters:  map[string]string{"type": "hyperdisk-balanced"},
+			enablePdConversion: true,
+			expConvertCalled:   false,
+			expErrCode:         codes.OK,
 		},
 		{
 			name:               "a matching disk type is not a conversion",
@@ -2660,6 +2686,24 @@ func TestVolumeModifyDiskTypeConversion(t *testing.T) {
 				t.Errorf("Expected conversion throughput %v, got %v", int64PtrStr(tc.expThroughput), int64PtrStr(got))
 			}
 		})
+	}
+}
+
+// conversionAPIError builds an error shaped like the one the convert API
+// returns, where the machine readable reason is carried in an ErrorInfo detail
+// rather than in the top level error item.
+func conversionAPIError(code int, reason, message string) *googleapi.Error {
+	return &googleapi.Error{
+		Code:    code,
+		Message: message,
+		Errors:  []googleapi.ErrorItem{{Reason: "badRequest", Message: message}},
+		Details: []interface{}{
+			map[string]interface{}{
+				"@type":  "type.googleapis.com/google.rpc.ErrorInfo",
+				"reason": reason,
+				"domain": "compute.googleapis.com",
+			},
+		},
 	}
 }
 

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -2514,6 +2514,169 @@ func TestCreateVolumeWithVolumeAttributeClassParameters(t *testing.T) {
 
 }
 
+func TestVolumeModifyDiskTypeConversion(t *testing.T) {
+	iops := int64(3000)
+	throughput := int64(188)
+
+	testCases := []struct {
+		name string
+		// disk is the disk the volume is backed by, inserted into the fake.
+		disk                *compute.Disk
+		volumeID            string
+		mutableParameters   map[string]string
+		enablePdConversion  bool
+		convertErr          error
+		expConvertCalled    bool
+		expTargetDiskType   string
+		expIops             *int64
+		expThroughput       *int64
+		expErrCode          codes.Code
+		expErrMessageSubstr string
+	}{
+		{
+			name:               "converts a detached pd disk to hyperdisk",
+			disk:               &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-standard", SizeGb: 200},
+			volumeID:           testVolumeID,
+			mutableParameters:  map[string]string{"type": "hyperdisk-balanced"},
+			enablePdConversion: true,
+			expConvertCalled:   true,
+			expTargetDiskType:  "hyperdisk-balanced",
+			// The conversion runs asynchronously, so the modification is not
+			// complete when the call returns.
+			expErrCode:          codes.Unavailable,
+			expErrMessageSubstr: "conversion of volume",
+		},
+		{
+			name:               "passes iops and throughput as the target configuration",
+			disk:               &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-standard", SizeGb: 200},
+			volumeID:           testVolumeID,
+			mutableParameters:  map[string]string{"type": "hyperdisk-balanced", "iops": "3000", "throughput": "188Mi"},
+			enablePdConversion: true,
+			expConvertCalled:   true,
+			expTargetDiskType:  "hyperdisk-balanced",
+			expIops:            &iops,
+			expThroughput:      &throughput,
+			expErrCode:         codes.Unavailable,
+		},
+		{
+			name:                "rejects conversion while the disk is attached",
+			disk:                &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-standard", SizeGb: 200, Users: []string{"instance-1"}},
+			volumeID:            testVolumeID,
+			mutableParameters:   map[string]string{"type": "hyperdisk-balanced"},
+			enablePdConversion:  true,
+			expConvertCalled:    false,
+			expErrCode:          codes.FailedPrecondition,
+			expErrMessageSubstr: "detach the volume",
+		},
+		{
+			name:                "rejects conversion of a regional disk",
+			disk:                &compute.Disk{Name: name, Region: region, SelfLink: testRegionalID, Type: "pd-standard", SizeGb: 200},
+			volumeID:            testRegionalID,
+			mutableParameters:   map[string]string{"type": "hyperdisk-balanced"},
+			enablePdConversion:  true,
+			expConvertCalled:    false,
+			expErrCode:          codes.InvalidArgument,
+			expErrMessageSubstr: "not supported for regional disks",
+		},
+		{
+			name:                "rejects conversion when the feature is disabled",
+			disk:                &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-standard", SizeGb: 200},
+			volumeID:            testVolumeID,
+			mutableParameters:   map[string]string{"type": "hyperdisk-balanced"},
+			enablePdConversion:  false,
+			expConvertCalled:    false,
+			expErrCode:          codes.InvalidArgument,
+			expErrMessageSubstr: "not enabled",
+		},
+		{
+			name:               "treats an unsupported conversion intent as terminal",
+			disk:               &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "hyperdisk-balanced", SizeGb: 200},
+			volumeID:           testVolumeID,
+			mutableParameters:  map[string]string{"type": "hyperdisk-throughput"},
+			enablePdConversion: true,
+			convertErr:         &googleapi.Error{Code: http.StatusBadRequest, Message: "conversion from hyperdisk-balanced to hyperdisk-throughput is not supported"},
+			expConvertCalled:   true,
+			expTargetDiskType:  "hyperdisk-throughput",
+			expErrCode:         codes.InvalidArgument,
+		},
+		{
+			name:               "treats an unmet precondition as retryable",
+			disk:               &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-standard", SizeGb: 200},
+			volumeID:           testVolumeID,
+			mutableParameters:  map[string]string{"type": "hyperdisk-balanced"},
+			enablePdConversion: true,
+			convertErr:         &googleapi.Error{Code: http.StatusTooManyRequests, Message: "too many concurrent conversion operations"},
+			expConvertCalled:   true,
+			expTargetDiskType:  "hyperdisk-balanced",
+			expErrCode:         codes.Unavailable,
+		},
+		{
+			name:               "a matching disk type is not a conversion",
+			disk:               &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "hyperdisk-balanced", SizeGb: 200},
+			volumeID:           testVolumeID,
+			mutableParameters:  map[string]string{"type": "hyperdisk-balanced", "iops": "3000"},
+			enablePdConversion: true,
+			expConvertCalled:   false,
+			expErrCode:         codes.OK,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fcp, err := gce.CreateFakeCloudProvider(project, zone, []*gce.CloudDisk{gce.CloudDiskFromV1(tc.disk)})
+			if err != nil {
+				t.Fatalf("Failed to create fake cloud provider: %v", err)
+			}
+			fcp.ConversionTestParams.TypeConversionErr = tc.convertErr
+
+			gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{EnablePdConversion: tc.enablePdConversion})
+
+			_, err = gceDriver.cs.ControllerModifyVolume(context.Background(), &csi.ControllerModifyVolumeRequest{
+				VolumeId:          tc.volumeID,
+				MutableParameters: tc.mutableParameters,
+			})
+
+			if gotCode := status.Code(err); gotCode != tc.expErrCode {
+				t.Errorf("Expected error code %v, got %v (err: %v)", tc.expErrCode, gotCode, err)
+			}
+			if tc.expErrMessageSubstr != "" && (err == nil || !strings.Contains(err.Error(), tc.expErrMessageSubstr)) {
+				t.Errorf("Expected error containing %q, got: %v", tc.expErrMessageSubstr, err)
+			}
+
+			gotCalled := fcp.ConversionTestParams.TypeConversionCalled
+			if gotCalled != tc.expConvertCalled {
+				t.Errorf("Expected conversion called to be %v, got %v", tc.expConvertCalled, gotCalled)
+			}
+			if !tc.expConvertCalled {
+				return
+			}
+			if got := fcp.ConversionTestParams.TypeConversionTargetType; got != tc.expTargetDiskType {
+				t.Errorf("Expected conversion target type %q, got %q", tc.expTargetDiskType, got)
+			}
+			if got := fcp.ConversionTestParams.TypeConversionIops; !equalInt64Ptr(got, tc.expIops) {
+				t.Errorf("Expected conversion IOPS %v, got %v", int64PtrStr(tc.expIops), int64PtrStr(got))
+			}
+			if got := fcp.ConversionTestParams.TypeConversionThroughput; !equalInt64Ptr(got, tc.expThroughput) {
+				t.Errorf("Expected conversion throughput %v, got %v", int64PtrStr(tc.expThroughput), int64PtrStr(got))
+			}
+		})
+	}
+}
+
+func equalInt64Ptr(a, b *int64) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func int64PtrStr(v *int64) string {
+	if v == nil {
+		return "<nil>"
+	}
+	return strconv.FormatInt(*v, 10)
+}
+
 func TestVolumeModifyOperation(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/pkg/k8sclient/client.go
+++ b/pkg/k8sclient/client.go
@@ -2,12 +2,15 @@ package k8sclient
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -140,4 +143,44 @@ func listPodsInNamespace(ctx context.Context, kubeClient kubernetes.Interface, n
 		klog.Errorf("Failed to list pods in namespace %s after retries: %v\n", namespace, err)
 	}
 	return podList, err
+}
+
+func updatePVAnnotation(ctx context.Context, kubeClient kubernetes.Interface, pvName string, annotationKey string, annotationValue string) error {
+	var patchPayload []byte
+	var patchType types.PatchType
+
+	if annotationValue == "" || annotationValue == "null" {
+		// Remove the annotation using JSON Patch (RFC 6902)
+		// We must escape '/' characters as '~1' per JSON pointer syntax
+		escapedKey := strings.ReplaceAll(annotationKey, "/", "~1")
+		patchStr := fmt.Sprintf(`[{"op": "remove", "path": "/metadata/annotations/%s"}]`, escapedKey)
+		patchPayload = []byte(patchStr)
+		patchType = types.JSONPatchType
+	} else {
+		// Add or update the annotation using Merge Patch (RFC 7386)
+		patchMap := map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]string{
+					annotationKey: annotationValue,
+				},
+			},
+		}
+		patchPayload, _ = json.Marshal(patchMap)
+		patchType = types.MergePatchType
+	}
+
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(_ context.Context) (bool, error) {
+		_, err := kubeClient.CoreV1().PersistentVolumes().Patch(ctx, pvName, patchType, patchPayload, metav1.PatchOptions{})
+		if err != nil {
+			klog.Warningf("Error patching annotation %s on PersistentVolume %s: %v, retrying...\n", annotationKey, pvName, err)
+			return false, nil // returning false causes it to retry
+		}
+		klog.V(4).Infof("Successfully patched annotation %s on PersistentVolume %s\n", annotationKey, pvName)
+		return true, nil
+	})
+
+	if err != nil {
+		klog.Errorf("Failed to patch PersistentVolume %s after retries: %v\n", pvName, err)
+	}
+	return err
 }

--- a/pkg/k8sclient/client.go
+++ b/pkg/k8sclient/client.go
@@ -145,7 +145,15 @@ func listPodsInNamespace(ctx context.Context, kubeClient kubernetes.Interface, n
 	return podList, err
 }
 
-func updatePVAnnotation(ctx context.Context, kubeClient kubernetes.Interface, pvName string, annotationKey string, annotationValue string) error {
+// UpdatePVAnnotation safely adds, updates, or removes an annotation on a PersistentVolume.
+// Pass "" or "null" as the annotationValue to remove the annotation.
+func UpdatePVAnnotation(ctx context.Context, pvName string, annotationKey string, annotationValue string) error {
+	// 1. Fetch the kubeClient automatically (Matches the pattern of this file!)
+	kubeClient, err := GetClient()
+	if err != nil {
+		return fmt.Errorf("failed to get kubernetes client: %w", err)
+	}
+
 	var patchPayload []byte
 	var patchType types.PatchType
 
@@ -169,10 +177,11 @@ func updatePVAnnotation(ctx context.Context, kubeClient kubernetes.Interface, pv
 		patchType = types.MergePatchType
 	}
 
-	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(_ context.Context) (bool, error) {
-		_, err := kubeClient.CoreV1().PersistentVolumes().Patch(ctx, pvName, patchType, patchPayload, metav1.PatchOptions{})
-		if err != nil {
-			klog.Warningf("Error patching annotation %s on PersistentVolume %s: %v, retrying...\n", annotationKey, pvName, err)
+	// 2. Execute the patch with Exponential Backoff
+	err = wait.ExponentialBackoffWithContext(ctx, backoff, func(_ context.Context) (bool, error) {
+		_, patchErr := kubeClient.CoreV1().PersistentVolumes().Patch(ctx, pvName, patchType, patchPayload, metav1.PatchOptions{})
+		if patchErr != nil {
+			klog.Warningf("Error patching annotation %s on PersistentVolume %s: %v, retrying...\n", annotationKey, pvName, patchErr)
 			return false, nil // returning false causes it to retry
 		}
 		klog.V(4).Infof("Successfully patched annotation %s on PersistentVolume %s\n", annotationKey, pvName)

--- a/pkg/parameters/parameters.go
+++ b/pkg/parameters/parameters.go
@@ -319,6 +319,12 @@ func ExtractModifyVolumeParameters(parameters map[string]string) (ModifyVolumePa
 				return ModifyVolumeParameters{}, fmt.Errorf("parameters contain invalid throughput parameter: %w", err)
 			}
 			modifyVolumeParams.Throughput = &throughput
+		case "type":
+			diskType := strings.ToLower(strings.TrimSpace(value))
+			if diskType == "" {
+				return ModifyVolumeParameters{}, fmt.Errorf("parameters contain empty type parameter")
+			}
+			modifyVolumeParams.DiskType = &diskType
 		default:
 			return ModifyVolumeParameters{}, fmt.Errorf("parameters contain unknown parameter: %s", key)
 		}

--- a/pkg/parameters/parameters_test.go
+++ b/pkg/parameters/parameters_test.go
@@ -694,3 +694,59 @@ func TestExtractModifyVolumeParameters(t *testing.T) {
 		t.Errorf("Got ExtractModifyVolumeParameters(%+v) = %+v; want: %v", parameters, result, expected)
 	}
 }
+
+func TestExtractModifyVolumeParametersDiskType(t *testing.T) {
+	hyperdiskBalanced := "hyperdisk-balanced"
+	iops := int64(3000)
+
+	testCases := []struct {
+		name       string
+		parameters map[string]string
+		expected   ModifyVolumeParameters
+		expectErr  bool
+	}{
+		{
+			name:       "type only",
+			parameters: map[string]string{"type": "hyperdisk-balanced"},
+			expected:   ModifyVolumeParameters{DiskType: &hyperdiskBalanced},
+		},
+		{
+			name:       "type is case insensitive and trimmed",
+			parameters: map[string]string{"type": "  Hyperdisk-Balanced  "},
+			expected:   ModifyVolumeParameters{DiskType: &hyperdiskBalanced},
+		},
+		{
+			name:       "type alongside iops",
+			parameters: map[string]string{"type": "hyperdisk-balanced", "iops": "3000"},
+			expected:   ModifyVolumeParameters{DiskType: &hyperdiskBalanced, IOPS: &iops},
+		},
+		{
+			name:       "empty type is rejected",
+			parameters: map[string]string{"type": "  "},
+			expectErr:  true,
+		},
+		{
+			name:       "unknown parameter is still rejected",
+			parameters: map[string]string{"disktype": "hyperdisk-balanced"},
+			expectErr:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ExtractModifyVolumeParameters(tc.parameters)
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("ExtractModifyVolumeParameters(%+v) = %+v; want error", tc.parameters, result)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("Got ExtractModifyVolumeParameters(%+v) = %+v; want: %+v", tc.parameters, result, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/parameters/types.go
+++ b/pkg/parameters/types.go
@@ -130,4 +130,5 @@ func (pp *ParameterProcessor) isDynamicVolumesDisabled() bool {
 type ModifyVolumeParameters struct {
 	IOPS       *int64
 	Throughput *int64
+	DiskType   *string
 }


### PR DESCRIPTION
# [FEAT] Implement PV annotation state tracking for VAC conversions

## What it does / Why we need it
As part of the PD to Hyperdisk Dynamic Migration feature, disk conversions can take several hours to complete. Relying on in-memory goroutines to track this state is dangerous; if the CSI driver pod restarts, the state is lost. 

This PR implements a Declarative State Machine using Kubernetes PersistentVolume (PV) annotations as the durable source of truth. It establishes the foundational tracking required to safely queue, monitor, and clean up disk type conversions without risking data corruption.

## Technical Implementation
* **`pkg/constants/constants.go`**: Added PRD annotation keys (`...-operation`, `-converted-to`, `-converted-from`) and `"Pending"` state.
* **`pkg/k8sclient/k8sclient.go`**: Created `UpdatePVAnnotation` helper using JSON/Merge patching and exponential backoff.
* **`controller.go` (Attached Deferrals)**: Injects `"Pending"` annotation and returns `FailedPrecondition` if user requests conversion on an attached disk (`len(users) > 0`).
* **`controller.go` (Busy States)**: Maintains `"Pending"` annotation if GCP returns `isConversionInProgressError`.
* **`controller.go` (Completion Cleanup)**: Writes `disk-type-converted-to` and deletes the `"Pending"` annotation once physical GCP disk type matches the VAC request.

## Fixes
* **Failure Mode 1 (Attached Disks)**: Blocks upgrades on active disks to protect data, and writes a `"Pending"` annotation on the PV so the system remembers to do the upgrade later even if the driver crashes.

## Next Steps
* [ ] Implement detach trigger hook in `ControllerUnpublishVolume`.
* [ ] Implement asynchronous GCP operation polling loop.
* [ ] Implement attach-time safety block (Fail-Closed) in `ControllerPublishVolume`.