### PR TITLE
Add readiness probe to node driver registrar

### DIFF
--- a/deploy/kubernetes/base/node_linux/node.yaml
+++ b/deploy/kubernetes/base/node_linux/node.yaml
@@ -1,4 +1,3 @@
-#TODO(#40): Force DaemonSet to not run on master.
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -19,6 +18,17 @@ spec:
       hostNetwork: true
       priorityClassName: csi-gce-pd-node
       serviceAccountName: csi-gce-pd-node-sa
+      # Set node affinity to prevent scheduling on control plane (master) nodes.
+      # Because this DaemonSet specifies a wildcard toleration (operator: Exists),
+      # it would otherwise be scheduled on control plane nodes.
+      # See: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/40
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
       nodeSelector:
         kubernetes.io/os: linux
       containers:

--- a/deploy/kubernetes/base/node_linux/node.yaml
+++ b/deploy/kubernetes/base/node_linux/node.yaml
@@ -28,6 +28,18 @@ spec:
             - "--v=5"
             - "--csi-address=/csi/csi.sock"
             - "--kubelet-registration-path=/var/lib/kubelet/plugins/pd.csi.storage.gke.io/csi.sock"
+            - "--http-endpoint=:9931"
+          ports:
+            - containerPort: 9931
+              name: healthz
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 3
           env:
             - name: KUBE_NODE_NAME
               valueFrom:

--- a/deploy/kubernetes/base/node_windows/node.yaml
+++ b/deploy/kubernetes/base/node_windows/node.yaml
@@ -29,6 +29,18 @@ spec:
             - --v=5
             - --csi-address=unix://C:\\csi\\csi.sock
             - --kubelet-registration-path=C:\\var\\lib\\kubelet\\plugins\\pd.csi.storage.gke.io\\csi.sock
+            - --http-endpoint=:9931
+          ports:
+            - containerPort: 9931
+              name: healthz
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 3
           env:
             - name: KUBE_NODE_NAME
               valueFrom:

--- a/deploy/kubernetes/base/node_windows/node.yaml
+++ b/deploy/kubernetes/base/node_windows/node.yaml
@@ -1,4 +1,3 @@
-#TODO(#40): Force DaemonSet to not run on master.
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -20,6 +19,17 @@ spec:
       # hostNetwork: true
       priorityClassName: csi-gce-pd-node
       serviceAccountName: csi-gce-pd-node-sa-win
+      # Set node affinity to prevent scheduling on control plane (master) nodes.
+      # Because this DaemonSet specifies a wildcard toleration (operator: Exists),
+      # it would otherwise be scheduled on control plane nodes.
+      # See: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/40
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
       nodeSelector:
         kubernetes.io/os: windows
       containers:

--- a/test/k8s-integration/cluster.go
+++ b/test/k8s-integration/cluster.go
@@ -149,6 +149,31 @@ func clusterUpGCE(k8sDir, gceZone string, numNodes int, numWindowsNodes int, ima
 		return fmt.Errorf("failed to bring up kubernetes e2e cluster on gce: %v", err.Error())
 	}
 
+	// In GCE clusters created by kube-up.sh, the master node is tainted with
+	// node-role.kubernetes.io/control-plane:NoSchedule but lacks the corresponding
+	// label. Apply the standard label so that nodeAffinity rules in the DaemonSet
+	// can properly exclude it.
+	nodesCmd := exec.Command("kubectl", "get", "nodes", "-o", "jsonpath={.items[*].metadata.name}")
+	out, err := nodesCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to get nodes: %s, err: %w", out, err)
+	}
+	foundMaster := false
+	for _, node := range strings.Fields(string(out)) {
+		if strings.HasSuffix(node, "-master") {
+			foundMaster = true
+			labelCmd := exec.Command("kubectl", "label", "node", node, "node-role.kubernetes.io/control-plane=", "--overwrite")
+			out, err := labelCmd.CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("failed to label master node %s: %s, err: %w", node, out, err)
+			}
+			klog.Infof("Labeled master node %s with node-role.kubernetes.io/control-plane", node)
+		}
+	}
+	if !foundMaster {
+		klog.Warningf("No master node found with suffix '-master' to label with node-role.kubernetes.io/control-plane")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
In order to integrate with the [Node Readiness Controller (NRC)](https://github.com/kubernetes-sigs/node-readiness-controller), which taints a node until the PD CSI driver is ready, this PR adds a `readinessProbe` and `--http-endpoint=:9931` to `csi-node-driver-registrar` in Linux and Windows node DaemonSets.

Without this probe, there is a race condition where the node pod is marked `Ready` before the driver finishes registration with Kubelet. Consequently, NRC may remove the node taint prematurely, causing scheduled workloads to fail volume mounting. Adding this `readinessProbe` ensures the pod is only marked `Ready` after driver registration completes, preventing the race condition.

Additionally, I noticed that the node DaemonSet was previously scheduled onto master/control-plane nodes due to the wildcard toleration (`operator: Exists`), which was tracked by the longstanding `#TODO(#40): Force DaemonSet to not run on master` in [issue#40](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/40). Without a readiness probe, the pod on the master node was considered `Ready` on startup despite failing registration shortly after. However, with the new `readinessProbe`, the master pod fails Kubelet registration, enters `CrashLoopBackOff`, and remains `NotReady`—which indefinitely blocks CI driver startup checks (e.g., `wait-for-driver.sh` in upstream GCE integration tests).

To resolve this, this PR adds `affinity.nodeAffinity` to both Linux and Windows node DaemonSets to ensure pods are not scheduled on nodes labeled with `node-role.kubernetes.io/control-plane`. Additionally, it updates `test/k8s-integration/cluster.go` to explicitly label master nodes with `node-role.kubernetes.io/control-plane` post-creation in GCE E2E clusters, where [kube-up.sh](https://github.com/kubernetes/kubernetes/blob/b2ec8b6fefac451a2dedafc4dd71f2f16c7a6abe/cluster/gce/config-default.sh#L196) provisions master nodes without standard role labels.



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add readiness probe to node driver registrar
```
