### PR TITLE
Add ResponseHeaderTimeout to GCE oauth http client transport

### DIFF
--- a/pkg/gce-cloud-provider/compute/gce.go
+++ b/pkg/gce-cloud-provider/compute/gce.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -443,7 +444,28 @@ func newOauthClient(ctx context.Context, tokenSource oauth2.TokenSource, timeout
 		return nil, err
 	}
 
-	return oauth2.NewClient(ctx, tokenSource), nil
+	// Configure custom transport with ResponseHeaderTimeout to ensure hung GCE API
+	// socket reads fail fast and release driver volume locks.
+	baseTransport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: 60 * time.Second,
+	}
+
+	customClient := &http.Client{
+		Transport: baseTransport,
+	}
+
+	ctxWithClient := context.WithValue(ctx, oauth2.HTTPClient, customClient)
+	return oauth2.NewClient(ctxWithClient, tokenSource), nil
 }
 
 func getProjectAndZone(config *ConfigFile) (string, string, error) {

--- a/pkg/gce-cloud-provider/compute/gce_test.go
+++ b/pkg/gce-cloud-provider/compute/gce_test.go
@@ -270,3 +270,46 @@ func TestCreateCloudService(t *testing.T) {
 		})
 	}
 }
+
+func TestNewOauthClient_TransportConfig(t *testing.T) {
+	ctx := context.Background()
+	client, err := newOauthClient(ctx, &mockTokenSource{}, 5*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error creating oauth client: %v", err)
+	}
+	if client == nil {
+		t.Fatalf("expected non-nil client")
+	}
+
+	oauth2Transport, ok := client.Transport.(*oauth2.Transport)
+	if !ok {
+		t.Fatalf("expected client.Transport to be *oauth2.Transport, got %T", client.Transport)
+	}
+
+	baseTransport, ok := oauth2Transport.Base.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected oauth2Transport.Base to be *http.Transport, got %T", oauth2Transport.Base)
+	}
+
+	if baseTransport.ResponseHeaderTimeout != 60*time.Second {
+		t.Errorf("expected ResponseHeaderTimeout to be 60s, got %v", baseTransport.ResponseHeaderTimeout)
+	}
+	if !baseTransport.ForceAttemptHTTP2 {
+		t.Errorf("expected ForceAttemptHTTP2 to be true, got %v", baseTransport.ForceAttemptHTTP2)
+	}
+	if baseTransport.MaxIdleConns != 100 {
+		t.Errorf("expected MaxIdleConns to be 100, got %v", baseTransport.MaxIdleConns)
+	}
+	if baseTransport.IdleConnTimeout != 90*time.Second {
+		t.Errorf("expected IdleConnTimeout to be 90s, got %v", baseTransport.IdleConnTimeout)
+	}
+	if baseTransport.TLSHandshakeTimeout != 10*time.Second {
+		t.Errorf("expected TLSHandshakeTimeout to be 10s, got %v", baseTransport.TLSHandshakeTimeout)
+	}
+	if baseTransport.ExpectContinueTimeout != 1*time.Second {
+		t.Errorf("expected ExpectContinueTimeout to be 1s, got %v", baseTransport.ExpectContinueTimeout)
+	}
+	if baseTransport.DialContext == nil {
+		t.Errorf("expected DialContext to be non-nil")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Configure custom http.Transport with ResponseHeaderTimeout: 30s in newOauthClient to ensure that stalled GCE API socket reads fail fast. This allows the driver's CreateVolume and other CSI operations to return errors promptly upon endpoint hangs, triggering defer volumeLocks.Release and preventing in-memory volume lock deadlocks on subsequent retries.

**Special notes for your reviewer**:
Added testing logs and verification plan in b/552618197

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add 60s ResponseHeaderTimeout to GCE oauth http client transport
```
