### PR TITLE
Bump gcp-compute-persistent-disk-csi-driver image to v1.26.5

### DIFF
--- a/deploy/kubernetes/images/stable-master/image.yaml
+++ b/deploy/kubernetes/images/stable-master/image.yaml
@@ -46,6 +46,6 @@ imageTag:
   name: gke.gcr.io/gcp-compute-persistent-disk-csi-driver
   # pdImagePlaceholder in test/k8s-integration/main.go is updated automatically with the newTag
   newName: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-  newTag: "v1.17.4"
+  newTag: "v1.26.5"
 ---
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The `stable-master` image.yaml on the `release-1.26` branch pins `gcp-compute-persistent-disk-csi-driver` to `v1.17.4`, well behind the `v1.26.x` line — `v1.26.5` is the latest release on this branch. This bumps the driver image tag to `v1.26.5` so the overlay matches the branch it ships on.

**Special notes for your reviewer**:
Mirrors #2343, which made the same fix on `master`; this applies it to `release-1.26`.

```release-note
NONE
```
