### PR TITLE
POC: In-flight attach operation tracking verification

### DIFF
--- a/pkg/gce-cloud-provider/compute/cloud-disk.go
+++ b/pkg/gce-cloud-provider/compute/cloud-disk.go
@@ -300,3 +300,25 @@ func (d *CloudDisk) GetProvisionedThroughput() int64 {
 		return 0
 	}
 }
+
+func (d *CloudDisk) GetLastDetachTimestamp() string {
+	switch {
+	case d.disk != nil:
+		return d.disk.LastDetachTimestamp
+	case d.betaDisk != nil:
+		return d.betaDisk.LastDetachTimestamp
+	default:
+		return ""
+	}
+}
+
+func (d *CloudDisk) GetCreationTimestamp() string {
+	switch {
+	case d.disk != nil:
+		return d.disk.CreationTimestamp
+	case d.betaDisk != nil:
+		return d.betaDisk.CreationTimestamp
+	default:
+		return ""
+	}
+}

--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -60,6 +60,7 @@ type FakeCloudProvider struct {
 	instances  map[string]*computev1.Instance
 	snapshots  map[string]*computev1.Snapshot
 	images     map[string]*computev1.Image
+	operations map[string]*computev1.Operation
 
 	// marker to set disk status during InsertDisk operation.
 	mockDiskStatus string
@@ -75,6 +76,7 @@ func CreateFakeCloudProvider(project, zone string, cloudDisks []*CloudDisk) (*Fa
 		instances:  map[string]*computev1.Instance{},
 		snapshots:  map[string]*computev1.Snapshot{},
 		images:     map[string]*computev1.Image{},
+		operations: map[string]*computev1.Operation{},
 		pageTokens: map[string]sets.String{},
 		// A newly created disk is marked READY by default.
 		mockDiskStatus: "READY",
@@ -292,7 +294,7 @@ func (cloud *FakeCloudProvider) DeleteDisk(ctx context.Context, project string, 
 	return nil
 }
 
-func (cloud *FakeCloudProvider) AttachDisk(ctx context.Context, project string, volKey *meta.Key, readWrite, diskType, instanceZone, instanceName string, forceAttach bool) error {
+func (cloud *FakeCloudProvider) AttachDisk(ctx context.Context, project string, volKey *meta.Key, readWrite, diskType, instanceZone, instanceName string, forceAttach bool, reqID string) error {
 	source := cloud.GetDiskSourceURI(project, volKey)
 
 	attachedDiskV1 := &computev1.AttachedDisk{
@@ -309,6 +311,32 @@ func (cloud *FakeCloudProvider) AttachDisk(ctx context.Context, project string, 
 	}
 	instance.Disks = append(instance.Disks, attachedDiskV1)
 	return nil
+}
+
+func (cloud *FakeCloudProvider) GetOperationByClientOpID(ctx context.Context, project, instanceZone, clientOpID string) (*computev1.Operation, error) {
+	if clientOpID == "" {
+		return nil, nil
+	}
+	for _, op := range cloud.operations {
+		if op.ClientOperationId == clientOpID {
+			return op, nil
+		}
+	}
+	return nil, nil
+}
+
+func (cloud *FakeCloudProvider) WaitForZonalOp(ctx context.Context, project, opName string, zone string) error {
+	if op, ok := cloud.operations[opName]; ok {
+		op.Status = "DONE"
+	}
+	return nil
+}
+
+func (cloud *FakeCloudProvider) InsertOperation(op *computev1.Operation) {
+	if cloud.operations == nil {
+		cloud.operations = make(map[string]*computev1.Operation)
+	}
+	cloud.operations[op.Name] = op
 }
 
 func (cloud *FakeCloudProvider) DetachDisk(ctx context.Context, project, deviceName, instanceZone, instanceName string) error {
@@ -607,14 +635,14 @@ func (cloud *FakeBlockingCloudProvider) DetachDisk(ctx context.Context, project,
 	return cloud.FakeCloudProvider.DetachDisk(ctx, project, deviceName, instanceZone, instanceName)
 }
 
-func (cloud *FakeBlockingCloudProvider) AttachDisk(ctx context.Context, project string, volKey *meta.Key, readWrite, diskType, instanceZone, instanceName string, forceAttach bool) error {
+func (cloud *FakeBlockingCloudProvider) AttachDisk(ctx context.Context, project string, volKey *meta.Key, readWrite, diskType, instanceZone, instanceName string, forceAttach bool, reqID string) error {
 	execute := make(chan Signal)
 	cloud.ReadyToExecute <- execute
 	val := <-execute
 	if val.ReportError {
 		return fmt.Errorf("force mock error for AttachDisk: volkey %s", volKey)
 	}
-	return cloud.FakeCloudProvider.AttachDisk(ctx, project, volKey, readWrite, diskType, instanceZone, instanceName, forceAttach)
+	return cloud.FakeCloudProvider.AttachDisk(ctx, project, volKey, readWrite, diskType, instanceZone, instanceName, forceAttach, reqID)
 }
 
 func notFoundError() *googleapi.Error {

--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -103,7 +103,9 @@ type GCECompute interface {
 	InsertDisk(ctx context.Context, project string, volKey *meta.Key, params common.DiskParameters, capBytes int64, capacityRange *csi.CapacityRange, replicaZones []string, snapshotID string, volumeContentSourceVolumeID string, multiWriter bool, accessMode string) error
 	DeleteDisk(ctx context.Context, project string, volumeKey *meta.Key) error
 	UpdateDisk(ctx context.Context, project string, volKey *meta.Key, existingDisk *CloudDisk, params common.ModifyVolumeParameters) error
-	AttachDisk(ctx context.Context, project string, volKey *meta.Key, readWrite, diskType, instanceZone, instanceName string, forceAttach bool) error
+	AttachDisk(ctx context.Context, project string, volKey *meta.Key, readWrite, diskType, instanceZone, instanceName string, forceAttach bool, reqID string) error
+	GetOperationByClientOpID(ctx context.Context, project, instanceZone, clientOpID string) (*computev1.Operation, error)
+	WaitForZonalOp(ctx context.Context, project, opName string, zone string) error
 	DetachDisk(ctx context.Context, project, deviceName, instanceZone, instanceName string) error
 	SetDiskAccessMode(ctx context.Context, project string, volKey *meta.Key, accessMode string) error
 	ListCompatibleDiskTypeZones(ctx context.Context, project string, zones []string, diskType string) ([]string, error)
@@ -894,8 +896,8 @@ func (cloud *CloudProvider) deleteRegionalDisk(ctx context.Context, project, reg
 	return nil
 }
 
-func (cloud *CloudProvider) AttachDisk(ctx context.Context, project string, volKey *meta.Key, readWrite, diskType, instanceZone, instanceName string, forceAttach bool) error {
-	klog.V(5).Infof("Attaching disk %v to %s", volKey, instanceName)
+func (cloud *CloudProvider) AttachDisk(ctx context.Context, project string, volKey *meta.Key, readWrite, diskType, instanceZone, instanceName string, forceAttach bool, reqID string) error {
+	klog.V(5).Infof("Attaching disk %v to %s (requestId: %s)", volKey, instanceName, reqID)
 	source := cloud.GetDiskSourceURI(project, volKey)
 
 	deviceName, err := common.GetDeviceName(volKey)
@@ -918,13 +920,17 @@ func (cloud *CloudProvider) AttachDisk(ctx context.Context, project string, volK
 	if _, ok := cloud.tenantServiceMap[project]; ok {
 		service = cloud.tenantServiceMap[project]
 	}
-	op, err := service.Instances.AttachDisk(project, instanceZone, instanceName, attachedDiskV1).Context(ctx).ForceAttach(forceAttach).Do()
+	attachCall := service.Instances.AttachDisk(project, instanceZone, instanceName, attachedDiskV1).Context(ctx).ForceAttach(forceAttach)
+	if reqID != "" {
+		attachCall = attachCall.RequestId(reqID)
+	}
+	op, err := attachCall.Do()
 	if err != nil {
 		return fmt.Errorf("failed cloud service attach disk call: %w", err)
 	}
-	klog.V(5).Infof("AttachDisk operation %s for disk %s", op.Name, attachedDiskV1.DeviceName)
+	klog.V(5).Infof("AttachDisk operation %s (requestId: %s) for disk %s", op.Name, reqID, attachedDiskV1.DeviceName)
 
-	err = cloud.waitForZonalOp(ctx, project, op.Name, instanceZone)
+	err = cloud.WaitForZonalOp(ctx, project, op.Name, instanceZone)
 	if err != nil {
 		return fmt.Errorf("failed when waiting for zonal op: %w", err)
 	}
@@ -1063,10 +1069,35 @@ func (cloud *CloudProvider) getRegionalDiskTypeURI(project string, region, diskT
 	return cloud.service.BasePath + fmt.Sprintf(diskTypeURITemplateRegional, project, region, diskType)
 }
 
-func (cloud *CloudProvider) waitForZonalOp(ctx context.Context, project, opName string, zone string) error {
+func (cloud *CloudProvider) GetOperationByClientOpID(ctx context.Context, project, instanceZone, clientOpID string) (*computev1.Operation, error) {
+	if clientOpID == "" {
+		return nil, nil
+	}
+	service := cloud.service
+	if _, ok := cloud.tenantServiceMap[project]; ok {
+		service = cloud.tenantServiceMap[project]
+	}
+	filter := fmt.Sprintf("clientOperationId = %s", clientOpID)
+	opList, err := service.ZoneOperations.List(project, instanceZone).Filter(filter).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list zonal operations for clientOperationId %s: %w", clientOpID, err)
+	}
+	for _, op := range opList.Items {
+		if op.ClientOperationId == clientOpID {
+			return op, nil
+		}
+	}
+	return nil, nil
+}
+
+func (cloud *CloudProvider) WaitForZonalOp(ctx context.Context, project, opName string, zone string) error {
 	// The v1 API can query for v1, alpha, or beta operations.
 	return wait.ExponentialBackoff(WaitForOpBackoff, func() (bool, error) {
-		pollOp, err := cloud.service.ZoneOperations.Get(project, zone, opName).Context(ctx).Do()
+		service := cloud.service
+		if _, ok := cloud.tenantServiceMap[project]; ok {
+			service = cloud.tenantServiceMap[project]
+		}
+		pollOp, err := service.ZoneOperations.Get(project, zone, opName).Context(ctx).Do()
 		if err != nil {
 			klog.Errorf("WaitForOp(op: %s, zone: %#v) failed to poll the operation", opName, zone)
 			return false, err
@@ -1074,6 +1105,10 @@ func (cloud *CloudProvider) waitForZonalOp(ctx context.Context, project, opName 
 		done, err := opIsDone(pollOp)
 		return done, err
 	})
+}
+
+func (cloud *CloudProvider) waitForZonalOp(ctx context.Context, project, opName string, zone string) error {
+	return cloud.WaitForZonalOp(ctx, project, opName, zone)
 }
 
 func (cloud *CloudProvider) waitForRegionalOp(ctx context.Context, project, opName string, region string) error {

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	googleuuid "github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/util/flowcontrol"
@@ -1202,7 +1203,8 @@ func (gceCS *GCEControllerServer) executeControllerPublishVolume(ctx context.Con
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "could not split nodeID: %v", err.Error()), disk
 	}
-	err = gceCS.CloudProvider.AttachDisk(ctx, project, volKey, readWrite, attachableDiskTypePersistent, instanceZone, instanceName, pdcsiContext.ForceAttach)
+	reqID := generateAttachCycleUUID(volumeID, nodeID, disk)
+	err = gceCS.CloudProvider.AttachDisk(ctx, project, volKey, readWrite, attachableDiskTypePersistent, instanceZone, instanceName, pdcsiContext.ForceAttach, reqID)
 	if err != nil {
 		var udErr *gce.UnsupportedDiskError
 		if errors.As(err, &udErr) {
@@ -1318,12 +1320,19 @@ func (gceCS *GCEControllerServer) executeControllerUnpublishVolume(ctx context.C
 	}
 
 	attached := diskIsAttached(deviceName, instance)
+	if !attached {
+		attached, err = gceCS.waitForInflightAttach(ctx, project, volumeID, nodeID, instanceZone, instanceName, deviceName, diskToUnpublish)
+		if err != nil {
+			return nil, err, diskToUnpublish
+		}
+	}
 
 	if !attached {
 		// Volume is not attached to node. Success!
 		klog.V(4).Infof("ControllerUnpublishVolume succeeded for disk %v from node %v. Already not attached.", volKey, nodeID)
 		return &csi.ControllerUnpublishVolumeResponse{}, nil, diskToUnpublish
 	}
+
 	err = gceCS.CloudProvider.DetachDisk(ctx, project, deviceName, instanceZone, instanceName)
 	if err != nil {
 		return nil, common.LoggedError("Failed to detach: ", err), diskToUnpublish
@@ -1331,6 +1340,42 @@ func (gceCS *GCEControllerServer) executeControllerUnpublishVolume(ctx context.C
 
 	klog.V(4).Infof("ControllerUnpublishVolume succeeded for disk %v from node %v", volKey, nodeID)
 	return &csi.ControllerUnpublishVolumeResponse{}, nil, diskToUnpublish
+}
+
+func (gceCS *GCEControllerServer) waitForInflightAttach(ctx context.Context, project, volumeID, nodeID, instanceZone, instanceName, deviceName string, disk *gce.CloudDisk) (bool, error) {
+	if disk == nil {
+		klog.Warningf("Could not check in-flight attach operation for volume %v on node %v because disk could not be retrieved", volumeID, nodeID)
+		return false, nil
+	}
+
+	reqID := generateAttachCycleUUID(volumeID, nodeID, disk)
+	op, err := gceCS.CloudProvider.GetOperationByClientOpID(ctx, project, instanceZone, reqID)
+	if err != nil {
+		return false, fmt.Errorf("failed to check attach operations: %w", err)
+	}
+	if op == nil {
+		return false, nil
+	}
+
+	if op.Status != "DONE" {
+		klog.Infof("Waiting for in-flight attach operation %s (requestId: %s) for volume %s on node %s", op.Name, reqID, volumeID, instanceName)
+		err = gceCS.CloudProvider.WaitForZonalOp(ctx, project, op.Name, instanceZone)
+		if err != nil {
+			return false, fmt.Errorf("failed when waiting for in-flight attach operation %s: %w", op.Name, err)
+		}
+	}
+
+	// Refresh instance to verify if disk attached
+	instance, err := gceCS.CloudProvider.GetInstanceOrError(ctx, project, instanceZone, instanceName)
+	if err != nil {
+		if gce.IsGCENotFoundError(err) {
+			klog.Warningf("Treating volume %v as unpublished because node %v could not be found", volumeID, instanceName)
+			return false, nil
+		}
+		return false, common.LoggedError("error getting instance after checking attach operation: ", err)
+	}
+
+	return diskIsAttached(deviceName, instance), nil
 }
 
 func (gceCS *GCEControllerServer) parameterProcessor() *common.ParameterProcessor {
@@ -2170,6 +2215,18 @@ func getRequestCapacity(capRange *csi.CapacityRange) (int64, error) {
 		capBytes = MinimumVolumeSizeInBytes
 	}
 	return capBytes, nil
+}
+
+func generateAttachCycleUUID(volumeID, nodeID string, disk *gce.CloudDisk) string {
+	incarnation := ""
+	if disk != nil {
+		incarnation = disk.GetLastDetachTimestamp()
+		if incarnation == "" {
+			incarnation = disk.GetCreationTimestamp()
+		}
+	}
+	seed := fmt.Sprintf("%s/%s/%s", volumeID, nodeID, incarnation)
+	return googleuuid.NewSHA1(googleuuid.NameSpaceURL, []byte(seed)).String()
 }
 
 func diskIsAttached(deviceName string, instance *compute.Instance) bool {

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -1204,6 +1204,8 @@ func (gceCS *GCEControllerServer) executeControllerPublishVolume(ctx context.Con
 		return nil, status.Errorf(codes.InvalidArgument, "could not split nodeID: %v", err.Error()), disk
 	}
 	reqID := generateAttachCycleUUID(volumeID, nodeID, disk)
+	klog.Infof("[POC VERIFICATION] ControllerPublishVolume: Generated attach cycle UUID %s for volume %s on node %s (LastDetachTimestamp: %q, CreationTimestamp: %q)",
+		reqID, volumeID, nodeID, disk.GetLastDetachTimestamp(), disk.GetCreationTimestamp())
 	err = gceCS.CloudProvider.AttachDisk(ctx, project, volKey, readWrite, attachableDiskTypePersistent, instanceZone, instanceName, pdcsiContext.ForceAttach, reqID)
 	if err != nil {
 		var udErr *gce.UnsupportedDiskError
@@ -1317,6 +1319,21 @@ func (gceCS *GCEControllerServer) executeControllerUnpublishVolume(ctx context.C
 	deviceName, err := common.GetDeviceName(volKey)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "error getting device name: %v", err.Error()), diskToUnpublish
+	}
+
+	// [POC VERIFICATION] Always retrieve and log the GCE Operation for this attach cycle to verify requestId matching in production/staging.
+	if diskToUnpublish != nil {
+		pocReqID := generateAttachCycleUUID(volumeID, nodeID, diskToUnpublish)
+		pocOp, pocErr := gceCS.CloudProvider.GetOperationByClientOpID(ctx, project, instanceZone, pocReqID)
+		if pocErr != nil {
+			klog.Infof("[POC VERIFICATION] ControllerUnpublishVolume: Error querying GCE Operation for requestId %s: %v", pocReqID, pocErr)
+		} else if pocOp != nil {
+			klog.Infof("[POC VERIFICATION] ControllerUnpublishVolume: MATCHED GCE Operation for requestId %s: name=%s, status=%s, opType=%s, targetLink=%s, insertTime=%s, endTime=%s",
+				pocReqID, pocOp.Name, pocOp.Status, pocOp.OperationType, pocOp.TargetLink, pocOp.InsertTime, pocOp.EndTime)
+		} else {
+			klog.Infof("[POC VERIFICATION] ControllerUnpublishVolume: No GCE Operation found for requestId %s (volume: %s, node: %s, LastDetachTimestamp: %q, CreationTimestamp: %q)",
+				pocReqID, volumeID, nodeID, diskToUnpublish.GetLastDetachTimestamp(), diskToUnpublish.GetCreationTimestamp())
+		}
 	}
 
 	attached := diskIsAttached(deviceName, instance)

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	googleuuid "github.com/google/uuid"
 
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
@@ -5841,3 +5842,180 @@ func mergeParameters(a map[string]string, b map[string]string) map[string]string
 	}
 	return merged
 }
+
+func TestGenerateAttachCycleUUID(t *testing.T) {
+	volID := "projects/my-proj/zones/us-central1-a/disks/pvc-123"
+	nodeID := "projects/my-proj/zones/us-central1-a/instances/node-1"
+
+	// 1. New disk without LastDetachTimestamp uses CreationTimestamp
+	disk1 := gcecloudprovider.CloudDiskFromV1(&compute.Disk{
+		Name:              "pvc-123",
+		CreationTimestamp: "2026-01-01T00:00:00.000Z",
+	})
+	uuid1 := generateAttachCycleUUID(volID, nodeID, disk1)
+	if _, err := googleuuid.Parse(uuid1); err != nil {
+		t.Fatalf("expected valid RFC 4122 UUID, got %s: %v", uuid1, err)
+	}
+
+	// Deterministic: same disk and node produce exact same UUID
+	uuid1Repeat := generateAttachCycleUUID(volID, nodeID, disk1)
+	if uuid1 != uuid1Repeat {
+		t.Fatalf("expected deterministic UUID %s, got %s", uuid1, uuid1Repeat)
+	}
+
+	// 2. Disk with LastDetachTimestamp uses LastDetachTimestamp
+	disk2 := gcecloudprovider.CloudDiskFromV1(&compute.Disk{
+		Name:                "pvc-123",
+		CreationTimestamp:   "2026-01-01T00:00:00.000Z",
+		LastDetachTimestamp: "2026-01-02T10:00:00.000Z",
+	})
+	uuid2 := generateAttachCycleUUID(volID, nodeID, disk2)
+	if _, err := googleuuid.Parse(uuid2); err != nil {
+		t.Fatalf("expected valid RFC 4122 UUID, got %s: %v", uuid2, err)
+	}
+	if uuid1 == uuid2 {
+		t.Fatalf("expected different UUID after detach, got same %s", uuid1)
+	}
+
+	// 3. Subsequent detach updates timestamp and produces a new UUID
+	disk3 := gcecloudprovider.CloudDiskFromV1(&compute.Disk{
+		Name:                "pvc-123",
+		CreationTimestamp:   "2026-01-01T00:00:00.000Z",
+		LastDetachTimestamp: "2026-01-03T15:30:00.000Z",
+	})
+	uuid3 := generateAttachCycleUUID(volID, nodeID, disk3)
+	if uuid2 == uuid3 {
+		t.Fatalf("expected different UUID for subsequent detach cycle, got same %s", uuid2)
+	}
+}
+
+func TestControllerUnpublishWaitsForInflightAttach(t *testing.T) {
+	volID := fmt.Sprintf("projects/%s/zones/%s/disks/test-vol", project, zone)
+	nodeID := fmt.Sprintf("projects/%s/zones/%s/instances/test-node", project, zone)
+
+	disk := gcecloudprovider.CloudDiskFromV1(&compute.Disk{
+		Name:              "test-vol",
+		Zone:              zone,
+		CreationTimestamp: "2026-01-01T00:00:00.000Z",
+	})
+
+	fcp, err := gcecloudprovider.CreateFakeCloudProvider(project, zone, []*gcecloudprovider.CloudDisk{disk})
+	if err != nil {
+		t.Fatalf("Failed to create fake cloud provider: %v", err)
+	}
+
+	// Add instance without any attached disks
+	instance := &compute.Instance{
+		Name:  "test-node",
+		Zone:  zone,
+		Disks: []*compute.AttachedDisk{},
+	}
+	fcp.InsertInstance(instance, zone, "test-node")
+
+	// Calculate expected attach cycle UUID
+	reqID := generateAttachCycleUUID(volID, nodeID, disk)
+
+	// Simulate an in-flight attach operation with matching clientOperationId
+	op := &compute.Operation{
+		Name:              "operation-attach-123",
+		ClientOperationId: reqID,
+		Status:            "RUNNING",
+		OperationType:     "attachDisk",
+		TargetLink:        fmt.Sprintf("projects/%s/zones/%s/instances/test-node", project, zone),
+	}
+	fcp.InsertOperation(op)
+
+	gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{})
+
+	req := &csi.ControllerUnpublishVolumeRequest{
+		VolumeId: volID,
+		NodeId:   nodeID,
+	}
+
+	// ControllerUnpublishVolume should detect in-flight operation, wait for it (which marks it DONE in fake provider),
+	// and complete unpublish.
+	resp, err := gceDriver.cs.ControllerUnpublishVolume(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ControllerUnpublishVolume failed: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("expected non-nil response")
+	}
+
+	// Verify the operation was retrieved and completed (status is now DONE)
+	retrievedOp, err := fcp.GetOperationByClientOpID(context.Background(), project, zone, reqID)
+	if err != nil {
+		t.Fatalf("failed to query operations: %v", err)
+	}
+	if retrievedOp == nil || retrievedOp.Status != "DONE" {
+		t.Fatalf("expected operation status DONE, got %v", retrievedOp)
+	}
+}
+
+func TestControllerUnpublishHandlesOperationCompletedInRaceWindow(t *testing.T) {
+	volID := fmt.Sprintf("projects/%s/zones/%s/disks/test-vol", project, zone)
+	nodeID := fmt.Sprintf("projects/%s/zones/%s/instances/test-node", project, zone)
+
+	disk := gcecloudprovider.CloudDiskFromV1(&compute.Disk{
+		Name:              "test-vol",
+		Zone:              zone,
+		CreationTimestamp: "2026-01-01T00:00:00.000Z",
+	})
+
+	fcp, err := gcecloudprovider.CreateFakeCloudProvider(project, zone, []*gcecloudprovider.CloudDisk{disk})
+	if err != nil {
+		t.Fatalf("Failed to create fake cloud provider: %v", err)
+	}
+
+	// Add instance where disk is already attached in backend
+	instance := &compute.Instance{
+		Name: "test-node",
+		Zone: zone,
+		Disks: []*compute.AttachedDisk{
+			{
+				DeviceName: "test-vol",
+				Mode:       "READ_WRITE",
+			},
+		},
+	}
+	fcp.InsertInstance(instance, zone, "test-node")
+
+	// Calculate expected attach cycle UUID
+	reqID := generateAttachCycleUUID(volID, nodeID, disk)
+
+	// Simulate completed operation (status DONE) in GCE
+	op := &compute.Operation{
+		Name:              "operation-attach-456",
+		ClientOperationId: reqID,
+		Status:            "DONE",
+		OperationType:     "attachDisk",
+		TargetLink:        fmt.Sprintf("projects/%s/zones/%s/instances/test-node", project, zone),
+	}
+	fcp.InsertOperation(op)
+
+	gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{})
+
+	req := &csi.ControllerUnpublishVolumeRequest{
+		VolumeId: volID,
+		NodeId:   nodeID,
+	}
+
+	resp, err := gceDriver.cs.ControllerUnpublishVolume(context.Background(), req)
+	if err != nil {
+		t.Fatalf("ControllerUnpublishVolume failed: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("expected non-nil response")
+	}
+
+	// Verify disk was detached from the instance
+	updatedInstance, err := fcp.GetInstanceOrError(context.Background(), project, zone, "test-node")
+	if err != nil {
+		t.Fatalf("failed to get instance: %v", err)
+	}
+	if diskIsAttached("test-vol", updatedInstance) {
+		t.Fatalf("expected disk test-vol to be detached, but was still attached")
+	}
+}
+
+


### PR DESCRIPTION
### Proof of Concept: Deterministic Request ID & In-Flight Attach Tracking

This PR adds live verification logging and refactored helper methods to prove that deterministic UUID generation matches the GCE `clientOperationId` during publish and unpublish cycles.

#### Live Cluster Verification Logs (from test run):
```
I0828 22:46:58.906619       1 controller.go:1207] [POC VERIFICATION] ControllerPublishVolume: Generated attach cycle UUID 77c50803-6585-58b3-937f-66fa900b6660 for volume projects/fuechr-gke-dev/zones/us-central1-a/disks/pvc-f6f5c2cc-5b48-481b-a9d9-37f5b2e96382 on node projects/fuechr-gke-dev/zones/us-central1-a/instances/gke-gcsfusetest-csi-dev-pool-11dfa3b7-w8hg (LastDetachTimestamp: "", CreationTimestamp: "2026-08-28T15:46:55.969-07:00")
I0828 22:48:04.731926       1 controller.go:1331] [POC VERIFICATION] ControllerUnpublishVolume: MATCHED GCE Operation for requestId 77c50803-6585-58b3-937f-66fa900b6660: name=operation-1787957218969-65a233ae90909-b9e17705-e04c1686, status=DONE, opType=attachDisk, targetLink=https://www.googleapis.com/compute/v1/projects/fuechr-gke-dev/zones/us-central1-a/instances/gke-gcsfusetest-csi-dev-pool-11dfa3b7-w8hg, insertTime=2026-08-28T15:46:59.197-07:00, endTime=2026-08-28T15:47:03.844-07:00
```
