### PR TITLE
fix: deterministic attach-cycle UUID and in-flight operation tracking

### DIFF
--- a/pkg/gce-cloud-provider/compute/cloud-disk.go
+++ b/pkg/gce-cloud-provider/compute/cloud-disk.go
@@ -311,3 +311,25 @@ func (d *CloudDisk) GetProvisionedThroughput() int64 {
 		return 0
 	}
 }
+
+func (d *CloudDisk) GetLastDetachTimestamp() string {
+	switch {
+	case d.disk != nil:
+		return d.disk.LastDetachTimestamp
+	case d.betaDisk != nil:
+		return d.betaDisk.LastDetachTimestamp
+	default:
+		return ""
+	}
+}
+
+func (d *CloudDisk) GetCreationTimestamp() string {
+	switch {
+	case d.disk != nil:
+		return d.disk.CreationTimestamp
+	case d.betaDisk != nil:
+		return d.betaDisk.CreationTimestamp
+	default:
+		return ""
+	}
+}

--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -61,6 +61,7 @@ type FakeCloudProvider struct {
 	instances  map[string]*computev1.Instance
 	snapshots  map[string]*computev1.Snapshot
 	images     map[string]*computev1.Image
+	operations map[string]*computev1.Operation
 
 	// PD-on-Gen4 conversion testing fields
 	ConversionTestParams ConversionTestParams
@@ -89,6 +90,7 @@ func CreateFakeCloudProvider(project, zone string, cloudDisks []*CloudDisk) (*Fa
 		instances:  map[string]*computev1.Instance{},
 		snapshots:  map[string]*computev1.Snapshot{},
 		images:     map[string]*computev1.Image{},
+		operations: map[string]*computev1.Operation{},
 		pageTokens: map[string]sets.String{},
 		// A newly created disk is marked READY by default.
 		mockDiskStatus: "READY",
@@ -279,7 +281,7 @@ func (cloud *FakeCloudProvider) DeleteDisk(ctx context.Context, project string, 
 	return nil
 }
 
-func (cloud *FakeCloudProvider) AttachDisk(ctx context.Context, project string, volKey *meta.Key, readWrite, diskType, instanceZone, instanceName string, forceAttach bool) error {
+func (cloud *FakeCloudProvider) AttachDisk(ctx context.Context, project string, volKey *meta.Key, readWrite, diskType, instanceZone, instanceName string, forceAttach bool, reqID string) error {
 	cloud.ConversionTestParams.AttachCallCount++
 	if cloud.ConversionTestParams.AttachCallCount == 1 && cloud.ConversionTestParams.InitialAttachFails {
 		return fmt.Errorf("Please run the conversion tool to reset the supported VM families of this disk")
@@ -320,6 +322,31 @@ func (cloud *FakeCloudProvider) ConvertDisk(ctx context.Context, project string,
 	return nil
 }
 
+func (cloud *FakeCloudProvider) GetOperationByClientOpID(ctx context.Context, project, instanceZone, clientOpID string) (*computev1.Operation, error) {
+	if clientOpID == "" {
+		return nil, nil
+	}
+	for _, op := range cloud.operations {
+		if op.ClientOperationId == clientOpID {
+			return op, nil
+		}
+	}
+	return nil, nil
+}
+
+func (cloud *FakeCloudProvider) WaitForZonalOp(ctx context.Context, project, opName string, zone string) error {
+	if op, ok := cloud.operations[opName]; ok {
+		op.Status = "DONE"
+	}
+	return nil
+}
+
+func (cloud *FakeCloudProvider) InsertOperation(op *computev1.Operation) {
+	if cloud.operations == nil {
+		cloud.operations = make(map[string]*computev1.Operation)
+	}
+	cloud.operations[op.Name] = op
+}
 func (cloud *FakeCloudProvider) DetachDisk(ctx context.Context, project, deviceName, instanceZone, instanceName string) error {
 	instance, ok := cloud.instances[instanceName]
 	if !ok {
@@ -627,14 +654,14 @@ func (cloud *FakeBlockingCloudProvider) DetachDisk(ctx context.Context, project,
 	return cloud.FakeCloudProvider.DetachDisk(ctx, project, deviceName, instanceZone, instanceName)
 }
 
-func (cloud *FakeBlockingCloudProvider) AttachDisk(ctx context.Context, project string, volKey *meta.Key, readWrite, diskType, instanceZone, instanceName string, forceAttach bool) error {
+func (cloud *FakeBlockingCloudProvider) AttachDisk(ctx context.Context, project string, volKey *meta.Key, readWrite, diskType, instanceZone, instanceName string, forceAttach bool, reqID string) error {
 	execute := make(chan Signal)
 	cloud.ReadyToExecute <- execute
 	val := <-execute
 	if val.ReportError {
 		return fmt.Errorf("force mock error for AttachDisk: volkey %s", volKey)
 	}
-	return cloud.FakeCloudProvider.AttachDisk(ctx, project, volKey, readWrite, diskType, instanceZone, instanceName, forceAttach)
+	return cloud.FakeCloudProvider.AttachDisk(ctx, project, volKey, readWrite, diskType, instanceZone, instanceName, forceAttach, reqID)
 }
 
 func notFoundError() *googleapi.Error {

--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -115,7 +115,9 @@ type GCECompute interface {
 	InsertDisk(ctx context.Context, project string, volKey *meta.Key, params parameters.DiskParameters, capBytes int64, capacityRange *csi.CapacityRange, replicaZones []string, snapshotID string, volumeContentSourceVolumeID string, multiWriter bool, accessMode string) error
 	DeleteDisk(ctx context.Context, project string, volumeKey *meta.Key) error
 	UpdateDisk(ctx context.Context, project string, volKey *meta.Key, existingDisk *CloudDisk, params parameters.ModifyVolumeParameters) error
-	AttachDisk(ctx context.Context, project string, volKey *meta.Key, readWrite, diskType, instanceZone, instanceName string, forceAttach bool) error
+	AttachDisk(ctx context.Context, project string, volKey *meta.Key, readWrite, diskType, instanceZone, instanceName string, forceAttach bool, reqID string) error
+	GetOperationByClientOpID(ctx context.Context, project, instanceZone, clientOpID string) (*computev1.Operation, error)
+	WaitForZonalOp(ctx context.Context, project, opName string, zone string) error
 	DetachDisk(ctx context.Context, project, deviceName, instanceZone, instanceName string) error
 	ConvertDisk(ctx context.Context, project string, volKey *meta.Key, instanceName, instanceZone string, quickConversionOnly bool) error
 	SetDiskAccessMode(ctx context.Context, project string, volKey *meta.Key, accessMode string) error
@@ -680,7 +682,7 @@ func (cloud *CloudProvider) insertConstructedDisk(ctx context.Context, disk *com
 
 	klog.V(5).Infof("InsertDisk operation %s for disk %s", opName, disk.Name)
 	if isZonal {
-		err = cloud.waitForZonalOp(ctx, project, opName, volKey.Zone)
+		err = cloud.WaitForZonalOp(ctx, project, opName, volKey.Zone)
 	} else {
 		err = cloud.waitForRegionalOp(ctx, project, opName, volKey.Region)
 	}
@@ -881,7 +883,7 @@ func (cloud *CloudProvider) deleteZonalDisk(ctx context.Context, project, zone, 
 	}
 	klog.V(5).Infof("DeleteDisk operation %s for disk %s", op.Name, name)
 
-	err = cloud.waitForZonalOp(ctx, project, op.Name, zone)
+	err = cloud.WaitForZonalOp(ctx, project, op.Name, zone)
 	if err != nil {
 		return err
 	}
@@ -906,8 +908,8 @@ func (cloud *CloudProvider) deleteRegionalDisk(ctx context.Context, project, reg
 	return nil
 }
 
-func (cloud *CloudProvider) AttachDisk(ctx context.Context, project string, volKey *meta.Key, readWrite, diskType, instanceZone, instanceName string, forceAttach bool) error {
-	klog.V(5).Infof("Attaching disk %v to %s", volKey, instanceName)
+func (cloud *CloudProvider) AttachDisk(ctx context.Context, project string, volKey *meta.Key, readWrite, diskType, instanceZone, instanceName string, forceAttach bool, reqID string) error {
+	klog.V(5).Infof("Attaching disk %v to %s (requestId: %s)", volKey, instanceName, reqID)
 	source := cloud.GetDiskSourceURI(project, volKey)
 
 	deviceName, err := common.GetDeviceName(volKey)
@@ -930,13 +932,17 @@ func (cloud *CloudProvider) AttachDisk(ctx context.Context, project string, volK
 	if _, ok := cloud.tenantServiceMap[project]; ok {
 		service = cloud.tenantServiceMap[project]
 	}
-	op, err := service.Instances.AttachDisk(project, instanceZone, instanceName, attachedDiskV1).Context(ctx).ForceAttach(forceAttach).Do()
+	op, err := service.Instances.AttachDisk(project, instanceZone, instanceName, attachedDiskV1).
+		Context(ctx).
+		ForceAttach(forceAttach).
+		RequestId(reqID).
+		Do()
 	if err != nil {
 		return fmt.Errorf("failed cloud service attach disk call: %w", err)
 	}
-	klog.V(5).Infof("AttachDisk operation %s for disk %s", op.Name, attachedDiskV1.DeviceName)
+	klog.V(5).Infof("AttachDisk operation %s (requestId: %s) for disk %s", op.Name, reqID, attachedDiskV1.DeviceName)
 
-	err = cloud.waitForZonalOp(ctx, project, op.Name, instanceZone)
+	err = cloud.WaitForZonalOp(ctx, project, op.Name, instanceZone)
 	if err != nil {
 		return fmt.Errorf("failed when waiting for zonal op: %w", err)
 	}
@@ -955,7 +961,7 @@ func (cloud *CloudProvider) DetachDisk(ctx context.Context, project, deviceName,
 	}
 	klog.V(5).Infof("DetachDisk operation %s for disk %s", op.Name, deviceName)
 
-	err = cloud.waitForZonalOp(ctx, project, op.Name, instanceZone)
+	err = cloud.WaitForZonalOp(ctx, project, op.Name, instanceZone)
 	if err != nil {
 		return err
 	}
@@ -979,7 +985,7 @@ func (cloud *CloudProvider) ConvertDisk(ctx context.Context, project string, vol
 	klog.V(5).Infof("Convert operation %s for disk %s", op.Name, volKey.Name)
 
 	if quickConversionOnly {
-		err = cloud.waitForZonalOp(ctx, project, op.Name, volKey.Zone)
+		err = cloud.WaitForZonalOp(ctx, project, op.Name, volKey.Zone)
 	} else {
 		err = cloud.waitForLongRunningZonalOp(ctx, project, op.Name, volKey.Zone)
 	}
@@ -1003,7 +1009,7 @@ func (cloud *CloudProvider) SetDiskAccessMode(ctx context.Context, project strin
 		}
 		klog.V(5).Infof("SetDiskAccessMode operation %s for disk %s", op.Name, volKey.Name)
 
-		err = cloud.waitForZonalOp(ctx, project, op.Name, volKey.Zone)
+		err = cloud.WaitForZonalOp(ctx, project, op.Name, volKey.Zone)
 		if err != nil {
 			return fmt.Errorf("failed waiting for op for zonal disk update for %v: %w", volKey, err)
 		}
@@ -1038,7 +1044,7 @@ func (cloud *CloudProvider) SetDiskLabels(ctx context.Context, project string, v
 		}
 		klog.V(5).Infof("SetDiskLabels operation %s for disk %s", op.Name, volKey.Name)
 
-		err = cloud.waitForZonalOp(ctx, project, op.Name, volKey.Zone)
+		err = cloud.WaitForZonalOp(ctx, project, op.Name, volKey.Zone)
 		if err != nil {
 			return fmt.Errorf("failed waiting for op for zonal disk label update for %v: %w", volKey, err)
 		}
@@ -1142,7 +1148,28 @@ func (cloud *CloudProvider) getRegionalDiskTypeURI(project string, region, diskT
 	return cloud.service.BasePath + fmt.Sprintf(diskTypeURITemplateRegional, project, region, diskType)
 }
 
-func (cloud *CloudProvider) waitForZonalOp(ctx context.Context, project, opName string, zone string) error {
+func (cloud *CloudProvider) GetOperationByClientOpID(ctx context.Context, project, instanceZone, clientOpID string) (*computev1.Operation, error) {
+	if clientOpID == "" {
+		return nil, nil
+	}
+	service := cloud.service
+	if _, ok := cloud.tenantServiceMap[project]; ok {
+		service = cloud.tenantServiceMap[project]
+	}
+	filter := fmt.Sprintf("clientOperationId = %s", clientOpID)
+	opList, err := service.ZoneOperations.List(project, instanceZone).Filter(filter).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list zonal operations for clientOperationId %s: %w", clientOpID, err)
+	}
+	for _, op := range opList.Items {
+		if op.ClientOperationId == clientOpID {
+			return op, nil
+		}
+	}
+	return nil, nil
+}
+
+func (cloud *CloudProvider) WaitForZonalOp(ctx context.Context, project, opName string, zone string) error {
 	return cloud.waitForZonalOpWithBackoff(ctx, project, opName, zone, WaitForOpBackoff)
 }
 
@@ -1587,7 +1614,7 @@ func (cloud *CloudProvider) resizeZonalDisk(ctx context.Context, project string,
 
 	klog.V(5).Infof("ResizeDisk operation %s for disk %s", op.Name, volKey.Name)
 
-	err = cloud.waitForZonalOp(ctx, project, op.Name, volKey.Zone)
+	err = cloud.WaitForZonalOp(ctx, project, op.Name, volKey.Zone)
 	if err != nil {
 		return -1, fmt.Errorf("failed waiting for op for zonal resize for %s: %w", volKey.String(), err)
 	}

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	googleuuid "github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/util/flowcontrol"
@@ -1263,7 +1264,8 @@ func (gceCS *GCEControllerServer) executeControllerPublishVolume(ctx context.Con
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "could not split nodeID: %v", err.Error()), disk
 	}
-	err = gceCS.CloudProvider.AttachDisk(ctx, project, volKey, readWrite, attachableDiskTypePersistent, instanceZone, instanceName, pdcsiContext.ForceAttach)
+	reqID := generateAttachCycleUUID(volumeID, nodeID, disk)
+	err = gceCS.CloudProvider.AttachDisk(ctx, project, volKey, readWrite, attachableDiskTypePersistent, instanceZone, instanceName, pdcsiContext.ForceAttach, reqID)
 	if err != nil {
 		var udErr *gce.UnsupportedDiskError
 		if errors.As(err, &udErr) {
@@ -1274,7 +1276,7 @@ func (gceCS *GCEControllerServer) executeControllerPublishVolume(ctx context.Con
 		}
 		klog.Infof("Received error from AttachDisk: %s", err.Error())
 		if isConversionRequiredError(err) {
-			err = gceCS.convertDiskAndReAttach(ctx, project, volKey, disk, pdcsiContext, readWrite, instanceZone, instanceName)
+			err = gceCS.convertDiskAndReAttach(ctx, project, volKey, disk, pdcsiContext, readWrite, instanceZone, instanceName, reqID)
 		}
 		if err != nil {
 			return nil, common.LoggedError("Failed to Attach: ", err), disk
@@ -1295,7 +1297,7 @@ func isConversionRequiredError(err error) bool {
 	return strings.Contains(err.Error(), "Please run the conversion tool to reset the supported VM families of this disk")
 }
 
-func (gceCS *GCEControllerServer) convertDiskAndReAttach(ctx context.Context, project string, volKey *meta.Key, disk *gce.CloudDisk, pdcsiContext *PDCSIContext, readWrite, instanceZone, instanceName string) error {
+func (gceCS *GCEControllerServer) convertDiskAndReAttach(ctx context.Context, project string, volKey *meta.Key, disk *gce.CloudDisk, pdcsiContext *PDCSIContext, readWrite, instanceZone, instanceName, reqID string) error {
 	if !gceCS.EnablePdConversion {
 		klog.Info("PD conversion feature is not enabled, skipping automated conversion logic")
 		return nil
@@ -1307,7 +1309,7 @@ func (gceCS *GCEControllerServer) convertDiskAndReAttach(ctx context.Context, pr
 	if convertErr == nil {
 		klog.Infof("Fast conversion for disk (%s) succeeded, retrying attach", volKey.Name)
 		metrics.SetConversionResult(ctx, "fast")
-		return gceCS.CloudProvider.AttachDisk(ctx, project, volKey, readWrite, attachableDiskTypePersistent, instanceZone, instanceName, pdcsiContext.ForceAttach)
+		return gceCS.CloudProvider.AttachDisk(ctx, project, volKey, readWrite, attachableDiskTypePersistent, instanceZone, instanceName, pdcsiContext.ForceAttach, reqID)
 	} else if !isSlowConversionRequiredError(convertErr) {
 		klog.Infof("Ran into an unknown conversion error for disk (%s)", volKey.Name)
 		return fmt.Errorf("unknown error while attempting fast conversion: %w", convertErr)
@@ -1326,7 +1328,7 @@ func (gceCS *GCEControllerServer) convertDiskAndReAttach(ctx context.Context, pr
 			return fmt.Errorf("unknown error while attempting slow conversion: %w", convertErr)
 		}
 		metrics.SetConversionResult(ctx, "slow")
-		return gceCS.CloudProvider.AttachDisk(ctx, project, volKey, readWrite, attachableDiskTypePersistent, instanceZone, instanceName, pdcsiContext.ForceAttach)
+		return gceCS.CloudProvider.AttachDisk(ctx, project, volKey, readWrite, attachableDiskTypePersistent, instanceZone, instanceName, pdcsiContext.ForceAttach, reqID)
 	} else {
 		klog.Infof("Disk (%s) is not opted-in, aborting attach attempt", volKey.Name)
 	}
@@ -1519,6 +1521,12 @@ func (gceCS *GCEControllerServer) executeControllerUnpublishVolume(ctx context.C
 	}
 
 	attached := diskIsAttached(deviceName, instance)
+	if !attached {
+		attached, err = gceCS.waitForInflightAttach(ctx, project, volumeID, nodeID, instanceZone, instanceName, deviceName, diskToUnpublish)
+		if err != nil {
+			return nil, err, diskToUnpublish
+		}
+	}
 
 	if !attached {
 		// Volume is not attached to node. Success!
@@ -1532,6 +1540,42 @@ func (gceCS *GCEControllerServer) executeControllerUnpublishVolume(ctx context.C
 
 	klog.V(4).Infof("ControllerUnpublishVolume succeeded for disk %v from node %v", volKey, nodeID)
 	return &csi.ControllerUnpublishVolumeResponse{}, nil, diskToUnpublish
+}
+
+func (gceCS *GCEControllerServer) waitForInflightAttach(ctx context.Context, project, volumeID, nodeID, instanceZone, instanceName, deviceName string, disk *gce.CloudDisk) (bool, error) {
+	if disk == nil {
+		klog.Warningf("Could not check in-flight attach operation for volume %v on node %v because disk could not be retrieved", volumeID, nodeID)
+		return false, nil
+	}
+
+	reqID := generateAttachCycleUUID(volumeID, nodeID, disk)
+	op, err := gceCS.CloudProvider.GetOperationByClientOpID(ctx, project, instanceZone, reqID)
+	if err != nil {
+		return false, fmt.Errorf("failed to check attach operations: %w", err)
+	}
+	if op == nil {
+		return false, nil
+	}
+
+	if op.Status != "DONE" {
+		klog.Infof("Waiting for in-flight attach operation %s (requestId: %s) for volume %s on node %s", op.Name, reqID, volumeID, instanceName)
+		err = gceCS.CloudProvider.WaitForZonalOp(ctx, project, op.Name, instanceZone)
+		if err != nil {
+			return false, fmt.Errorf("failed when waiting for in-flight attach operation %s: %w", op.Name, err)
+		}
+	}
+
+	// Refresh instance to verify if disk attached
+	instance, err := gceCS.CloudProvider.GetInstanceOrError(ctx, project, instanceZone, instanceName)
+	if err != nil {
+		if gce.IsGCENotFoundError(err) {
+			klog.Warningf("Treating volume %v as unpublished because node %v could not be found", volumeID, instanceName)
+			return false, nil
+		}
+		return false, common.LoggedError("error getting instance after checking attach operation: ", err)
+	}
+
+	return diskIsAttached(deviceName, instance), nil
 }
 
 func (gceCS *GCEControllerServer) parameterProcessor() *parameters.ParameterProcessor {
@@ -2400,6 +2444,18 @@ func getRequestCapacity(capRange *csi.CapacityRange) (int64, error) {
 		capBytes = MinimumVolumeSizeInBytes
 	}
 	return capBytes, nil
+}
+
+func generateAttachCycleUUID(volumeID, nodeID string, disk *gce.CloudDisk) string {
+	incarnation := ""
+	if disk != nil {
+		incarnation = disk.GetLastDetachTimestamp()
+		if incarnation == "" {
+			incarnation = disk.GetCreationTimestamp()
+		}
+	}
+	seed := fmt.Sprintf("%s/%s/%s", volumeID, nodeID, incarnation)
+	return googleuuid.NewSHA1(googleuuid.NameSpaceURL, []byte(seed)).String()
 }
 
 func diskIsAttached(deviceName string, instance *compute.Instance) bool {

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	googleuuid "github.com/google/uuid"
 
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
@@ -6280,15 +6281,15 @@ func mergeParameters(a map[string]string, b map[string]string) map[string]string
 }
 
 func TestListVolumes_Concurrent(t *testing.T) {
-	var d []*gce.CloudDisk
+	var d []*gcecloudprovider.CloudDisk
 	for i := 0; i < 50; i++ {
 		name := fmt.Sprintf("disk-%v", i)
-		d = append(d, gce.CloudDiskFromV1(&compute.Disk{
+		d = append(d, gcecloudprovider.CloudDiskFromV1(&compute.Disk{
 			Name:     name,
 			SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/disks/%s", project, zone, name),
 		}))
 	}
-	fakeCloudProvider, err := gce.CreateFakeCloudProvider(project, zone, d)
+	fakeCloudProvider, err := gcecloudprovider.CreateFakeCloudProvider(project, zone, d)
 	if err != nil {
 		t.Fatalf("Failed to create fake cloud provider: %v", err)
 	}
@@ -6330,15 +6331,15 @@ func TestListVolumes_Concurrent(t *testing.T) {
 
 func TestListSnapshots_Concurrent(t *testing.T) {
 	// Create source disks in mock provider
-	var d []*gce.CloudDisk
+	var d []*gcecloudprovider.CloudDisk
 	for i := 0; i < 50; i++ {
 		name := fmt.Sprintf("disk-%v", i)
-		d = append(d, gce.CloudDiskFromV1(&compute.Disk{
+		d = append(d, gcecloudprovider.CloudDiskFromV1(&compute.Disk{
 			Name:     name,
 			SelfLink: fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/disks/%s", project, zone, name),
 		}))
 	}
-	fakeCloudProvider, err := gce.CreateFakeCloudProvider(project, zone, d)
+	fakeCloudProvider, err := gcecloudprovider.CreateFakeCloudProvider(project, zone, d)
 	if err != nil {
 		t.Fatalf("Failed to create fake cloud provider: %v", err)
 	}
@@ -6390,4 +6391,179 @@ func TestListSnapshots_Concurrent(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestGenerateAttachCycleUUID(t *testing.T) {
+	volID := "projects/my-proj/zones/us-central1-a/disks/pvc-123"
+	nodeID := "projects/my-proj/zones/us-central1-a/instances/node-1"
+
+	// 1. New disk without LastDetachTimestamp uses CreationTimestamp
+	disk1 := gcecloudprovider.CloudDiskFromV1(&compute.Disk{
+		Name:              "pvc-123",
+		CreationTimestamp: "2026-01-01T00:00:00.000Z",
+	})
+	uuid1 := generateAttachCycleUUID(volID, nodeID, disk1)
+	if _, err := googleuuid.Parse(uuid1); err != nil {
+		t.Fatalf("expected valid RFC 4122 UUID, got %s: %v", uuid1, err)
+	}
+
+	// Deterministic: same disk and node produce exact same UUID
+	uuid1Repeat := generateAttachCycleUUID(volID, nodeID, disk1)
+	if uuid1 != uuid1Repeat {
+		t.Fatalf("expected deterministic UUID %s, got %s", uuid1, uuid1Repeat)
+	}
+
+	// 2. Disk with LastDetachTimestamp uses LastDetachTimestamp
+	disk2 := gcecloudprovider.CloudDiskFromV1(&compute.Disk{
+		Name:                "pvc-123",
+		CreationTimestamp:   "2026-01-01T00:00:00.000Z",
+		LastDetachTimestamp: "2026-01-02T10:00:00.000Z",
+	})
+	uuid2 := generateAttachCycleUUID(volID, nodeID, disk2)
+	if _, err := googleuuid.Parse(uuid2); err != nil {
+		t.Fatalf("expected valid RFC 4122 UUID, got %s: %v", uuid2, err)
+	}
+	if uuid1 == uuid2 {
+		t.Fatalf("expected different UUID after detach, got same %s", uuid1)
+	}
+
+	// 3. Subsequent detach updates timestamp and produces a new UUID
+	disk3 := gcecloudprovider.CloudDiskFromV1(&compute.Disk{
+		Name:                "pvc-123",
+		CreationTimestamp:   "2026-01-01T00:00:00.000Z",
+		LastDetachTimestamp: "2026-01-03T15:30:00.000Z",
+	})
+	uuid3 := generateAttachCycleUUID(volID, nodeID, disk3)
+	if uuid2 == uuid3 {
+		t.Fatalf("expected different UUID for subsequent detach cycle, got same %s", uuid2)
+	}
+}
+
+func TestControllerUnpublishWaitsForInflightAttach(t *testing.T) {
+	volID := fmt.Sprintf("projects/%s/zones/%s/disks/test-vol", project, zone)
+	nodeID := fmt.Sprintf("projects/%s/zones/%s/instances/test-node", project, zone)
+
+	disk := gcecloudprovider.CloudDiskFromV1(&compute.Disk{
+		Name:              "test-vol",
+		Zone:              zone,
+		CreationTimestamp: "2026-01-01T00:00:00.000Z",
+	})
+
+	fcp, err := gcecloudprovider.CreateFakeCloudProvider(project, zone, []*gcecloudprovider.CloudDisk{disk})
+	if err != nil {
+		t.Fatalf("Failed to create fake cloud provider: %v", err)
+	}
+
+	// Add instance without any attached disks
+	instance := &compute.Instance{
+		Name:  "test-node",
+		Zone:  zone,
+		Disks: []*compute.AttachedDisk{},
+	}
+	fcp.InsertInstance(instance, zone, "test-node")
+
+	// Calculate expected attach cycle UUID
+	reqID := generateAttachCycleUUID(volID, nodeID, disk)
+
+	// Simulate an in-flight attach operation with matching clientOperationId
+	op := &compute.Operation{
+		Name:              "operation-attach-123",
+		ClientOperationId: reqID,
+		Status:            "RUNNING",
+		OperationType:     "attachDisk",
+		TargetLink:        fmt.Sprintf("projects/%s/zones/%s/instances/test-node", project, zone),
+	}
+	fcp.InsertOperation(op)
+
+	gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{})
+
+	req := &csi.ControllerUnpublishVolumeRequest{
+		VolumeId: volID,
+		NodeId:   nodeID,
+	}
+
+	// ControllerUnpublishVolume should detect in-flight operation, wait for it (which marks it DONE in fake provider),
+	// and complete unpublish.
+	resp, err := gceDriver.cs.ControllerUnpublishVolume(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ControllerUnpublishVolume failed: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("expected non-nil response")
+	}
+
+	// Verify the operation was retrieved and completed (status is now DONE)
+	retrievedOp, err := fcp.GetOperationByClientOpID(context.Background(), project, zone, reqID)
+	if err != nil {
+		t.Fatalf("failed to query operations: %v", err)
+	}
+	if retrievedOp == nil || retrievedOp.Status != "DONE" {
+		t.Fatalf("expected operation status DONE, got %v", retrievedOp)
+	}
+}
+
+func TestControllerUnpublishHandlesOperationCompletedInRaceWindow(t *testing.T) {
+	volID := fmt.Sprintf("projects/%s/zones/%s/disks/test-vol", project, zone)
+	nodeID := fmt.Sprintf("projects/%s/zones/%s/instances/test-node", project, zone)
+
+	disk := gcecloudprovider.CloudDiskFromV1(&compute.Disk{
+		Name:              "test-vol",
+		Zone:              zone,
+		CreationTimestamp: "2026-01-01T00:00:00.000Z",
+	})
+
+	fcp, err := gcecloudprovider.CreateFakeCloudProvider(project, zone, []*gcecloudprovider.CloudDisk{disk})
+	if err != nil {
+		t.Fatalf("Failed to create fake cloud provider: %v", err)
+	}
+
+	// Add instance where disk is already attached in backend
+	instance := &compute.Instance{
+		Name: "test-node",
+		Zone: zone,
+		Disks: []*compute.AttachedDisk{
+			{
+				DeviceName: "test-vol",
+				Mode:       "READ_WRITE",
+			},
+		},
+	}
+	fcp.InsertInstance(instance, zone, "test-node")
+
+	// Calculate expected attach cycle UUID
+	reqID := generateAttachCycleUUID(volID, nodeID, disk)
+
+	// Simulate completed operation (status DONE) in GCE
+	op := &compute.Operation{
+		Name:              "operation-attach-456",
+		ClientOperationId: reqID,
+		Status:            "DONE",
+		OperationType:     "attachDisk",
+		TargetLink:        fmt.Sprintf("projects/%s/zones/%s/instances/test-node", project, zone),
+	}
+	fcp.InsertOperation(op)
+
+	gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{})
+
+	req := &csi.ControllerUnpublishVolumeRequest{
+		VolumeId: volID,
+		NodeId:   nodeID,
+	}
+
+	resp, err := gceDriver.cs.ControllerUnpublishVolume(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ControllerUnpublishVolume failed: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("expected non-nil response")
+	}
+
+	// Verify disk was detached from the instance
+	updatedInstance, err := fcp.GetInstanceOrError(context.Background(), project, zone, "test-node")
+	if err != nil {
+		t.Fatalf("failed to get instance: %v", err)
+	}
+	if diskIsAttached("test-vol", updatedInstance) {
+		t.Fatalf("expected disk test-vol to be detached, but was still attached")
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Title: Fix stuck volume attachments on timed-out attach operations using deterministic request IDs

Bug References: b/456549021, b/455002758, b/539609334

Problem
When ControllerPublishVolume times out while an attach Long-Running Operation (LRO) is still in-flight in GCE, an immediate ControllerUnpublishVolume checks instance.Disks, prematurely assumes the disk is detached, and returns success. Kubernetes then deletes the VolumeAttachment, leaving the disk orphaned/attached to the old node and causing new pod attachments to fail indefinitely with RESOURCE_IN_USE_BY_ANOTHER_RESOURCE.

Fix (Option 3: Deterministic Request ID per Attach Cycle)
Makes attach operations traceable across restarts without storing state:

Deterministic UUID Generation: Generates an RFC 4122 UUIDv5 requestId seeded by volumeID/nodeID/LastDetachTimestamp (or CreationTimestamp on initial attach).

Attach Tracking: Passes the generated requestId to Instances.AttachDisk.

Unpublish In-Flight Check: In ControllerUnpublishVolume, recreates the deterministic requestId and checks ZoneOperations.List by clientOperationId. If an attach operation is in-flight, it waits for completion and proceeds with detachment, preventing premature success.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
