### PR TITLE
fix: remove inaccurate pd disk types from gen4 vms in node-labeler configmap

### DIFF
--- a/deploy/kubernetes/overlays/node-labeler/configmap.yaml
+++ b/deploy/kubernetes/overlays/node-labeler/configmap.yaml
@@ -78,9 +78,7 @@ data:
         "hyperdisk-balanced-high-availability": true,
         "hyperdisk-extreme": true,
         "hyperdisk-ml": true,
-        "hyperdisk-throughput": true,
-        "pd-balanced": true,
-        "pd-ssd": true
+        "hyperdisk-throughput": true
       },
       "c4d": {
         "hyperdisk-balanced": true,
@@ -210,9 +208,7 @@ data:
       "n4": {
         "hyperdisk-balanced": true,
         "hyperdisk-balanced-high-availability": true,
-        "hyperdisk-throughput": true,
-        "pd-balanced": true,
-        "pd-ssd": true
+        "hyperdisk-throughput": true
       },
       "n4a": {
         "hyperdisk-balanced": true,


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Remove inaccurate Persistent Disk (`pd-*`) disk types (`pd-balanced`, `pd-ssd`) from gen4 VM entries (`c4a`, `n4`) in `deploy/kubernetes/overlays/node-labeler/configmap.yaml`. Gen4 VMs only support Hyperdisk.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
