### PR TITLE
Pd to hyperdisk conversion

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -88,6 +88,28 @@ const (
 	HyperdiskExtremeIopsPerGB          = 2
 	HyperdiskThroughputThroughputPerGB = 10
 	BytesInGB                          = 1024
+
+	// Maximum provisioned IOPS/throughput ceilings, per
+	// https://cloud.google.com/compute/docs/disks/hyperdisk-perf-limits
+	//
+	// hyperdisk-balanced: max IOPS is MIN(500 * sizeGb, 160000); max
+	// throughput depends on the provisioned IOPS value (P) rather than size:
+	// MIN(2400, P/4) MiB/s.
+	HyperdiskBalancedMaxIops               = 160000
+	HyperdiskBalancedMaxThroughput         = 2400
+	HyperdiskBalancedThroughputIopsDivisor = 4
+	// hyperdisk-extreme: max IOPS is MIN(1200 * sizeGb, 350000). Throughput is
+	// not user-provisionable for this type.
+	HyperdiskExtremeMaxIopsPerGB = 1200
+	HyperdiskExtremeMaxIops      = 350000
+	// hyperdisk-throughput: max throughput is MIN(90 * sizeTiB, 2400) MiB/s.
+	// IOPS is not user-provisionable for this type.
+	HyperdiskThroughputMaxThroughputPerTiB = 90
+	HyperdiskThroughputMaxThroughput       = 2400
+	// hyperdisk-ml: max throughput is MIN(1600 * sizeGb, 2097152) MiB/s. IOPS
+	// is not user-provisionable for this type.
+	HyperdiskMLMaxThroughputPerGB = 1600
+	HyperdiskMLMaxThroughput      = 2097152
 )
 
 var (
@@ -587,4 +609,98 @@ func minThroughputForThroughput(disk *computev1.Disk, requestGb int64) (needed b
 		return true, 0, minRequiredThroughput
 	}
 	return false, 0, 0
+}
+
+// ValidateMaxProvisioned checks the requested provisioned IOPS and/or
+// throughput against GCE's published ceiling for diskType and sizeGb, so an
+// out-of-range request is rejected client-side instead of round-tripping to
+// the API.
+// https://cloud.google.com/compute/docs/disks/hyperdisk-perf-limits
+//
+// currentIops is the disk's already-provisioned IOPS. It is used as the basis
+// for hyperdisk-balanced's throughput ceiling, which depends on the
+// provisioned IOPS value rather than disk size, when the request changes
+// throughput without also changing IOPS.
+func ValidateMaxProvisioned(diskType string, sizeGb, currentIops int64, iops, throughput *int64) error {
+	switch {
+	case strings.Contains(diskType, parameters.DiskTypeHyperdiskBalanced):
+		return maxIopsThroughputForBalanced(sizeGb, currentIops, iops, throughput)
+	case strings.Contains(diskType, parameters.DiskTypeHdE):
+		return maxIopsForExtreme(sizeGb, iops)
+	case strings.Contains(diskType, parameters.DiskTypeHdT):
+		return maxThroughputForThroughputType(sizeGb, throughput)
+	case strings.Contains(diskType, parameters.DiskTypeHdML):
+		return maxThroughputForMLType(sizeGb, throughput)
+	}
+	return nil
+}
+
+func maxIopsThroughputForBalanced(sizeGb, currentIops int64, iops, throughput *int64) error {
+	maxIops := sizeGb * HyperdiskBalancedIopsPerGB
+	if maxIops > HyperdiskBalancedMaxIops {
+		maxIops = HyperdiskBalancedMaxIops
+	}
+	if iops != nil && *iops > maxIops {
+		return fmt.Errorf("provisioned IOPS %d exceeds the maximum of %d for a %d GiB hyperdisk-balanced disk", *iops, maxIops, sizeGb)
+	}
+	if throughput == nil {
+		return nil
+	}
+	// The throughput ceiling depends on the provisioned IOPS value (P) rather
+	// than size. Use the requested IOPS when this request also changes it,
+	// otherwise fall back to the disk's already-provisioned IOPS.
+	p := currentIops
+	if iops != nil {
+		p = *iops
+	}
+	maxThroughput := p / HyperdiskBalancedThroughputIopsDivisor
+	if maxThroughput > HyperdiskBalancedMaxThroughput {
+		maxThroughput = HyperdiskBalancedMaxThroughput
+	}
+	if *throughput > maxThroughput {
+		return fmt.Errorf("provisioned throughput %d MiB/s exceeds the maximum of %d MiB/s for provisioned IOPS %d on hyperdisk-balanced", *throughput, maxThroughput, p)
+	}
+	return nil
+}
+
+func maxIopsForExtreme(sizeGb int64, iops *int64) error {
+	if iops == nil {
+		return nil
+	}
+	maxIops := sizeGb * HyperdiskExtremeMaxIopsPerGB
+	if maxIops > HyperdiskExtremeMaxIops {
+		maxIops = HyperdiskExtremeMaxIops
+	}
+	if *iops > maxIops {
+		return fmt.Errorf("provisioned IOPS %d exceeds the maximum of %d for a %d GiB hyperdisk-extreme disk", *iops, maxIops, sizeGb)
+	}
+	return nil
+}
+
+func maxThroughputForThroughputType(sizeGb int64, throughput *int64) error {
+	if throughput == nil {
+		return nil
+	}
+	maxThroughput := sizeGb * HyperdiskThroughputMaxThroughputPerTiB / BytesInGB
+	if maxThroughput > HyperdiskThroughputMaxThroughput {
+		maxThroughput = HyperdiskThroughputMaxThroughput
+	}
+	if *throughput > maxThroughput {
+		return fmt.Errorf("provisioned throughput %d MiB/s exceeds the maximum of %d MiB/s for a %d GiB hyperdisk-throughput disk", *throughput, maxThroughput, sizeGb)
+	}
+	return nil
+}
+
+func maxThroughputForMLType(sizeGb int64, throughput *int64) error {
+	if throughput == nil {
+		return nil
+	}
+	maxThroughput := sizeGb * HyperdiskMLMaxThroughputPerGB
+	if maxThroughput > HyperdiskMLMaxThroughput {
+		maxThroughput = HyperdiskMLMaxThroughput
+	}
+	if *throughput > maxThroughput {
+		return fmt.Errorf("provisioned throughput %d MiB/s exceeds the maximum of %d MiB/s for a %d GiB hyperdisk-ml disk", *throughput, maxThroughput, sizeGb)
+	}
+	return nil
 }

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -1140,3 +1140,147 @@ func TestGetMinIopsThroughput(t *testing.T) {
 		})
 	}
 }
+
+func iopsInt64Ptr(v int64) *int64 { return &v }
+
+func TestValidateMaxProvisioned(t *testing.T) {
+	testcases := []struct {
+		name        string
+		diskType    string
+		sizeGb      int64
+		currentIops int64
+		iops        *int64
+		throughput  *int64
+		expectErr   bool
+	}{
+		{
+			name:     "hyperdisk-balanced IOPS within max",
+			diskType: "hyperdisk-balanced",
+			sizeGb:   500,
+			iops:     iopsInt64Ptr(160000),
+		},
+		{
+			name:      "hyperdisk-balanced IOPS above the flat cap",
+			diskType:  "hyperdisk-balanced",
+			sizeGb:    500,
+			iops:      iopsInt64Ptr(160001),
+			expectErr: true,
+		},
+		{
+			name:      "hyperdisk-balanced IOPS above the size-scaled max",
+			diskType:  "hyperdisk-balanced",
+			sizeGb:    100,
+			iops:      iopsInt64Ptr(50001), // max is 500 * 100 = 50000
+			expectErr: true,
+		},
+		{
+			name:       "hyperdisk-balanced throughput within max for requested IOPS",
+			diskType:   "hyperdisk-balanced",
+			sizeGb:     500,
+			iops:       iopsInt64Ptr(4000),
+			throughput: iopsInt64Ptr(1000), // max is 4000/4 = 1000
+		},
+		{
+			name:       "hyperdisk-balanced throughput above max for requested IOPS",
+			diskType:   "hyperdisk-balanced",
+			sizeGb:     500,
+			iops:       iopsInt64Ptr(4000),
+			throughput: iopsInt64Ptr(1001),
+			expectErr:  true,
+		},
+		{
+			name:        "hyperdisk-balanced throughput-only change uses the disk's current IOPS",
+			diskType:    "hyperdisk-balanced",
+			sizeGb:      500,
+			currentIops: 4000,
+			throughput:  iopsInt64Ptr(1001), // max is 4000/4 = 1000
+			expectErr:   true,
+		},
+		{
+			name:       "hyperdisk-balanced throughput above the flat cap",
+			diskType:   "hyperdisk-balanced",
+			sizeGb:     500,
+			iops:       iopsInt64Ptr(160000),
+			throughput: iopsInt64Ptr(2401), // max is min(2400, 160000/4) = 2400
+			expectErr:  true,
+		},
+		{
+			name:     "hyperdisk-extreme IOPS within max",
+			diskType: "hyperdisk-extreme",
+			sizeGb:   300,
+			iops:     iopsInt64Ptr(350000),
+		},
+		{
+			name:      "hyperdisk-extreme IOPS above the size-scaled max",
+			diskType:  "hyperdisk-extreme",
+			sizeGb:    100,
+			iops:      iopsInt64Ptr(120001), // max is 1200 * 100 = 120000
+			expectErr: true,
+		},
+		{
+			name:      "hyperdisk-extreme IOPS above the flat cap",
+			diskType:  "hyperdisk-extreme",
+			sizeGb:    300,
+			iops:      iopsInt64Ptr(350001),
+			expectErr: true,
+		},
+		{
+			name:       "hyperdisk-throughput within max",
+			diskType:   "hyperdisk-throughput",
+			sizeGb:     10240,             // 10 TiB
+			throughput: iopsInt64Ptr(900), // max is 90 * 10 = 900
+		},
+		{
+			name:       "hyperdisk-throughput above the size-scaled max",
+			diskType:   "hyperdisk-throughput",
+			sizeGb:     10240,
+			throughput: iopsInt64Ptr(901),
+			expectErr:  true,
+		},
+		{
+			name:       "hyperdisk-throughput above the flat cap",
+			diskType:   "hyperdisk-throughput",
+			sizeGb:     102400, // 100 TiB
+			throughput: iopsInt64Ptr(2401),
+			expectErr:  true,
+		},
+		{
+			name:       "hyperdisk-ml within max",
+			diskType:   "hyperdisk-ml",
+			sizeGb:     1000,
+			throughput: iopsInt64Ptr(1600000), // max is 1600 * 1000 = 1600000
+		},
+		{
+			name:       "hyperdisk-ml above the size-scaled max",
+			diskType:   "hyperdisk-ml",
+			sizeGb:     1000,
+			throughput: iopsInt64Ptr(1600001),
+			expectErr:  true,
+		},
+		{
+			name:       "hyperdisk-ml above the flat cap",
+			diskType:   "hyperdisk-ml",
+			sizeGb:     2000,
+			throughput: iopsInt64Ptr(2097153),
+			expectErr:  true,
+		},
+		{
+			name:       "unrecognized disk type is not validated",
+			diskType:   "pd-ssd",
+			sizeGb:     10,
+			iops:       iopsInt64Ptr(999999999),
+			throughput: iopsInt64Ptr(999999999),
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateMaxProvisioned(tc.diskType, tc.sizeGb, tc.currentIops, tc.iops, tc.throughput)
+			if tc.expectErr && err == nil {
+				t.Errorf("ValidateMaxProvisioned: expected an error, got nil")
+			}
+			if !tc.expectErr && err != nil {
+				t.Errorf("ValidateMaxProvisioned: expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -97,6 +97,9 @@ const (
 	// passed through to the claim on the next attempt rather than being visible
 	// only as an event.
 	DiskTypeConversionLastErrorKey = "pdcsi.gke.io/disk-type-conversion-last-error"
+	// DiskTypeConversionInfeasibleKey holds why a VolumeAttributesClass could
+	// not be acted on, so the reason outlives the class once it is withdrawn.
+	DiskTypeConversionInfeasibleKey = "pdcsi.gke.io/disk-type-conversion-infeasible"
 
 	// Conversion States
 	ConversionStatePending = "Pending"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -87,6 +87,28 @@ const (
 
 	// ClusterIDLabel is the key in disk labels to indicate the cluster identifier of the disk.
 	ClusterIDLabel = "cluster-id-gke-io"
+
+	// Annotations for Disk Type Conversion
+	DiskTypeConversionOperationKey = "pdcsi.gke.io/disk-type-conversion-operation"
+	DiskTypeConvertedFromKey       = "pdcsi.gke.io/disk-type-converted-from"
+	DiskTypeConvertedToKey         = "pdcsi.gke.io/disk-type-converted-to"
+	// DiskTypeConversionLastErrorKey holds the error reported by a conversion
+	// that ran and failed but will be retried, so that the failure can be
+	// passed through to the claim on the next attempt rather than being visible
+	// only as an event.
+	DiskTypeConversionLastErrorKey = "pdcsi.gke.io/disk-type-conversion-last-error"
+
+	// Conversion States
+	ConversionStatePending = "Pending"
+
+	// Reasons and actions for the events emitted while converting a disk type.
+	DiskTypeConversionStartReason    = "DiskTypeConversionStart"
+	DiskTypeConversionCompleteReason = "DiskTypeConversionComplete"
+	DiskTypeConversionRetryReason    = "DiskTypeConversionRetry"
+	DiskTypeConversionCancelReason   = "DiskTypeConversionCancelled"
+	DiskTypeConversionQueuedReason   = "DiskTypeConversionQueued"
+	DiskTypeConversionFailedReason   = "DiskTypeConversionFailed"
+	DiskTypeConversionAction         = "ConvertDiskType"
 )
 
 // doc https://cloud.google.com/compute/docs/general-purpose-machines

--- a/pkg/gce-cloud-provider/compute/fake-gce.go
+++ b/pkg/gce-cloud-provider/compute/fake-gce.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
@@ -65,6 +66,16 @@ type FakeCloudProvider struct {
 	// PD-on-Gen4 conversion testing fields
 	ConversionTestParams ConversionTestParams
 
+	// Controls for IsConvertOperationDone. PollNotDoneTimes is how many checks
+	// report the conversion as still running before it finishes, so a test can
+	// exercise a conversion that takes more than one check.
+	PollNotDoneTimes  int
+	PollErr           error
+	PollOperationErr  error
+	pollCallCount     int
+	pollOperationName string
+	pollLock          sync.Mutex
+
 	// marker to set disk status during InsertDisk operation.
 	mockDiskStatus string
 }
@@ -77,6 +88,14 @@ type ConversionTestParams struct {
 	SlowConversionCalled bool
 	FastConversionCalled bool
 	AttachCallCount      int
+
+	// Disk type conversion (ConvertDiskType).
+	TypeConversionCalled     bool
+	TypeConversionCallCount  int
+	TypeConversionErr        error
+	TypeConversionTargetType string
+	TypeConversionIops       *int64
+	TypeConversionThroughput *int64
 }
 
 var _ GCECompute = &FakeCloudProvider{}
@@ -335,6 +354,81 @@ func (cloud *FakeCloudProvider) DetachDisk(ctx context.Context, project, deviceN
 	instance.Disks[found] = instance.Disks[len(instance.Disks)-1]
 	instance.Disks = instance.Disks[:len(instance.Disks)-1]
 	return nil
+}
+
+func (cloud *FakeCloudProvider) ConvertDiskType(ctx context.Context, project string, volKey *meta.Key, targetDiskType string, provisionedIops, provisionedThroughput *int64) (string, error) {
+	// Conversions can be started from a background worker, so the record of
+	// what was asked for is shared with whoever is checking it.
+	cloud.pollLock.Lock()
+	defer cloud.pollLock.Unlock()
+
+	cloud.ConversionTestParams.TypeConversionCalled = true
+	cloud.ConversionTestParams.TypeConversionCallCount++
+	cloud.ConversionTestParams.TypeConversionTargetType = targetDiskType
+	cloud.ConversionTestParams.TypeConversionIops = provisionedIops
+	cloud.ConversionTestParams.TypeConversionThroughput = provisionedThroughput
+
+	if cloud.ConversionTestParams.TypeConversionErr != nil {
+		return "", cloud.ConversionTestParams.TypeConversionErr
+	}
+
+	// The real API converts asynchronously, but the fake applies the new type
+	// immediately so tests can observe the end state.
+	disk, ok := cloud.disks[volKey.String()]
+	if !ok {
+		return "", notFoundError()
+	}
+	typeURI := cloud.GetDiskTypeURI(project, volKey, targetDiskType)
+	if disk.disk != nil {
+		disk.disk.Type = typeURI
+	}
+	if disk.betaDisk != nil {
+		disk.betaDisk.Type = typeURI
+	}
+	return fmt.Sprintf("https://www.googleapis.com/compute/alpha/projects/%s/zones/%s/operations/operation-convert-%s", project, volKey.Zone, volKey.Name), nil
+}
+
+// IsConvertOperationDone reports the conversion as still running for the first
+// ConversionTestParams.PollNotDoneTimes calls, so that a test can exercise a
+// conversion that takes more than one check to finish.
+func (cloud *FakeCloudProvider) IsConvertOperationDone(ctx context.Context, project, zone, operationName string) (bool, error) {
+	cloud.pollLock.Lock()
+	defer cloud.pollLock.Unlock()
+
+	cloud.pollCallCount++
+	cloud.pollOperationName = operationName
+
+	if cloud.PollErr != nil {
+		return false, cloud.PollErr
+	}
+	if cloud.pollCallCount <= cloud.PollNotDoneTimes {
+		return false, nil
+	}
+	if cloud.PollOperationErr != nil {
+		return true, cloud.PollOperationErr
+	}
+	return true, nil
+}
+
+// ConversionCalled reports whether a disk type conversion was requested.
+func (cloud *FakeCloudProvider) ConversionCalled() bool {
+	cloud.pollLock.Lock()
+	defer cloud.pollLock.Unlock()
+	return cloud.ConversionTestParams.TypeConversionCalled
+}
+
+// PollCalls reports how many times the conversion operation has been checked.
+func (cloud *FakeCloudProvider) PollCalls() int {
+	cloud.pollLock.Lock()
+	defer cloud.pollLock.Unlock()
+	return cloud.pollCallCount
+}
+
+// PolledOperation reports the operation name that was last checked.
+func (cloud *FakeCloudProvider) PolledOperation() string {
+	cloud.pollLock.Lock()
+	defer cloud.pollLock.Unlock()
+	return cloud.pollOperationName
 }
 
 func (cloud *FakeCloudProvider) SetDiskAccessMode(ctx context.Context, project string, volKey *meta.Key, accessMode string) error {

--- a/pkg/gce-cloud-provider/compute/gce-compute.go
+++ b/pkg/gce-cloud-provider/compute/gce-compute.go
@@ -118,6 +118,8 @@ type GCECompute interface {
 	AttachDisk(ctx context.Context, project string, volKey *meta.Key, readWrite, diskType, instanceZone, instanceName string, forceAttach bool) error
 	DetachDisk(ctx context.Context, project, deviceName, instanceZone, instanceName string) error
 	ConvertDisk(ctx context.Context, project string, volKey *meta.Key, instanceName, instanceZone string, quickConversionOnly bool) error
+	ConvertDiskType(ctx context.Context, project string, volKey *meta.Key, targetDiskType string, provisionedIops, provisionedThroughput *int64) (string, error)
+	IsConvertOperationDone(ctx context.Context, project, zone, operationName string) (bool, error)
 	SetDiskAccessMode(ctx context.Context, project string, volKey *meta.Key, accessMode string) error
 	SetDiskLabels(ctx context.Context, project string, volKey *meta.Key, disk *CloudDisk, labels map[string]string) error
 	ListCompatibleDiskTypeZones(ctx context.Context, project string, zones []string, diskType string) ([]string, error)
@@ -725,6 +727,13 @@ func (cloud *CloudProvider) updateZonalDisk(ctx context.Context, project string,
 	_, err := diskUpdateOp.Context(ctx).Do()
 
 	if err != nil {
+		// GCE rejects an out-of-range or unsupported IOPS/throughput value (e.g.
+		// "IOPS cannot be smaller than 3000") by reason, not by HTTP status alone:
+		// 400/403 are also used for retriable conditions such as a rate limit or
+		// exhausted quota, which must not be classified as a bad request.
+		if IsGCEError(err, "badRequest") || IsGCEError(err, "invalidParameter") || IsGCEInvalidError(err) {
+			return status.Errorf(codes.InvalidArgument, "error updating disk %v: %v", volKey, err)
+		}
 		return fmt.Errorf("error updating disk %v: %w", volKey, err)
 	}
 
@@ -988,6 +997,88 @@ func (cloud *CloudProvider) ConvertDisk(ctx context.Context, project string, vol
 		return fmt.Errorf("failed while waiting for zonal conversion operation: %w", err)
 	}
 	return nil
+}
+
+// ConvertDiskType converts a disk to targetDiskType in place, optionally
+// applying the provisioned IOPS and throughput the target type should be
+// created with. The disk keeps its name and self link.
+//
+// Conversion can take from minutes to hours depending on disk size, so this
+// only starts the operation and returns as soon as the API accepts it. It
+// returns the self link of the conversion operation, which callers record so
+// the conversion can still be found after the driver restarts.
+func (cloud *CloudProvider) ConvertDiskType(ctx context.Context, project string, volKey *meta.Key, targetDiskType string, provisionedIops, provisionedThroughput *int64) (string, error) {
+	if volKey.Type() != meta.Zonal {
+		return "", fmt.Errorf("disk type conversion is not supported for regional disk %s", volKey.Name)
+	}
+	klog.V(5).Infof("Converting disk %v in zone %v to type %s", volKey.Name, volKey.Zone, targetDiskType)
+
+	// TargetDiskType is the bare disk type name, not a disk type URI. Passing a
+	// URI is rejected with DISK_TYPE_CONVERSION_UNSUPPORTED.
+	params := &computealpha.DiskConvertParams{
+		TargetDiskType: targetDiskType,
+	}
+	if provisionedIops != nil {
+		params.ProvisionedIops = *provisionedIops
+	}
+	if provisionedThroughput != nil {
+		params.ProvisionedThroughput = *provisionedThroughput
+	}
+
+	// Paced so that a migration of many volumes does not exceed the per-region
+	// limit on conversion calls. Waiting here costs a moment on a call whose
+	// operation runs for minutes, and saves a rejected request.
+	if err := cloud.convertRateLimiter.Wait(ctx); err != nil {
+		return "", fmt.Errorf("failed to acquire a disk conversion request token for %s: %w", volKey.Name, err)
+	}
+
+	op, err := cloud.alphaService.Disks.Convert(project, volKey.Zone, volKey.Name, &computealpha.DisksConvertRequest{Params: params}).Context(ctx).Do()
+	if err != nil {
+		return "", err
+	}
+	klog.V(4).Infof("Started convert operation %s for disk %s to type %s", op.Name, volKey.Name, targetDiskType)
+	// The self link is what identifies the operation once this call returns.
+	// Fall back to the operation name so a response without a self link still
+	// leaves something to track the conversion by.
+	if op.SelfLink != "" {
+		return op.SelfLink, nil
+	}
+	return op.Name, nil
+}
+
+// IsConvertOperationDone reports whether a disk type conversion has finished,
+// and returns the conversion's own error if it finished by failing.
+//
+// The operation is read from the alpha API, because that is where a conversion
+// started by disks.convert exists. Conversions are zonal, so there is no
+// regional equivalent of this call.
+//
+// This checks the operation once rather than waiting for it. A conversion can
+// run for hours, far longer than a request should be held open, so the caller
+// decides how often to ask.
+func (cloud *CloudProvider) IsConvertOperationDone(ctx context.Context, project, zone, operationName string) (bool, error) {
+	op, err := cloud.alphaService.ZoneOperations.Get(project, zone, operationName).Context(ctx).Do()
+	if err != nil {
+		return false, err
+	}
+	if op == nil || op.Status != operationStatusDone {
+		return false, nil
+	}
+	if op.Error != nil && len(op.Error.Errors) > 0 && op.Error.Errors[0] != nil {
+		opErr := op.Error.Errors[0]
+		// Returned as a googleapi.Error carrying the operation's own error code
+		// as the reason, so that the caller can classify the failure the same
+		// way it classifies one returned when the operation was requested.
+		return true, &googleapi.Error{
+			Code:    int(op.HttpErrorStatusCode),
+			Message: fmt.Sprintf("operation %s failed: %s: %s", operationName, opErr.Code, opErr.Message),
+			Errors: []googleapi.ErrorItem{{
+				Reason:  opErr.Code,
+				Message: opErr.Message,
+			}},
+		}
+	}
+	return true, nil
 }
 
 func (cloud *CloudProvider) SetDiskAccessMode(ctx context.Context, project string, volKey *meta.Key, accessMode string) error {

--- a/pkg/gce-cloud-provider/compute/gce.go
+++ b/pkg/gce-cloud-provider/compute/gce.go
@@ -68,6 +68,16 @@ const (
 	// gcpTagsRequestRateLimit is the tag request rate limit per second.
 	gcpTagsRequestRateLimit = 8
 
+	// gceConvertRequestRateLimit is the disk conversion request rate limit per
+	// second. GCE allows 375 disk conversion calls per minute per region, so
+	// this stays under that with room for the calls a retry makes.
+	gceConvertRequestRateLimit = 5
+
+	// gceConvertRequestTokenBucketSize is the burst size for disk conversion
+	// requests, so that a batch of volumes being converted together is not
+	// spread out any more than the limit requires.
+	gceConvertRequestTokenBucketSize = 5
+
 	// gcpTagsRequestTokenBucketSize is the burst/token bucket size used
 	// for limiting API requests.
 	gcpTagsRequestTokenBucketSize = 8
@@ -129,6 +139,11 @@ type CloudProvider struct {
 	waitForAttachConfig WaitForAttachConfig
 
 	tagsRateLimiter *rate.Limiter
+
+	// convertRateLimiter paces calls to the disk conversion API, so that a large
+	// migration does not spend its calls on requests the API would reject for
+	// exceeding the per-region rate.
+	convertRateLimiter *rate.Limiter
 
 	listInstancesConfig ListInstancesConfig
 
@@ -219,8 +234,11 @@ func CreateCloudProvider(ctx context.Context, vendorVersion string, configPath s
 		listInstancesConfig: listInstancesConfig,
 		// GCP has a rate limit of 600 requests per minute, restricting
 		// here to 8 requests per second.
-		tagsRateLimiter:  common.NewLimiter(gcpTagsRequestRateLimit, gcpTagsRequestTokenBucketSize, true),
-		tenantServiceMap: make(map[string]*compute.Service),
+		tagsRateLimiter: common.NewLimiter(gcpTagsRequestRateLimit, gcpTagsRequestTokenBucketSize, true),
+		// GCE allows 375 disk conversion calls per minute per region, restricting
+		// here to 5 requests per second.
+		convertRateLimiter: common.NewLimiter(gceConvertRequestRateLimit, gceConvertRequestTokenBucketSize, true),
+		tenantServiceMap:   make(map[string]*compute.Service),
 	}
 
 	if multiTenancyEnabled {

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"math/rand"
 	neturl "net/url"
+	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -33,8 +35,10 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/strings/slices"
@@ -56,6 +60,20 @@ type GCEControllerServer struct {
 	volumeEntries     []*csi.ListVolumesResponse_Entry
 	volumeEntriesSeen map[string]int
 	listVolumesLock   sync.Mutex
+
+	// The background watchers following disk type conversions, keyed by volume
+	// key. A watcher outlives the call that started it, so it has to be
+	// stoppable when the volume goes away.
+	conversionWatchers     map[string]*conversionWatcher
+	conversionWatchersLock sync.Mutex
+
+	// Tracks the background conversions started on detach, so that they can be
+	// waited for rather than assumed finished.
+	conversionWorkers sync.WaitGroup
+
+	// How often a running conversion is checked. Zero means the default,
+	// conversionPollBackoff. Tests set it so they need not wait minutes.
+	conversionPollBackoffOverride wait.Backoff
 
 	snapshots         []*csi.ListSnapshotsResponse_Entry
 	snapshotTokens    map[string]int
@@ -913,8 +931,48 @@ func (gceCS *GCEControllerServer) ControllerModifyVolume(ctx context.Context, re
 		return nil, err
 	}
 
-	// Check if the disk supports dynamic IOPS/Throughput provisioning
+	// A class that asks for nothing is how a volume's class is withdrawn, so a
+	// conversion still queued for it is dropped rather than left waiting for a
+	// class that no longer asks for anything.
+	if volumeModifyParams.DiskType == nil && volumeModifyParams.IOPS == nil && volumeModifyParams.Throughput == nil {
+		opVal, exists, _ := k8sclient.GetPVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionOperationKey)
+		if exists && opVal == constants.ConversionStatePending {
+			klog.V(4).Infof("VAC cleared for volume %s. Cancelling queued conversion.", volumeID)
+			_ = k8sclient.RemovePVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionOperationKey)
+			k8sclient.EmitPVEvent(ctx, volKey.Name, v1.EventTypeNormal, constants.DiskTypeConversionCancelReason, constants.DiskTypeConversionAction, "Disk type conversion cancelled by user")
+		}
+
+		klog.V(4).Infof("Volume %s has empty parameters, nothing to modify.", volumeID)
+		return &csi.ControllerModifyVolumeResponse{}, nil
+	}
+
+	// If the VolumeAttributesClass requests a disk type that doesn't match the
+	// disk's actual type, this is a disk type conversion request rather than an
+	// IOPS/throughput update. This must be handled before the checks below,
+	// which are keyed on the disk's current type and would reject types that
+	// are valid conversion sources.
 	diskType := existingDisk.GetPDType()
+	if volumeModifyParams.DiskType != nil && *volumeModifyParams.DiskType != diskType {
+		return gceCS.convertDiskType(ctx, project, volKey, volumeID, existingDisk, volumeModifyParams)
+	}
+
+	// The disk already has the requested type, either because a conversion
+	// finished or because it never needed one.
+	if volumeModifyParams.DiskType != nil {
+		if err := gceCS.completeConversionIfInProgress(ctx, volKey, volumeID, diskType); err != nil {
+			return nil, err
+		}
+	}
+
+	// The disk is already the requested type. If no other attributes were
+	// requested there is nothing left to do, which is also how a completed
+	// conversion is reported as successful on a subsequent retry.
+	if volumeModifyParams.IOPS == nil && volumeModifyParams.Throughput == nil {
+		klog.V(4).Infof("Volume %s already has the requested attributes", volumeID)
+		return &csi.ControllerModifyVolumeResponse{}, nil
+	}
+
+	// Check if the disk supports dynamic IOPS/Throughput provisioning
 	supportsIopsChange := gceCS.diskSupportsIopsChange(diskType)
 	supportsThroughputChange := gceCS.diskSupportsThroughputChange(diskType)
 	if !supportsIopsChange && !supportsThroughputChange {
@@ -930,6 +988,10 @@ func (gceCS *GCEControllerServer) ControllerModifyVolume(ctx context.Context, re
 		return nil, err
 	}
 
+	if err := common.ValidateMaxProvisioned(diskType, existingDisk.GetSizeGb(), existingDisk.GetProvisionedIops(), volumeModifyParams.IOPS, volumeModifyParams.Throughput); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Failed to modify volume %s: %v", volumeID, err)
+	}
+
 	err = gceCS.CloudProvider.UpdateDisk(ctx, project, volKey, existingDisk, volumeModifyParams)
 	if err != nil {
 		klog.Errorf("Failed to modify volume %s: %v", volumeID, err)
@@ -938,6 +1000,903 @@ func (gceCS *GCEControllerServer) ControllerModifyVolume(ctx context.Context, re
 	}
 
 	return &csi.ControllerModifyVolumeResponse{}, nil
+}
+
+// convertDiskType starts an in-place disk type conversion for a volume whose
+// VolumeAttributesClass requests a type different from the disk's current type.
+//
+// The GCE conversion can run for minutes to hours, far longer than a single
+// ModifyVolume call may block, so this returns as soon as the operation has
+// been accepted. The modification stays pending and is retried; once the disk
+// reports the target type, the retry falls through to the regular
+// IOPS/throughput path and the modification completes.
+func (gceCS *GCEControllerServer) convertDiskType(ctx context.Context, project string, volKey *meta.Key, volumeID string, existingDisk *gce.CloudDisk, params parameters.ModifyVolumeParameters) (*csi.ControllerModifyVolumeResponse, error) {
+	targetDiskType := *params.DiskType
+	currentDiskType := existingDisk.GetPDType()
+
+	if !gceCS.EnablePdConversion {
+		return nil, status.Errorf(codes.InvalidArgument, "cannot convert volume %s from %s to %s: disk conversion is not enabled on this driver", volumeID, currentDiskType, targetDiskType)
+	}
+
+	if reason := unsupportedConversionReason(volKey, existingDisk); reason != "" {
+		return nil, status.Errorf(codes.InvalidArgument, "cannot convert volume %s from %s to %s: %s", volumeID, currentDiskType, targetDiskType, reason)
+	}
+
+	// Conversion does not change disk size, so the target type's ceilings are
+	// checked against the disk's current size and IOPS, same as the plain
+	// IOPS/throughput update path below.
+	if err := common.ValidateMaxProvisioned(targetDiskType, existingDisk.GetSizeGb(), existingDisk.GetProvisionedIops(), params.IOPS, params.Throughput); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "cannot convert volume %s from %s to %s: %v", volumeID, currentDiskType, targetDiskType, err)
+	}
+
+	// An IOPS or throughput value that the target type does not support is
+	// rejected here rather than sent to the convert API, the same way it is
+	// rejected on the plain IOPS/throughput update path below.
+	if params.IOPS != nil && !gceCS.diskSupportsIopsChange(targetDiskType) {
+		return nil, status.Errorf(codes.InvalidArgument, "cannot convert volume %s from %s to %s: cannot specify IOPS for disk type %s", volumeID, currentDiskType, targetDiskType, targetDiskType)
+	}
+	if params.Throughput != nil && !gceCS.diskSupportsThroughputChange(targetDiskType) {
+		return nil, status.Errorf(codes.InvalidArgument, "cannot convert volume %s from %s to %s: cannot specify throughput for disk type %s", volumeID, currentDiskType, targetDiskType, targetDiskType)
+	}
+
+	// Conversion requires the disk to be detached. Report this as retryable so
+	// the conversion starts once the workload using the volume is scaled down.
+	if users := existingDisk.GetUsers(); len(users) > 0 {
+		// The annotation is what makes the detach hook start this conversion, so
+		// losing it means the conversion never resumes. The error returned below
+		// is retryable, and the next attempt writes the annotation again.
+		gceCS.markConversionPending(ctx, volKey, volumeID)
+		return nil, status.Errorf(codes.FailedPrecondition, "cannot convert volume %s from %s to %s while it is attached to %v, detach the volume to start the conversion", volumeID, currentDiskType, targetDiskType, users)
+	}
+
+	operation, err := gceCS.startDiskTypeConversion(ctx, project, volKey, currentDiskType, targetDiskType, params)
+	if err != nil {
+		// A conversion already running means the disk is being rebuilt, so the
+		// volume stays blocked whatever the failure is classified as.
+		if isConversionInProgressError(err) {
+			gceCS.markConversionPending(ctx, volKey, volumeID)
+			return nil, status.Errorf(codes.Unavailable, "conversion of volume %s from %s to %s is in progress", volumeID, currentDiskType, targetDiskType)
+		}
+		if isUnsupportedConversionIntentError(err) {
+			return nil, status.Errorf(codes.InvalidArgument, "cannot convert volume %s from %s to %s: %v", volumeID, currentDiskType, targetDiskType, err)
+		}
+		// The conversion will be retried, so the volume has to stay blocked in
+		// the meantime.
+		gceCS.markConversionPending(ctx, volKey, volumeID)
+		if reason := conversionRetryReason(err); reason != "" {
+			return nil, status.Errorf(codes.Unavailable, "conversion of volume %s from %s to %s will be retried: %s: %v", volumeID, currentDiskType, targetDiskType, reason, err)
+		}
+		return nil, status.Errorf(codes.Unavailable, "failed to start conversion of volume %s from %s to %s: %v", volumeID, currentDiskType, targetDiskType, err)
+	}
+
+	// An earlier conversion that failed and was requeued is reported here, so
+	// that the reason it failed reaches the claim rather than being visible only
+	// as an event. The new conversion has already started, so the record of the
+	// old failure is no longer needed.
+	if lastErr, exists, err := k8sclient.GetPVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionLastErrorKey); err != nil {
+		klog.Warningf("Could not read the recorded conversion failure of volume %s: %v", volumeID, err)
+	} else if exists && lastErr != "" {
+		if err := k8sclient.RemovePVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionLastErrorKey); err != nil {
+			klog.Warningf("Failed to clear the recorded conversion failure of volume %s: %v", volumeID, err)
+		}
+		return nil, status.Errorf(codes.Unavailable, "conversion of volume %s from %s to %s was retried after it failed with: %s; the new conversion is in progress (%s)", volumeID, currentDiskType, targetDiskType, lastErr, operation)
+	}
+
+	// The conversion has started but is not finished, so the requested
+	// attributes are not in effect yet.
+	return nil, status.Errorf(codes.Unavailable, "conversion of volume %s from %s to %s is in progress (%s)", volumeID, currentDiskType, targetDiskType, operation)
+}
+
+// markConversionPending records that a volume is waiting for a conversion that
+// has not started, so that the volume stays blocked and the conversion is
+// attempted again.
+//
+// A conversion that is already running keeps its operation instead. The
+// operation is the only record of which conversion is running: it is what a user
+// tracks, what a restarted driver polls, and what tells a later check that the
+// conversion has finished.
+func (gceCS *GCEControllerServer) markConversionPending(ctx context.Context, volKey *meta.Key, volumeID string) {
+	operation, exists, err := k8sclient.GetPVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionOperationKey)
+	if err != nil {
+		// The state could not be read, so the volume is marked pending to keep
+		// it blocked.
+		klog.Warningf("Could not read the conversion state of volume %s before marking it pending: %v", volumeID, err)
+	} else if exists && operation != "" && operation != "null" && operation != constants.ConversionStatePending {
+		klog.V(4).Infof("Volume %s is already being converted by operation %s, leaving it recorded", volumeID, operation)
+		return
+	}
+
+	if err := k8sclient.SetPVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionOperationKey, constants.ConversionStatePending); err != nil {
+		klog.Warningf("Failed to mark volume %s as pending conversion, the conversion will not start on detach until this succeeds: %v", volumeID, err)
+	}
+}
+
+// startDiskTypeConversion asks GCE to convert a disk and records the state that
+// lets the conversion be tracked and completed later, by whichever call sees the
+// disk next. It returns the conversion operation.
+//
+// The caller decides what a failure means for the operation it is serving, and
+// is responsible for the checks that depend on that context, such as whether the
+// disk is still attached.
+func (gceCS *GCEControllerServer) startDiskTypeConversion(ctx context.Context, project string, volKey *meta.Key, currentDiskType, targetDiskType string, params parameters.ModifyVolumeParameters) (string, error) {
+	klog.V(4).Infof("Converting disk %s from %s to %s", volKey.Name, currentDiskType, targetDiskType)
+
+	operation, err := gceCS.CloudProvider.ConvertDiskType(ctx, project, volKey, targetDiskType, params.IOPS, params.Throughput)
+	if err != nil {
+		klog.Errorf("Failed to convert disk %s from %s to %s: %v", volKey.Name, currentDiskType, targetDiskType, err)
+		return "", err
+	}
+
+	// Record the type the disk is being converted from before the operation, so
+	// that the pair of converted-from and converted-to annotations can be
+	// completed later, when the disk no longer reports its original type.
+	if err := k8sclient.SetPVAnnotation(ctx, volKey.Name, constants.DiskTypeConvertedFromKey, currentDiskType); err != nil {
+		klog.Warningf("Failed to record the original type of disk %s, the completed conversion will not report what it was converted from: %v", volKey.Name, err)
+	}
+
+	// The operation self link identifies this conversion for as long as it runs.
+	// It is what a user inspects to track the conversion, and what tells any
+	// later call, including one made by a restarted driver, that the volume is
+	// still being converted.
+	if err := k8sclient.SetPVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionOperationKey, operation); err != nil {
+		klog.Errorf("Started conversion operation %s for disk %s but failed to record it, attaches are not blocked until this succeeds: %v", operation, volKey.Name, err)
+	}
+
+	k8sclient.EmitPVEvent(ctx, volKey.Name, v1.EventTypeNormal, constants.DiskTypeConversionStartReason, constants.DiskTypeConversionAction,
+		fmt.Sprintf("Disk type conversion started for volume %q from %s to %s", volKey.Name, currentDiskType, targetDiskType))
+
+	// Follow the conversion so that its completion is recorded when it happens
+	// rather than at the next operation on the volume. This is an optimisation:
+	// losing the watcher costs promptness, not correctness.
+	gceCS.watchConversion(project, volKey, operation)
+
+	return operation, nil
+}
+
+// conversionPollBackoff paces the checks on a running conversion. Conversions
+// take from minutes to hours, so the interval grows to a cap rather than
+// polling at a fixed rate, and is capped so that a conversion which finishes
+// early is still noticed promptly.
+var conversionPollBackoff = wait.Backoff{
+	Duration: 10 * time.Second,
+	Factor:   1.5,
+	Jitter:   0.1,
+	Cap:      2 * time.Minute,
+	Steps:    math.MaxInt32,
+}
+
+// conversionOperationName extracts the operation name from the value recorded in
+// the conversion annotation, which is normally a self link.
+func conversionOperationName(operation string) string {
+	if operation == "" || operation == constants.ConversionStatePending {
+		return ""
+	}
+	return path.Base(operation)
+}
+
+// watchConversion follows a running conversion in the background and records the
+// outcome when it finishes.
+//
+// This is only a way to notice a conversion promptly, never the record of one.
+// The state that matters is on the PersistentVolume, so a conversion whose
+// watcher is lost to a restart is still completed correctly by the next attach
+// or expand. That is why nothing here fails an operation.
+func (gceCS *GCEControllerServer) watchConversion(project string, volKey *meta.Key, operation string) {
+	opName := conversionOperationName(operation)
+	if opName == "" {
+		return
+	}
+
+	// The request that started the conversion is finished long before the
+	// conversion is, so the watcher gets a context that outlives it and is
+	// cancelled explicitly instead.
+	ctx, cancel := context.WithCancel(context.Background())
+	watcher := &conversionWatcher{
+		cancel: cancel,
+		opName: opName,
+	}
+	gceCS.registerConversionWatcher(volKey, watcher)
+
+	// Counted alongside the conversions started on detach, so a caller can wait
+	// for all the background work. A cancelled watcher leaves the registry at
+	// once but stops a moment later, so the registry alone does not say when the
+	// goroutine has finished.
+	gceCS.conversionWorkers.Add(1)
+	go func() {
+		defer gceCS.conversionWorkers.Done()
+		defer gceCS.unregisterConversionWatcher(volKey, watcher)
+		gceCS.pollConversion(ctx, project, volKey, operation, opName)
+	}()
+}
+
+// conversionWatcher is a running watcher, identified by its own pointer so that
+// a watcher which has been replaced cannot deregister its replacement.
+type conversionWatcher struct {
+	cancel context.CancelFunc
+	opName string // Track which operation this watcher is following
+}
+
+// registerConversionWatcher records a watcher, stopping any watcher already
+// following this volume.
+func (gceCS *GCEControllerServer) registerConversionWatcher(volKey *meta.Key, watcher *conversionWatcher) {
+	gceCS.conversionWatchersLock.Lock()
+	defer gceCS.conversionWatchersLock.Unlock()
+
+	if gceCS.conversionWatchers == nil {
+		gceCS.conversionWatchers = map[string]*conversionWatcher{}
+	}
+	// A volume has at most one conversion, so an existing watcher is following
+	// an attempt that has been superseded. Leaving it running would poll an
+	// operation nobody is waiting for.
+	if previous, ok := gceCS.conversionWatchers[volKey.String()]; ok {
+		previous.cancel()
+	}
+	gceCS.conversionWatchers[volKey.String()] = watcher
+}
+
+// unregisterConversionWatcher removes a watcher, but only if it is still the
+// registered one. A watcher that has been replaced must not remove the watcher
+// that replaced it, which it would otherwise do on its way out.
+func (gceCS *GCEControllerServer) unregisterConversionWatcher(volKey *meta.Key, watcher *conversionWatcher) {
+	gceCS.conversionWatchersLock.Lock()
+	defer gceCS.conversionWatchersLock.Unlock()
+
+	if current, ok := gceCS.conversionWatchers[volKey.String()]; ok && current == watcher {
+		delete(gceCS.conversionWatchers, volKey.String())
+	}
+}
+
+// stopConversionWatcher stops following a volume's conversion. It is called when
+// the volume is deleted, so that a watcher does not outlive the disk it is
+// polling.
+func (gceCS *GCEControllerServer) stopConversionWatcher(volKey *meta.Key) {
+	gceCS.conversionWatchersLock.Lock()
+	defer gceCS.conversionWatchersLock.Unlock()
+
+	if watcher, ok := gceCS.conversionWatchers[volKey.String()]; ok {
+		klog.V(4).Infof("Stopping the disk type conversion watcher for volume %s", volKey.Name)
+		watcher.cancel()
+		delete(gceCS.conversionWatchers, volKey.String())
+	}
+}
+
+// pollConversion checks a conversion until it finishes, the volume stops needing
+// it, or the watcher is cancelled.
+func (gceCS *GCEControllerServer) pollConversion(ctx context.Context, project string, volKey *meta.Key, operation, opName string) {
+	klog.V(4).Infof("Watching disk type conversion %s of volume %s", opName, volKey.Name)
+	backoff := conversionPollBackoff
+	if gceCS.conversionPollBackoffOverride.Duration > 0 {
+		backoff = gceCS.conversionPollBackoffOverride
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			klog.V(4).Infof("Stopped watching disk type conversion %s of volume %s", opName, volKey.Name)
+			return
+		case <-time.After(backoff.Step()):
+		}
+
+		done, err := gceCS.CloudProvider.IsConvertOperationDone(ctx, project, volKey.Zone, opName)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			if done {
+				// The conversion ran and failed. A failure the target
+				// configuration can never recover from is terminal, so the
+				// state is cleared and the volume released. Any other failure,
+				// including one that carries no recognised reason, is retriable:
+				// the volume goes back to waiting for a conversion, which keeps
+				// it blocked and starts a new conversion on the next attempt.
+				klog.Errorf("Disk type conversion %s of volume %s failed: %v", opName, volKey.Name, err)
+				if isUnsupportedConversionIntentError(err) {
+					gceCS.recordFailedConversion(ctx, volKey, operation, err)
+					return
+				}
+				gceCS.requeueFailedConversion(ctx, volKey, err)
+				return
+			}
+			// The operation could not be read. Keep watching, because the
+			// conversion itself is unaffected by a failure to look at it.
+			klog.Warningf("Could not check disk type conversion %s of volume %s, still watching: %v", opName, volKey.Name, err)
+			continue
+		}
+		if !done {
+			continue
+		}
+
+		disk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey)
+		if err != nil {
+			klog.Warningf("Disk type conversion %s of volume %s finished but the disk could not be read, leaving it to be recorded at the next attach: %v", opName, volKey.Name, err)
+			return
+		}
+		klog.V(4).Infof("Disk type conversion %s of volume %s finished", opName, volKey.Name)
+		if err := gceCS.recordCompletedConversion(ctx, volKey, operation, disk.GetPDType()); err != nil {
+			klog.Warningf("Failed to record the completed conversion of volume %s, it will be recorded at the next attach: %v", volKey.Name, err)
+		}
+
+		// The class may have been changed while this conversion was running, so
+		// what it asks for now decides whether another conversion follows.
+		//
+		// Recording the completion stops this watcher, which cancels the context
+		// the poll was using, so the work that follows gets one that outlives it.
+		reconcileCtx := context.Background()
+		if err := gceCS.reconcileLatestVACAfterConversion(reconcileCtx, project, volKey, disk); err != nil {
+			klog.Warningf("Failed to act on the VolumeAttributesClass of volume %s after its conversion: %v", volKey.Name, err)
+		}
+		return
+	}
+}
+
+// requeueFailedConversion puts a volume back to waiting for a conversion, after
+// one that ran and failed for a reason that can clear on its own or be cleared
+// by the user.
+//
+// The volume keeps the pending state, so it stays blocked and the conversion is
+// attempted again, and the failure is kept so that the next attempt can report
+// it on the claim rather than leaving it visible only as an event.
+func (gceCS *GCEControllerServer) requeueFailedConversion(ctx context.Context, volKey *meta.Key, conversionErr error) {
+	if err := k8sclient.SetPVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionLastErrorKey, conversionErr.Error()); err != nil {
+		klog.Warningf("Failed to record why the conversion of volume %s failed, it will not be reported on the claim: %v", volKey.Name, err)
+	}
+	// The disk keeps its original type until a conversion succeeds, so what was
+	// recorded about converting away from it is not true yet.
+	if err := k8sclient.RemovePVAnnotation(ctx, volKey.Name, constants.DiskTypeConvertedFromKey); err != nil {
+		klog.Warningf("Failed to clear the original type recorded for volume %s: %v", volKey.Name, err)
+	}
+	if err := k8sclient.SetPVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionOperationKey, constants.ConversionStatePending); err != nil {
+		klog.Errorf("Failed to put volume %s back to waiting for conversion after its conversion failed, it will not be retried until this succeeds: %v", volKey.Name, err)
+		return
+	}
+
+	message := fmt.Sprintf("Disk type conversion of volume %q failed and will be retried: %v", volKey.Name, conversionErr)
+	if reason := conversionRetryReason(conversionErr); reason != "" {
+		message = fmt.Sprintf("Disk type conversion of volume %q failed and will be retried: %s: %v", volKey.Name, reason, conversionErr)
+	}
+	k8sclient.EmitPVEvent(ctx, volKey.Name, v1.EventTypeWarning, constants.DiskTypeConversionRetryReason, constants.DiskTypeConversionAction, message)
+}
+
+// recordFailedConversion clears the state of a conversion that ran and failed,
+// so that the volume is usable and the modification can be attempted again.
+func (gceCS *GCEControllerServer) recordFailedConversion(ctx context.Context, volKey *meta.Key, operation string, conversionErr error) {
+	// A conversion that is no longer the one recorded on the volume has been
+	// superseded, so its failure is not written: clearing the state here would
+	// release a volume whose newer conversion is still running.
+	currentOp, exists, err := k8sclient.GetPVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionOperationKey)
+	if err != nil {
+		klog.Errorf("Failed to read the conversion state of volume %s: %v", volKey.Name, err)
+		return
+	}
+	if !exists || (operation != "" && currentOp != operation) {
+		klog.V(4).Infof("Not recording the failure of conversion %s of volume %s, the volume is now on %q", operation, volKey.Name, currentOp)
+		return
+	}
+	if err != nil {
+		klog.Errorf("Failed to read conversion annotation for disk %s: %v", volKey.Name, err)
+		return
+	}
+
+	// If the annotation doesn't exist, nothing to clear
+	if !exists {
+		return
+	}
+
+	// Check if this is the current operation
+	// We need to check if the error we're recording matches the current operation
+	// For simplicity, if there's an operation annotation, we'll clear it on failure.
+	// This is safe because a failed conversion should always unblock the volume.
+
+	if err := k8sclient.RemovePVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionOperationKey); err != nil {
+		klog.Errorf("Failed to clear the conversion state of volume %s after it failed, operations on it stay blocked until this succeeds: %v", volKey.Name, err)
+		return
+	}
+	// The disk keeps its original type, so what was recorded about converting
+	// away from it is no longer true.
+	if err := k8sclient.RemovePVAnnotation(ctx, volKey.Name, constants.DiskTypeConvertedFromKey); err != nil {
+		klog.Warningf("Failed to clear the original type recorded for volume %s: %v", volKey.Name, err)
+	}
+	k8sclient.EmitPVEvent(ctx, volKey.Name, v1.EventTypeWarning, constants.DiskTypeConversionFailedReason, constants.DiskTypeConversionAction,
+		fmt.Sprintf("Disk type conversion of volume %q failed: %v", volKey.Name, conversionErr))
+}
+
+// isCurrentWatcher checks if the given operation is still the active conversion
+// for the volume. This prevents stale watchers from taking action on a newer
+// conversion that replaced them.
+func (gceCS *GCEControllerServer) isCurrentWatcher(
+	ctx context.Context,
+	volKey *meta.Key,
+	opName string,
+) (bool, error) {
+	currentOp, exists, err := k8sclient.GetPVAnnotation(
+		ctx,
+		volKey.Name,
+		constants.DiskTypeConversionOperationKey,
+	)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		// No active conversion - this watcher is not current
+		return false, nil
+	}
+	// Compare the operation names (the annotation might be a full URI)
+	return currentOp == opName || path.Base(currentOp) == opName, nil
+}
+
+// unsupportedConversionReason describes why a disk can never be converted, or
+// returns the empty string for one that can be. These are properties of the disk
+// rather than of the requested target, so they are worth answering before
+// calling the API, which would only reject the request anyway.
+func unsupportedConversionReason(volKey *meta.Key, disk *gce.CloudDisk) string {
+	// Regional disks have no conversion API.
+	if volKey.Type() != meta.Zonal {
+		return "disk type conversion is not supported for regional disks"
+	}
+	if disk == nil {
+		return ""
+	}
+	// A disk that more than one node can write to cannot be taken away and
+	// rebuilt the way a conversion needs to.
+	if disk.GetMultiWriter() || disk.GetAccessMode() == constants.GCEReadWriteManyAccessMode {
+		return "disk type conversion is not supported for multi-writer disks"
+	}
+	return ""
+}
+
+// completeConversionIfInProgress records a finished disk type conversion, for a
+// volume whose disk already reports the type its VolumeAttributesClass asks for.
+//
+// A matching type on its own does not mean a conversion happened: applying a
+// VolumeAttributesClass that names the type a disk was created with is an
+// IOPS and throughput update, and must not leave the volume claiming it was
+// migrated. The conversion annotation, written when the conversion started, is
+// what tells the two apart.
+func (gceCS *GCEControllerServer) completeConversionIfInProgress(ctx context.Context, volKey *meta.Key, volumeID string, diskType string) error {
+	if !gceCS.EnablePdConversion {
+		return nil
+	}
+
+	operation, exists, err := k8sclient.GetPVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionOperationKey)
+	if err != nil {
+		// Clearing the annotation is what unblocks attaches, so a volume whose
+		// state could not be read must be retried rather than reported modified.
+		klog.Errorf("Could not read the disk type conversion state of volume %s: %v", volumeID, err)
+		return status.Errorf(codes.Unavailable, "cannot complete the modification of volume %s: could not determine whether a disk type conversion is in progress: %v", volumeID, err)
+	}
+	if !exists || operation == "" || operation == "null" {
+		// No conversion was ever started for this volume.
+		return nil
+	}
+
+	// A conversion that was only ever queued never ran, so the disk having the
+	// requested type means the volume no longer needs one, not that one happened.
+	// Recording it as converted would claim a migration that never took place.
+	if operation == constants.ConversionStatePending {
+		klog.V(4).Infof("Volume %s is already %s, dropping its queued disk type conversion", volumeID, diskType)
+		if err := k8sclient.RemovePVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionOperationKey); err != nil {
+			klog.Errorf("Failed to clear the queued conversion of volume %s, attaches stay blocked until this succeeds: %v", volumeID, err)
+			return status.Errorf(codes.Unavailable, "cannot complete the modification of volume %s: could not clear its queued conversion: %v", volumeID, err)
+		}
+		return nil
+	}
+
+	klog.V(4).Infof("Disk type conversion %s of volume %s to %s is complete", operation, volumeID, diskType)
+
+	// Clearing the annotation is what unblocks attaches, so a volume whose state
+	// could not be written must be retried rather than reported modified.
+	if err := gceCS.recordCompletedConversion(ctx, volKey, operation, diskType); err != nil {
+		return status.Errorf(codes.Unavailable, "converted volume %s to %s but could not clear its conversion state: %v", volumeID, diskType, err)
+	}
+	return nil
+}
+
+// checkNoConversionInProgress returns an error if a disk type conversion is
+// running or queued for a volume, to keep operations that are unsafe during a
+// conversion from starting. The operation name is only used in messages.
+//
+// A conversion that has already finished does not block anything. Because the
+// driver is only called on volume lifecycle events, nothing is guaranteed to be
+// watching a conversion when it completes, so this doubles as the point where a
+// conversion nobody saw finish is noticed and recorded. Without that, a driver
+// restart during a conversion would leave the volume unattachable for good.
+// disk may be nil, which only costs the completion check.
+//
+// This fails closed: if the conversion state cannot be read, the operation is
+// rejected rather than allowed. Wrongly rejecting delays a pod, while wrongly
+// allowing can corrupt the volume the conversion is rebuilding. The returned
+// error is retryable, so the caller's sidecar tries again once the API server
+// is reachable.
+func (gceCS *GCEControllerServer) checkNoConversionInProgress(ctx context.Context, volKey *meta.Key, disk *gce.CloudDisk, operation string) error {
+	// Without the feature there is nothing that could set the annotation, so
+	// clusters not converting disks keep their existing behaviour.
+	if !gceCS.EnablePdConversion {
+		return nil
+	}
+
+	opVal, exists, err := k8sclient.GetPVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionOperationKey)
+	if err != nil {
+		klog.Errorf("Refusing to %s disk %s: could not read its disk type conversion state: %v", operation, volKey.Name, err)
+		return status.Errorf(codes.Unavailable, "cannot %s disk %s: could not determine whether a disk type conversion is in progress: %v", operation, volKey.Name, err)
+	}
+	if !exists || opVal == "" || opVal == "null" {
+		return nil
+	}
+
+	// A conversion that never started cannot have finished, but it can have
+	// been abandoned: the detach that would run it may never come, so this is
+	// also checked here rather than only when the volume finally detaches.
+	if opVal == constants.ConversionStatePending {
+		_, cancelReason, err := gceCS.queuedConversionOutcome(ctx, volKey, disk)
+		if err != nil {
+			klog.Errorf("Refusing to %s disk %s: could not tell whether its queued disk type conversion is still requested: %v", operation, volKey.Name, err)
+			return status.Errorf(codes.Unavailable, "cannot %s disk %s: could not determine whether the queued disk type conversion is still requested: %v", operation, volKey.Name, err)
+		}
+		if cancelReason != "" {
+			klog.V(4).Infof("Disk %s has a queued disk type conversion that is no longer requested, unblocking the %s: %s", volKey.Name, operation, cancelReason)
+			gceCS.cancelQueuedConversion(ctx, volKey, cancelReason)
+			return nil
+		}
+	} else {
+		done, err := gceCS.conversionHasCompleted(ctx, volKey, disk)
+		if err != nil {
+			klog.Errorf("Refusing to %s disk %s: could not tell whether its disk type conversion finished: %v", operation, volKey.Name, err)
+			return status.Errorf(codes.Unavailable, "cannot %s disk %s: could not determine whether the disk type conversion finished: %v", operation, volKey.Name, err)
+		}
+		if done {
+			klog.V(4).Infof("Disk type conversion %s of disk %s finished while it was not being watched, recording it before the %s", opVal, volKey.Name, operation)
+			if err := gceCS.recordCompletedConversion(ctx, volKey, opVal, disk.GetPDType()); err != nil {
+				return status.Errorf(codes.Unavailable, "cannot %s disk %s: its disk type conversion finished but could not be recorded: %v", operation, volKey.Name, err)
+			}
+			return nil
+		}
+	}
+
+	klog.Errorf("Refusing to %s disk %s: disk type conversion is in progress: %s", operation, volKey.Name, opVal)
+	return status.Errorf(codes.Unavailable, "cannot %s disk %s: a disk type conversion is in progress (%s)", operation, volKey.Name, opVal)
+}
+
+// queuedConversionOutcome reports whether a queued (Pending) disk type
+// conversion is still requested by the volume's current
+// VolumeAttributesClass. A non-empty cancelReason means the conversion
+// should be abandoned rather than run; params is only meaningful when
+// cancelReason is empty and err is nil, in which case params.DiskType is
+// guaranteed to be set.
+//
+// disk may be nil, in which case the disk's current type cannot be checked
+// against the class and the conversion is treated as still wanted rather
+// than cancelled without proof.
+func (gceCS *GCEControllerServer) queuedConversionOutcome(ctx context.Context, volKey *meta.Key, disk *gce.CloudDisk) (params parameters.ModifyVolumeParameters, cancelReason string, err error) {
+	parameterMap, exists, err := k8sclient.GetVolumeAttributesClassForPV(ctx, volKey.Name)
+	if err != nil {
+		return parameters.ModifyVolumeParameters{}, "", err
+	}
+	if !exists {
+		return parameters.ModifyVolumeParameters{}, "its VolumeAttributesClass was removed", nil
+	}
+
+	extracted, err := parameters.ExtractModifyVolumeParameters(parameterMap)
+	if err != nil {
+		return parameters.ModifyVolumeParameters{}, fmt.Sprintf("its VolumeAttributesClass is invalid: %v", err), nil
+	}
+	if extracted.DiskType == nil {
+		return parameters.ModifyVolumeParameters{}, "its VolumeAttributesClass no longer asks for a disk type", nil
+	}
+	if disk != nil && disk.GetPDType() == *extracted.DiskType {
+		return parameters.ModifyVolumeParameters{}, fmt.Sprintf("it is already %s", disk.GetPDType()), nil
+	}
+	if reason := gceCS.unconvertibleToTargetReason(volKey, disk, *extracted.DiskType, extracted); reason != "" {
+		return parameters.ModifyVolumeParameters{}, reason, nil
+	}
+	return extracted, "", nil
+}
+
+// unconvertibleToTargetReason describes why a volume can never be converted to
+// the type its VolumeAttributesClass asks for, or returns the empty string when
+// nothing rules the conversion out. A conversion ruled out here will not happen
+// however long the volume waits, so the volume is released rather than left
+// waiting for a conversion that cannot run.
+func (gceCS *GCEControllerServer) unconvertibleToTargetReason(volKey *meta.Key, disk *gce.CloudDisk, targetDiskType string, params parameters.ModifyVolumeParameters) string {
+	if reason := unsupportedConversionReason(volKey, disk); reason != "" {
+		return reason
+	}
+	if params.IOPS != nil && !gceCS.diskSupportsIopsChange(targetDiskType) {
+		return fmt.Sprintf("IOPS cannot be specified for disk type %s", targetDiskType)
+	}
+	if params.Throughput != nil && !gceCS.diskSupportsThroughputChange(targetDiskType) {
+		return fmt.Sprintf("throughput cannot be specified for disk type %s", targetDiskType)
+	}
+	if disk == nil {
+		return ""
+	}
+	if err := common.ValidateMaxProvisioned(targetDiskType, disk.GetSizeGb(), disk.GetProvisionedIops(), params.IOPS, params.Throughput); err != nil {
+		return fmt.Sprintf("its VolumeAttributesClass asks for values %s does not support: %v", targetDiskType, err)
+	}
+	return ""
+}
+
+// conversionHasCompleted reports whether the conversion recorded for a volume
+// has already finished, by comparing the disk's current type against the type it
+// was converted from.
+//
+// The disk's own type is the authority here rather than the conversion
+// operation, because the operation only says the conversion was accepted, while
+// the type says the disk is the one the volume now expects.
+func (gceCS *GCEControllerServer) conversionHasCompleted(ctx context.Context, volKey *meta.Key, disk *gce.CloudDisk) (bool, error) {
+	if disk == nil {
+		return false, nil
+	}
+	convertedFrom, exists, err := k8sclient.GetPVAnnotation(ctx, volKey.Name, constants.DiskTypeConvertedFromKey)
+	if err != nil {
+		return false, err
+	}
+	// Conversions started before the original type was recorded, and those still
+	// waiting for a detach, have nothing to compare against. They are left to the
+	// conversion path to finish rather than guessed at here.
+	if !exists || convertedFrom == "" {
+		return false, nil
+	}
+	return disk.GetPDType() != convertedFrom, nil
+}
+
+// recordCompletedConversion writes the outcome of a finished conversion and
+// clears the state that blocks operations on the volume.
+// The operation parameter must match the current annotation to prevent stale
+// watchers from clearing newer conversions.
+func (gceCS *GCEControllerServer) recordCompletedConversion(ctx context.Context, volKey *meta.Key, operation, diskType string) error {
+	// A conversion that is no longer the one recorded on the volume has been
+	// superseded, so its outcome is not written: clearing the state here would
+	// release a volume whose newer conversion is still running.
+	currentOperation, exists, err := k8sclient.GetPVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionOperationKey)
+	if err != nil {
+		klog.Errorf("Failed to read the conversion state of volume %s: %v", volKey.Name, err)
+		return err
+	}
+	if !exists || currentOperation != operation {
+		klog.V(4).Infof("Not recording conversion %s of volume %s, the volume is now on %q", operation, volKey.Name, currentOperation)
+		return nil
+	}
+
+	if err := k8sclient.RemovePVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionLastErrorKey); err != nil {
+		klog.Warningf("Failed to clear the recorded conversion failure of volume %s: %v", volKey.Name, err)
+	}
+	if err := k8sclient.SetPVAnnotation(ctx, volKey.Name, constants.DiskTypeConvertedToKey, diskType); err != nil {
+		klog.Warningf("Failed to record the completed conversion of disk %s to %s: %v", volKey.Name, diskType, err)
+	}
+	// Removing this last means a failure part way through leaves the volume
+	// looking like it is still converting, which is retried, rather than looking
+	// converted while the record of it is incomplete.
+	if err := k8sclient.RemovePVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionOperationKey); err != nil {
+		klog.Errorf("Failed to clear the conversion annotation of disk %s, operations on it stay blocked until this succeeds: %v", volKey.Name, err)
+		return err
+	}
+
+	k8sclient.EmitPVEvent(ctx, volKey.Name, v1.EventTypeNormal, constants.DiskTypeConversionCompleteReason, constants.DiskTypeConversionAction,
+		fmt.Sprintf("Disk type conversion completed for volume %q, the disk is now %s", volKey.Name, diskType))
+
+	// Whichever call records the completion first is the one that reports it, so
+	// any watcher still following the conversion is stopped rather than left to
+	// record and report the same completion again. This comes last because a
+	// watcher recording its own conversion is cancelling the context it is
+	// still using.
+	gceCS.stopConversionWatcher(volKey)
+	return nil
+}
+
+// reconcileLatestVACAfterConversion checks if the VolumeAttributesClass (VAC)
+// still requires a disk type conversion after a conversion has completed.
+// This handles the case where the VAC was updated during the conversion.
+//
+// Returns:
+//   - nil: No new conversion needed (VAC removed, disk already matches, or conversion started successfully)
+//   - error: A new conversion is needed but couldn't be started
+func (gceCS *GCEControllerServer) reconcileLatestVACAfterConversion(
+	ctx context.Context,
+	project string,
+	volKey *meta.Key,
+	disk *gce.CloudDisk,
+) error {
+	// A. Read the current VAC using the existing queuedConversionOutcome
+	params, cancelReason, err := gceCS.queuedConversionOutcome(ctx, volKey, disk)
+	if err != nil {
+		return status.Errorf(codes.Unavailable,
+			"failed to read VolumeAttributesClass for disk %s after conversion: %v",
+			volKey.Name, err)
+	}
+
+	// B. Handle VAC removal or cancellation
+	if cancelReason != "" {
+		klog.V(4).Infof("No new conversion needed for disk %s: %s", volKey.Name, cancelReason)
+		// Ensure the volume is unblocked - the caller already cleared the operation
+		return nil
+	}
+
+	currentDiskType := disk.GetPDType()
+
+	// C. Check whether the disk already has the desired type
+	if params.DiskType == nil {
+		klog.V(4).Infof("No disk type requested in VAC for disk %s, nothing to reconcile", volKey.Name)
+		return nil
+	}
+
+	desiredDiskType := *params.DiskType
+	if desiredDiskType == currentDiskType {
+		klog.V(4).Infof("Disk %s already has the desired type %s, no new conversion needed",
+			volKey.Name, currentDiskType)
+		return nil
+	}
+
+	// D. Desired type differs - Conversion 2 is required
+	klog.V(4).Infof("VAC changed during conversion: disk %s is now %s but VAC wants %s, starting new conversion",
+		volKey.Name, currentDiskType, desiredDiskType)
+
+	// Check if this disk can be converted
+	if reason := unsupportedConversionReason(volKey, disk); reason != "" {
+		klog.Errorf("Cannot convert disk %s from %s to %s: %s",
+			volKey.Name, currentDiskType, desiredDiskType, reason)
+
+		// Clear any pending state so the volume isn't blocked
+		if err := k8sclient.RemovePVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionOperationKey); err != nil {
+			klog.Warningf("Failed to clear conversion state for disk %s: %v", volKey.Name, err)
+		}
+
+		k8sclient.EmitPVEvent(ctx, volKey.Name, v1.EventTypeWarning,
+			constants.DiskTypeConversionFailedReason,
+			constants.DiskTypeConversionAction,
+			fmt.Sprintf("Cannot convert volume %q from %s to %s: %s",
+				volKey.Name, currentDiskType, desiredDiskType, reason))
+
+		return status.Errorf(codes.InvalidArgument,
+			"cannot convert disk %s from %s to %s: %s",
+			volKey.Name, currentDiskType, desiredDiskType, reason)
+	}
+
+	// Check if the disk is attached
+	if users := disk.GetUsers(); len(users) > 0 {
+		// Disk is attached - mark as Pending and wait for detach
+		klog.V(4).Infof("Disk %s is still attached to %v, queuing new conversion from %s to %s",
+			volKey.Name, users, currentDiskType, desiredDiskType)
+
+		// Mark the conversion as pending - this will be picked up by startQueuedConversionOnDetach()
+		gceCS.markConversionPending(ctx, volKey, volKey.String())
+
+		k8sclient.EmitPVEvent(ctx, volKey.Name, v1.EventTypeNormal,
+			constants.DiskTypeConversionQueuedReason,
+			constants.DiskTypeConversionAction,
+			fmt.Sprintf("Disk type conversion queued for volume %q from %s to %s (will start on detach)",
+				volKey.Name, currentDiskType, desiredDiskType))
+
+		return nil // Not an error, just queued
+	}
+
+	// Disk is detached - start the new conversion immediately
+	klog.V(4).Infof("Disk %s is detached, starting new conversion from %s to %s",
+		volKey.Name, currentDiskType, desiredDiskType)
+
+	// Use convertDiskType to handle the conversion - it has all the necessary logic
+	// including the final operation check before clearing the state
+	// We need to call it with a dummy ModifyVolumeResponse since we're not in a ControllerModifyVolume call
+	_, convertErr := gceCS.startDiskTypeConversion(ctx, project, volKey,
+		currentDiskType, desiredDiskType, params)
+	if convertErr != nil {
+		if isUnsupportedConversionIntentError(convertErr) {
+			// Terminal error - don't retry
+			klog.Errorf("Cannot convert disk %s from %s to %s: %v",
+				volKey.Name, currentDiskType, desiredDiskType, convertErr)
+
+			// Clear the queued state
+			if clearErr := k8sclient.RemovePVAnnotation(ctx, volKey.Name,
+				constants.DiskTypeConversionOperationKey); clearErr != nil {
+				klog.Warningf("Failed to clear conversion state for disk %s: %v", volKey.Name, clearErr)
+			}
+
+			return status.Errorf(codes.InvalidArgument,
+				"cannot convert disk %s from %s to %s: %v",
+				volKey.Name, currentDiskType, desiredDiskType, convertErr)
+		}
+
+		// Retriable error - keep the volume queued
+		klog.Warningf("Failed to start new conversion for disk %s from %s to %s, will retry: %v",
+			volKey.Name, currentDiskType, desiredDiskType, convertErr)
+
+		// Keep the volume in pending state
+		gceCS.markConversionPending(ctx, volKey, volKey.String())
+
+		return status.Errorf(codes.Unavailable,
+			"failed to start new conversion for disk %s: %v", volKey.Name, convertErr)
+	}
+
+	klog.V(4).Infof("Successfully started new conversion for disk %s from %s to %s",
+		volKey.Name, currentDiskType, desiredDiskType)
+
+	return nil
+}
+
+// Reasons returned by the convert API that mean the requested conversion can
+// never succeed. Everything else, including errors that share their HTTP status
+// with these, is treated as transient and retried.
+var terminalConversionReasons = sets.NewString(
+	"DISK_TYPE_CONVERSION_UNSUPPORTED",
+	// Values the API rejects outright, such as an IOPS figure below the minimum
+	// for the target type.
+	"badRequest",
+	"invalidParameter",
+	"invalid",
+)
+
+// Reasons returned by the convert API that describe a condition the user or the
+// cloud is expected to clear, so that the wait can be explained rather than
+// reported as an unspecified failure. Every one of them is retried.
+//
+// The reason strings the convert API uses for these conditions still need
+// confirming against the API itself. Getting one wrong only costs the specific
+// message, because anything unrecognised is retried anyway.
+var retriableConversionReasons = map[string]string{
+	"resourceNotReady":                     "the disk is not ready to be converted yet",
+	"rateLimitExceeded":                    "the limit on disk conversion calls for this region has been reached",
+	"quotaExceeded":                        "a quota needed for the conversion has been exhausted",
+	"limitExceeded":                        "the limit on concurrent disk conversions for this project and region has been reached",
+	"CONCURRENT_OPERATIONS_QUOTA_EXCEEDED": "the limit on concurrent operations for this project and region has been reached",
+	"ZONE_RESOURCE_POOL_EXHAUSTED":         "the zone does not currently have capacity for the target disk type",
+	"QUOTA_EXCEEDED":                       "a quota needed for the conversion has been exhausted",
+	"RESOURCE_OPERATION_RATE_LIMIT":        "the limit on disk conversion calls for this region has been reached",
+	// The conversion snapshots the disk behind the scenes, which another
+	// snapshot of the same disk blocks. This includes a snapshot the user took
+	// and a temporary snapshot left behind by an earlier conversion.
+	"RESOURCE_IN_USE_BY_ANOTHER_RESOURCE": "a snapshot of the disk is still in use and must be released before it can be converted",
+}
+
+// conversionRetryReason explains a retriable conversion failure, or returns the
+// empty string for one that has no specific explanation.
+func conversionRetryReason(err error) string {
+	return retriableConversionReasons[conversionErrorReason(err)]
+}
+
+// conversionInProgressReason is returned when the disk is busy, which for a
+// conversion request means an earlier conversion is still running.
+const conversionInProgressReason = "resourceNotReady"
+
+// isUnsupportedConversionIntentError reports whether the conversion can never
+// succeed for the requested target configuration, meaning it should not be
+// retried. Note that the HTTP status alone cannot decide this: an in-progress
+// conversion is also reported as 400.
+func isUnsupportedConversionIntentError(err error) bool {
+	// The reason decides, not the HTTP status: a running conversion, a disk held
+	// by an instant snapshot and an out-of-range IOPS value all arrive as 400,
+	// and quota and rate limits arrive as 403. An unrecognised reason is
+	// retriable, so a delayed conversion keeps its volume blocked.
+	return terminalConversionReasons.Has(conversionErrorReason(err))
+}
+
+// isConversionInProgressError reports whether the error means a conversion of
+// this disk is already running.
+func isConversionInProgressError(err error) bool {
+	return conversionErrorReason(err) == conversionInProgressReason
+}
+
+// conversionErrorReason extracts the machine readable reason from a convert API
+// error, preferring the ErrorInfo detail over the top level error item because
+// the latter only carries generic reasons such as "badRequest".
+func conversionErrorReason(err error) string {
+	var apiErr *googleapi.Error
+	if !errors.As(err, &apiErr) {
+		return ""
+	}
+	for _, detail := range apiErr.Details {
+		detailMap, ok := detail.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if reason, ok := detailMap["reason"].(string); ok && reason != "" {
+			return reason
+		}
+	}
+	for _, errItem := range apiErr.Errors {
+		if errItem.Reason != "" {
+			return errItem.Reason
+		}
+	}
+	return ""
 }
 
 func (gceCS *GCEControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
@@ -1031,6 +1990,18 @@ func (gceCS *GCEControllerServer) deleteSingleDeviceDisk(ctx context.Context, re
 	defer gceCS.volumeLocks.Release(volumeID)
 	disk, _ := gceCS.CloudProvider.GetDisk(ctx, project, volKey)
 	metrics.UpdateRequestMetadataFromDisk(ctx, disk)
+
+	// A conversion rebuilds the disk through a temporary snapshot, which the
+	// delete would fail on. Reporting it as a conversion in progress lets the
+	// delete be retried once the conversion ends.
+	if err := gceCS.checkNoConversionInProgress(ctx, volKey, disk, "delete"); err != nil {
+		return nil, err
+	}
+
+	// The disk is going away, so anything still following a conversion of it is
+	// polling an operation whose result nobody can use.
+	gceCS.stopConversionWatcher(volKey)
+
 	err = gceCS.CloudProvider.DeleteDisk(ctx, project, volKey)
 	if err != nil {
 		return nil, common.LoggedError("Failed to delete disk: ", err)
@@ -1263,6 +2234,13 @@ func (gceCS *GCEControllerServer) executeControllerPublishVolume(ctx context.Con
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "could not split nodeID: %v", err.Error()), disk
 	}
+
+	// Attaching a disk that is being converted risks corrupting it, because the
+	// conversion API requires the disk to stay detached for the whole operation.
+	if err := gceCS.checkNoConversionInProgress(ctx, volKey, disk, "attach"); err != nil {
+		return nil, err, disk
+	}
+
 	err = gceCS.CloudProvider.AttachDisk(ctx, project, volKey, readWrite, attachableDiskTypePersistent, instanceZone, instanceName, pdcsiContext.ForceAttach)
 	if err != nil {
 		var udErr *gce.UnsupportedDiskError
@@ -1530,8 +2508,139 @@ func (gceCS *GCEControllerServer) executeControllerUnpublishVolume(ctx context.C
 		return nil, common.LoggedError("Failed to detach: ", err), diskToUnpublish
 	}
 
+	// A conversion queued while the disk was attached can run now that it is not.
+	gceCS.startQueuedConversionOnDetach(ctx, project, volKey)
+
 	klog.V(4).Infof("ControllerUnpublishVolume succeeded for disk %v from node %v", volKey, nodeID)
 	return &csi.ControllerUnpublishVolumeResponse{}, nil, diskToUnpublish
+}
+
+// startQueuedConversionOnDetach starts a disk type conversion that was waiting
+// for the disk to be detached, which has just happened.
+//
+// A conversion cannot be started from inside the detach itself, because it takes
+// far longer than the call may block for, so this only decides whether to start
+// one and hands the work to a background attempt. Nothing here fails the detach:
+// the detach has already succeeded, and a conversion that does not start stays
+// queued for the next detach or for the next time the class is applied.
+func (gceCS *GCEControllerServer) startQueuedConversionOnDetach(ctx context.Context, project string, volKey *meta.Key) {
+	if !gceCS.EnablePdConversion {
+		return
+	}
+
+	opVal, exists, err := k8sclient.GetPVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionOperationKey)
+	if err != nil {
+		klog.Warningf("Could not check whether disk %s has a conversion waiting for it to detach: %v", volKey.Name, err)
+		return
+	}
+	if !exists || opVal != constants.ConversionStatePending {
+		return
+	}
+
+	klog.V(4).Infof("Disk %s detached with a conversion queued, starting it", volKey.Name)
+	// The detach's context is cancelled when this call returns, so the
+	// conversion gets one that outlives it.
+	gceCS.conversionWorkers.Add(1)
+	go func() {
+		defer gceCS.conversionWorkers.Done()
+		gceCS.runQueuedConversion(context.Background(), project, volKey)
+	}()
+}
+
+// WaitForConversionWorkers blocks until the background conversion work has
+// finished, both the conversions started on detach and the watchers following
+// running ones. The work happens in the background, so this is how a caller that
+// needs it settled, such as a test, can wait for it.
+func (gceCS *GCEControllerServer) WaitForConversionWorkers() {
+	gceCS.conversionWorkers.Wait()
+}
+
+// runQueuedConversion starts the conversion a volume's VolumeAttributesClass
+// currently asks for.
+//
+// The class is read now rather than recorded when the conversion was queued, so
+// that this acts on what the user is asking for at the moment the conversion can
+// actually run. A user who no longer wants the conversion clears the class on
+// their claim, and this is where that takes effect.
+func (gceCS *GCEControllerServer) runQueuedConversion(ctx context.Context, project string, volKey *meta.Key) {
+	disk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey)
+	if err != nil {
+		klog.Warningf("Could not read disk %s to convert it, leaving its conversion queued: %v", volKey.Name, err)
+		return
+	}
+
+	params, cancelReason, err := gceCS.queuedConversionOutcome(ctx, volKey, disk)
+	if err != nil {
+		klog.Warningf("Could not read the VolumeAttributesClass of disk %s, leaving its conversion queued: %v", volKey.Name, err)
+		return
+	}
+	if cancelReason != "" {
+		// The user withdrew the conversion, its class is invalid, or the disk is
+		// already the requested type, which is also how a conversion that
+		// completed elsewhere is noticed.
+		klog.V(4).Infof("Cancelling the queued conversion of disk %s: %s", volKey.Name, cancelReason)
+		gceCS.cancelQueuedConversion(ctx, volKey, cancelReason)
+		return
+	}
+
+	currentDiskType := disk.GetPDType()
+	// A disk still listing users just after it detached is usually the detach not
+	// yet visible rather than a new attachment, so the disk is read again for a
+	// short while before the conversion is left queued.
+	if users := disk.GetUsers(); len(users) > 0 {
+		klog.V(4).Infof("Disk %s still lists users %v, waiting for the detach to become visible", volKey.Name, users)
+
+		pollErr := wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+			refetchedDisk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey)
+			if err != nil {
+				return false, err
+			}
+			if len(refetchedDisk.GetUsers()) == 0 {
+				disk = refetchedDisk
+				return true, nil
+			}
+			return false, nil
+		})
+		if pollErr != nil {
+			klog.V(4).Infof("Disk %s still lists users, leaving its conversion queued", volKey.Name)
+			return
+		}
+	}
+
+	if _, err := gceCS.startDiskTypeConversion(ctx, project, volKey, currentDiskType, *params.DiskType, params); err != nil {
+		if isUnsupportedConversionIntentError(err) {
+			// Retrying cannot help, and leaving the volume queued would block it
+			// on a conversion that will never run.
+			gceCS.cancelQueuedConversion(ctx, volKey, fmt.Sprintf("it cannot be converted from %s to %s: %v", currentDiskType, *params.DiskType, err))
+			return
+		}
+		// The volume stays queued, so the next detach or the next time the class
+		// is applied tries again.
+		if reason := conversionRetryReason(err); reason != "" {
+			klog.Warningf("Conversion of disk %s from %s to %s will be retried: %s: %v", volKey.Name, currentDiskType, *params.DiskType, reason, err)
+			k8sclient.EmitPVEvent(ctx, volKey.Name, v1.EventTypeWarning, constants.DiskTypeConversionRetryReason, constants.DiskTypeConversionAction,
+				fmt.Sprintf("Disk type conversion of volume %q has not started and will be retried: %s", volKey.Name, reason))
+			return
+		}
+		klog.Warningf("Failed to start the queued conversion of disk %s from %s to %s, it stays queued: %v", volKey.Name, currentDiskType, *params.DiskType, err)
+		k8sclient.EmitPVEvent(ctx, volKey.Name, v1.EventTypeWarning, constants.DiskTypeConversionRetryReason, constants.DiskTypeConversionAction,
+			fmt.Sprintf("Disk type conversion of volume %q has not started and will be retried: %v", volKey.Name, err))
+	}
+}
+
+// cancelQueuedConversion clears the state that keeps a volume waiting for a
+// conversion that is not going to run, so that the volume can be used again.
+func (gceCS *GCEControllerServer) cancelQueuedConversion(ctx context.Context, volKey *meta.Key, reason string) {
+	if err := k8sclient.RemovePVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionLastErrorKey); err != nil {
+		klog.Warningf("Failed to clear the recorded conversion failure of volume %s: %v", volKey.Name, err)
+	}
+	if err := k8sclient.RemovePVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionOperationKey); err != nil {
+		klog.Errorf("Failed to cancel the queued conversion of disk %s, operations on it stay blocked until this succeeds: %v", volKey.Name, err)
+		return
+	}
+	klog.V(4).Infof("Cancelled the queued conversion of disk %s: %s", volKey.Name, reason)
+	k8sclient.EmitPVEvent(ctx, volKey.Name, v1.EventTypeNormal, constants.DiskTypeConversionCancelReason, constants.DiskTypeConversionAction,
+		fmt.Sprintf("Disk type conversion of volume %q will not run because %s", volKey.Name, reason))
 }
 
 func (gceCS *GCEControllerServer) parameterProcessor() *parameters.ParameterProcessor {
@@ -1840,6 +2949,14 @@ func (gceCS *GCEControllerServer) CreateSnapshot(ctx context.Context, req *csi.C
 			return nil, status.Errorf(codes.NotFound, "CreateSnapshot could not find disk %v: %v", volKey.String(), err.Error())
 		}
 		return nil, common.LoggedError("CreateSnapshot, failed to getDisk: ", err)
+	}
+
+	// A disk type conversion snapshots the disk behind the scenes, so a
+	// concurrent snapshot request would race it for the same underlying
+	// resource. Serializing behind the conversion here means the caller sees
+	// a clear, retryable error instead of a GCE-side conflict.
+	if err := gceCS.checkNoConversionInProgress(ctx, volKey, disk, "snapshot"); err != nil {
+		return nil, err
 	}
 
 	snapshotParams, err := parameters.ExtractAndDefaultSnapshotParameters(req.GetParameters(), gceCS.Driver.name, gceCS.Driver.extraTags)
@@ -2199,6 +3316,13 @@ func (gceCS *GCEControllerServer) ControllerExpandVolume(ctx context.Context, re
 
 	sourceDisk, err := gceCS.CloudProvider.GetDisk(ctx, project, volKey)
 	metrics.UpdateRequestMetadataFromDisk(ctx, sourceDisk)
+
+	// Resizing a disk mid-conversion would race the conversion's own copy of the
+	// data, and the size the conversion restores is the one it started with.
+	if err := gceCS.checkNoConversionInProgress(ctx, volKey, sourceDisk, "expand"); err != nil {
+		return nil, err
+	}
+
 	resizedGb, err := gceCS.CloudProvider.ResizeDisk(ctx, project, volKey, reqBytes)
 
 	if err != nil {

--- a/pkg/gce-pd-csi-driver/controller.go
+++ b/pkg/gce-pd-csi-driver/controller.go
@@ -1019,6 +1019,7 @@ func (gceCS *GCEControllerServer) convertDiskType(ctx context.Context, project s
 	}
 
 	if reason := unsupportedConversionReason(volKey, existingDisk); reason != "" {
+		gceCS.withdrawInfeasibleClass(ctx, volKey, volumeID, reason)
 		return nil, status.Errorf(codes.InvalidArgument, "cannot convert volume %s from %s to %s: %s", volumeID, currentDiskType, targetDiskType, reason)
 	}
 
@@ -1026,6 +1027,7 @@ func (gceCS *GCEControllerServer) convertDiskType(ctx context.Context, project s
 	// checked against the disk's current size and IOPS, same as the plain
 	// IOPS/throughput update path below.
 	if err := common.ValidateMaxProvisioned(targetDiskType, existingDisk.GetSizeGb(), existingDisk.GetProvisionedIops(), params.IOPS, params.Throughput); err != nil {
+		gceCS.withdrawInfeasibleClass(ctx, volKey, volumeID, err.Error())
 		return nil, status.Errorf(codes.InvalidArgument, "cannot convert volume %s from %s to %s: %v", volumeID, currentDiskType, targetDiskType, err)
 	}
 
@@ -1033,10 +1035,14 @@ func (gceCS *GCEControllerServer) convertDiskType(ctx context.Context, project s
 	// rejected here rather than sent to the convert API, the same way it is
 	// rejected on the plain IOPS/throughput update path below.
 	if params.IOPS != nil && !gceCS.diskSupportsIopsChange(targetDiskType) {
-		return nil, status.Errorf(codes.InvalidArgument, "cannot convert volume %s from %s to %s: cannot specify IOPS for disk type %s", volumeID, currentDiskType, targetDiskType, targetDiskType)
+		reason := fmt.Sprintf("cannot specify IOPS for disk type %s", targetDiskType)
+		gceCS.withdrawInfeasibleClass(ctx, volKey, volumeID, reason)
+		return nil, status.Errorf(codes.InvalidArgument, "cannot convert volume %s from %s to %s: %s", volumeID, currentDiskType, targetDiskType, reason)
 	}
 	if params.Throughput != nil && !gceCS.diskSupportsThroughputChange(targetDiskType) {
-		return nil, status.Errorf(codes.InvalidArgument, "cannot convert volume %s from %s to %s: cannot specify throughput for disk type %s", volumeID, currentDiskType, targetDiskType, targetDiskType)
+		reason := fmt.Sprintf("cannot specify throughput for disk type %s", targetDiskType)
+		gceCS.withdrawInfeasibleClass(ctx, volKey, volumeID, reason)
+		return nil, status.Errorf(codes.InvalidArgument, "cannot convert volume %s from %s to %s: %s", volumeID, currentDiskType, targetDiskType, reason)
 	}
 
 	// Conversion requires the disk to be detached. Report this as retryable so
@@ -1058,6 +1064,7 @@ func (gceCS *GCEControllerServer) convertDiskType(ctx context.Context, project s
 			return nil, status.Errorf(codes.Unavailable, "conversion of volume %s from %s to %s is in progress", volumeID, currentDiskType, targetDiskType)
 		}
 		if isUnsupportedConversionIntentError(err) {
+			gceCS.withdrawInfeasibleClass(ctx, volKey, volumeID, err.Error())
 			return nil, status.Errorf(codes.InvalidArgument, "cannot convert volume %s from %s to %s: %v", volumeID, currentDiskType, targetDiskType, err)
 		}
 		// The conversion will be retried, so the volume has to stay blocked in
@@ -1085,6 +1092,36 @@ func (gceCS *GCEControllerServer) convertDiskType(ctx context.Context, project s
 	// The conversion has started but is not finished, so the requested
 	// attributes are not in effect yet.
 	return nil, status.Errorf(codes.Unavailable, "conversion of volume %s from %s to %s is in progress (%s)", volumeID, currentDiskType, targetDiskType, operation)
+}
+
+// withdrawInfeasibleClass records why a VolumeAttributesClass could not be acted
+// on and then takes it off the claim.
+//
+// The reason is written to the volume and reported as an event before the class
+// is removed, because removing it also clears the failure from the claim's
+// status: without recording it first, a user would be left with a volume that
+// looks as though nothing was ever asked of it.
+//
+// Withdrawing the class is best effort. Kubernetes only permits it while the
+// claim has never had a class applied, so a class that cannot be removed simply
+// stays, and the recorded reason explains it either way.
+func (gceCS *GCEControllerServer) withdrawInfeasibleClass(ctx context.Context, volKey *meta.Key, volumeID, reason string) {
+	if err := k8sclient.SetPVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionInfeasibleKey, reason); err != nil {
+		klog.Warningf("Failed to record why the VolumeAttributesClass of volume %s could not be used: %v", volumeID, err)
+	}
+
+	k8sclient.EmitPVEvent(ctx, volKey.Name, v1.EventTypeWarning, constants.DiskTypeConversionFailedReason, constants.DiskTypeConversionAction,
+		fmt.Sprintf("Disk type conversion of volume %q cannot be done: %s", volKey.Name, reason))
+
+	cleared, err := k8sclient.ClearVolumeAttributesClassForPV(ctx, volKey.Name)
+	if err != nil {
+		klog.Warningf("Failed to withdraw the VolumeAttributesClass of volume %s: %v", volumeID, err)
+		return
+	}
+	if cleared {
+		k8sclient.EmitPVEvent(ctx, volKey.Name, v1.EventTypeNormal, constants.DiskTypeConversionCancelReason, constants.DiskTypeConversionAction,
+			fmt.Sprintf("The VolumeAttributesClass of volume %q was removed because it cannot be applied: %s", volKey.Name, reason))
+	}
 }
 
 // markConversionPending records that a volume is waiting for a conversion that
@@ -1125,6 +1162,13 @@ func (gceCS *GCEControllerServer) startDiskTypeConversion(ctx context.Context, p
 	if err != nil {
 		klog.Errorf("Failed to convert disk %s from %s to %s: %v", volKey.Name, currentDiskType, targetDiskType, err)
 		return "", err
+	}
+
+	// A conversion the API accepted clears any record of an earlier class it
+	// could not act on, so a stale reason is not left on a volume that is now
+	// converting.
+	if err := k8sclient.RemovePVAnnotation(ctx, volKey.Name, constants.DiskTypeConversionInfeasibleKey); err != nil {
+		klog.Warningf("Failed to clear the recorded infeasible class of volume %s: %v", volKey.Name, err)
 	}
 
 	// Record the type the disk is being converted from before the operation, so

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -43,12 +43,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
 	clock "k8s.io/utils/clock/testing"
@@ -8508,4 +8510,123 @@ func TestReconcileAfterConversionSurvivesWatcherCancellation(t *testing.T) {
 		t.Errorf("Conversion targeted %q; want hyperdisk-extreme", got)
 	}
 	gceDriver.cs.stopConversionWatcher(volKey)
+}
+
+func TestInfeasibleClassIsRecordedThenWithdrawn(t *testing.T) {
+	// A class the volume cannot act on is taken off the claim, but only after
+	// the reason is recorded: removing the class also clears the failure from
+	// the claim's status, so without the record the volume would look as though
+	// nothing had been asked of it.
+	className := "vac-infeasible"
+	testCases := []struct {
+		name string
+		// currentClass is what the claim reports as already applied. Kubernetes
+		// only allows the class to be cleared while this is empty.
+		currentClass  string
+		expWithdrawn  bool
+		expReasonPart string
+	}{
+		{
+			name:          "a class that never applied is withdrawn",
+			expWithdrawn:  true,
+			expReasonPart: "cannot specify IOPS for disk type hyperdisk-throughput",
+		},
+		{
+			name:          "a class that has applied is left in place",
+			currentClass:  className,
+			expWithdrawn:  false,
+			expReasonPart: "cannot specify IOPS for disk type hyperdisk-throughput",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldGetKubeClient := k8sclient.GetClient
+			defer func() { k8sclient.GetClient = oldGetKubeClient }()
+
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pvc", Namespace: "default"},
+				Spec:       corev1.PersistentVolumeClaimSpec{VolumeAttributesClassName: &className},
+			}
+			if tc.currentClass != "" {
+				pvc.Status.CurrentVolumeAttributesClassName = &tc.currentClass
+			}
+			kubeClient := fake.NewSimpleClientset(
+				&corev1.PersistentVolume{
+					ObjectMeta: metav1.ObjectMeta{Name: name},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{Name: "test-pvc", Namespace: "default"},
+					},
+				},
+				pvc,
+				&storagev1beta1.VolumeAttributesClass{
+					ObjectMeta: metav1.ObjectMeta{Name: className},
+					DriverName: "pd.csi.storage.gke.io",
+					Parameters: map[string]string{"type": "hyperdisk-throughput", "iops": "3000"},
+				},
+			)
+			// The fake client does not enforce the rule that the class can only be
+			// cleared before one has applied, so it is enforced here.
+			kubeClient.PrependReactor("patch", "persistentvolumeclaims", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				if tc.currentClass != "" {
+					return true, nil, apierrors.NewInvalid(
+						corev1.SchemeGroupVersion.WithKind("PersistentVolumeClaim").GroupKind(),
+						"test-pvc",
+						nil)
+				}
+				return false, nil, nil
+			})
+			k8sclient.GetClient = func() (kubernetes.Interface, error) { return kubeClient, nil }
+
+			disk := &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 200}
+			fcp, err := gce.CreateFakeCloudProvider(project, zone, []*gce.CloudDisk{gce.CloudDiskFromV1(disk)})
+			if err != nil {
+				t.Fatalf("Failed to create fake cloud provider: %v", err)
+			}
+			gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{EnablePdConversion: true})
+			defer gceDriver.cs.WaitForConversionWorkers()
+
+			_, err = gceDriver.cs.ControllerModifyVolume(context.Background(), &csi.ControllerModifyVolumeRequest{
+				VolumeId:          testVolumeID,
+				MutableParameters: map[string]string{"type": "hyperdisk-throughput", "iops": "3000"},
+			})
+			if gotCode := status.Code(err); gotCode != codes.InvalidArgument {
+				t.Fatalf("Expected InvalidArgument, got %v (err: %v)", gotCode, err)
+			}
+
+			// The reason has to outlive the class, whether or not it was removed.
+			pv, getErr := kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), name, metav1.GetOptions{})
+			if getErr != nil {
+				t.Fatalf("Failed to get PersistentVolume: %v", getErr)
+			}
+			recorded := pv.Annotations[constants.DiskTypeConversionInfeasibleKey]
+			if !strings.Contains(recorded, tc.expReasonPart) {
+				t.Errorf("Recorded reason %q does not contain %q", recorded, tc.expReasonPart)
+			}
+
+			// The failure is reported before anything is removed.
+			events, evErr := kubeClient.CoreV1().Events(metav1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
+			if evErr != nil {
+				t.Fatalf("Failed to list events: %v", evErr)
+			}
+			var reportedFailure bool
+			for _, ev := range events.Items {
+				if ev.Reason == constants.DiskTypeConversionFailedReason {
+					reportedFailure = true
+				}
+			}
+			if !reportedFailure {
+				t.Errorf("No %s event was emitted", constants.DiskTypeConversionFailedReason)
+			}
+
+			gotPVC, pvcErr := kubeClient.CoreV1().PersistentVolumeClaims("default").Get(context.Background(), "test-pvc", metav1.GetOptions{})
+			if pvcErr != nil {
+				t.Fatalf("Failed to get PersistentVolumeClaim: %v", pvcErr)
+			}
+			withdrawn := gotPVC.Spec.VolumeAttributesClassName == nil
+			if withdrawn != tc.expWithdrawn {
+				t.Errorf("Class withdrawn=%v; want %v", withdrawn, tc.expWithdrawn)
+			}
+		})
+	}
 }

--- a/pkg/gce-pd-csi-driver/controller_test.go
+++ b/pkg/gce-pd-csi-driver/controller_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"math/rand"
 	"net/http"
 	"reflect"
@@ -34,15 +35,18 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	computebeta "google.golang.org/api/compute/v0.beta"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/util/flowcontrol"
@@ -2514,6 +2518,332 @@ func TestCreateVolumeWithVolumeAttributeClassParameters(t *testing.T) {
 
 }
 
+func TestVolumeModifyDiskTypeConversion(t *testing.T) {
+	iops := int64(3000)
+	throughput := int64(188)
+
+	testCases := []struct {
+		name string
+		// disk is the disk the volume is backed by, inserted into the fake.
+		disk                *compute.Disk
+		volumeID            string
+		mutableParameters   map[string]string
+		enablePdConversion  bool
+		convertErr          error
+		expConvertCalled    bool
+		expTargetDiskType   string
+		expIops             *int64
+		expThroughput       *int64
+		expErrCode          codes.Code
+		expErrMessageSubstr string
+		// pvAnnotations are the annotations the volume's PersistentVolume starts
+		// with, and expPVAnnotations the ones it is expected to end with. A key
+		// mapped to the empty string is expected to be absent.
+		pvAnnotations    map[string]string
+		expPVAnnotations map[string]string
+	}{
+		{
+			name:               "converts a detached pd disk to hyperdisk",
+			disk:               &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-standard", SizeGb: 200},
+			volumeID:           testVolumeID,
+			mutableParameters:  map[string]string{"type": "hyperdisk-balanced"},
+			enablePdConversion: true,
+			expConvertCalled:   true,
+			expTargetDiskType:  "hyperdisk-balanced",
+			// The conversion runs asynchronously, so the modification is not
+			// complete when the call returns.
+			expErrCode:          codes.Unavailable,
+			expErrMessageSubstr: "conversion of volume",
+			// Starting a conversion records the operation to track it by, and the
+			// type the disk is being converted away from.
+			expPVAnnotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: fmt.Sprintf("https://www.googleapis.com/compute/alpha/projects/%s/zones/%s/operations/operation-convert-%s", project, zone, name),
+				constants.DiskTypeConvertedFromKey:       "pd-standard",
+				constants.DiskTypeConvertedToKey:         "",
+			},
+		},
+		{
+			name:               "passes iops and throughput as the target configuration",
+			disk:               &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-standard", SizeGb: 200},
+			volumeID:           testVolumeID,
+			mutableParameters:  map[string]string{"type": "hyperdisk-balanced", "iops": "3000", "throughput": "188Mi"},
+			enablePdConversion: true,
+			expConvertCalled:   true,
+			expTargetDiskType:  "hyperdisk-balanced",
+			expIops:            &iops,
+			expThroughput:      &throughput,
+			expErrCode:         codes.Unavailable,
+		},
+		{
+			// GCE's ceiling for hyperdisk-balanced IOPS at 200 GiB is
+			// 500 * 200 = 100,000; this asks for the target type's cap to be
+			// enforced client-side rather than sent and rejected by the API.
+			name:                "rejects conversion when the target IOPS exceeds the max for the target type and size",
+			disk:                &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-standard", SizeGb: 200},
+			volumeID:            testVolumeID,
+			mutableParameters:   map[string]string{"type": "hyperdisk-balanced", "iops": "100001"},
+			enablePdConversion:  true,
+			expConvertCalled:    false,
+			expErrCode:          codes.InvalidArgument,
+			expErrMessageSubstr: "exceeds the maximum",
+		},
+		{
+			// hyperdisk-extreme supports IOPS but not throughput in the test's
+			// ProvisionableDisksConfig; this asks for that to be enforced
+			// client-side rather than sent and rejected by the API.
+			name:                "rejects conversion when the target type does not support throughput",
+			disk:                &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-standard", SizeGb: 200},
+			volumeID:            testVolumeID,
+			mutableParameters:   map[string]string{"type": "hyperdisk-extreme", "throughput": "188Mi"},
+			enablePdConversion:  true,
+			expConvertCalled:    false,
+			expErrCode:          codes.InvalidArgument,
+			expErrMessageSubstr: "cannot specify throughput",
+		},
+		{
+			name:                "rejects conversion while the disk is attached",
+			disk:                &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-standard", SizeGb: 200, Users: []string{"instance-1"}},
+			volumeID:            testVolumeID,
+			mutableParameters:   map[string]string{"type": "hyperdisk-balanced"},
+			enablePdConversion:  true,
+			expConvertCalled:    false,
+			expErrCode:          codes.FailedPrecondition,
+			expErrMessageSubstr: "detach the volume",
+		},
+		{
+			name:                "rejects conversion of a regional disk",
+			disk:                &compute.Disk{Name: name, Region: region, SelfLink: testRegionalID, Type: "pd-standard", SizeGb: 200},
+			volumeID:            testRegionalID,
+			mutableParameters:   map[string]string{"type": "hyperdisk-balanced"},
+			enablePdConversion:  true,
+			expConvertCalled:    false,
+			expErrCode:          codes.InvalidArgument,
+			expErrMessageSubstr: "not supported for regional disks",
+		},
+		{
+			name:                "rejects conversion when the feature is disabled",
+			disk:                &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-standard", SizeGb: 200},
+			volumeID:            testVolumeID,
+			mutableParameters:   map[string]string{"type": "hyperdisk-balanced"},
+			enablePdConversion:  false,
+			expConvertCalled:    false,
+			expErrCode:          codes.InvalidArgument,
+			expErrMessageSubstr: "not enabled",
+		},
+		{
+			name:               "treats an unsupported conversion intent as terminal",
+			disk:               &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "hyperdisk-balanced", SizeGb: 200},
+			volumeID:           testVolumeID,
+			mutableParameters:  map[string]string{"type": "hyperdisk-throughput"},
+			enablePdConversion: true,
+			convertErr:         conversionAPIError(http.StatusBadRequest, "DISK_TYPE_CONVERSION_UNSUPPORTED", "Disk type hyperdisk-balanced does not support conversion to hyperdisk-throughput"),
+			expConvertCalled:   true,
+			expTargetDiskType:  "hyperdisk-throughput",
+			expErrCode:         codes.InvalidArgument,
+		},
+		{
+			// An already running conversion is reported with the same HTTP
+			// status as an unsupported conversion, so it must be told apart by
+			// reason or the modification is wrongly abandoned.
+			name:                "treats an in-progress conversion as retryable",
+			disk:                &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 200},
+			volumeID:            testVolumeID,
+			mutableParameters:   map[string]string{"type": "hyperdisk-balanced"},
+			enablePdConversion:  true,
+			convertErr:          conversionAPIError(http.StatusBadRequest, "resourceNotReady", "The resource is not ready"),
+			expConvertCalled:    true,
+			expTargetDiskType:   "hyperdisk-balanced",
+			expErrCode:          codes.Unavailable,
+			expErrMessageSubstr: "is in progress",
+		},
+		{
+			name:               "treats an unmet precondition as retryable",
+			disk:               &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-standard", SizeGb: 200},
+			volumeID:           testVolumeID,
+			mutableParameters:  map[string]string{"type": "hyperdisk-balanced"},
+			enablePdConversion: true,
+			convertErr:         conversionAPIError(http.StatusTooManyRequests, "rateLimitExceeded", "too many concurrent conversion operations"),
+			expConvertCalled:   true,
+			expTargetDiskType:  "hyperdisk-balanced",
+			expErrCode:         codes.Unavailable,
+		},
+		{
+			// How a completed conversion is reported as successful: the retry
+			// after the disk reports the new type has nothing left to do.
+			name:               "a completed conversion reports success",
+			disk:               &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "hyperdisk-balanced", SizeGb: 200},
+			volumeID:           testVolumeID,
+			mutableParameters:  map[string]string{"type": "hyperdisk-balanced"},
+			enablePdConversion: true,
+			expConvertCalled:   false,
+			expErrCode:         codes.OK,
+			// A conversion was running, so the disk now reporting the target type
+			// means it finished.
+			pvAnnotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: "https://www.googleapis.com/compute/alpha/projects/p/zones/z/operations/op-1",
+				constants.DiskTypeConvertedFromKey:       "pd-balanced",
+			},
+			expPVAnnotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: "",
+				constants.DiskTypeConvertedFromKey:       "pd-balanced",
+				constants.DiskTypeConvertedToKey:         "hyperdisk-balanced",
+			},
+		},
+		{
+			// Switching to a class naming the type the disk already has is how a
+			// user drops a queued conversion, since Kubernetes forbids clearing
+			// the class. Nothing was converted, so nothing may claim it was.
+			name:               "a queued conversion that never ran is dropped, not recorded",
+			disk:               &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 200},
+			volumeID:           testVolumeID,
+			mutableParameters:  map[string]string{"type": "pd-balanced"},
+			enablePdConversion: true,
+			expConvertCalled:   false,
+			expErrCode:         codes.OK,
+			pvAnnotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: constants.ConversionStatePending,
+			},
+			expPVAnnotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: "",
+				constants.DiskTypeConvertedFromKey:       "",
+				constants.DiskTypeConvertedToKey:         "",
+			},
+		},
+		{
+			// A disk more than one node can write to cannot be taken away and
+			// rebuilt the way a conversion needs to, so this never succeeds.
+			name: "rejects conversion of a multi-writer disk",
+			disk: &compute.Disk{
+				Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 200,
+				AccessMode: constants.GCEReadWriteManyAccessMode,
+			},
+			volumeID:            testVolumeID,
+			mutableParameters:   map[string]string{"type": "hyperdisk-balanced"},
+			enablePdConversion:  true,
+			expConvertCalled:    false,
+			expErrCode:          codes.InvalidArgument,
+			expErrMessageSubstr: "multi-writer",
+		},
+		{
+			name:               "a matching disk type is not a conversion",
+			disk:               &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "hyperdisk-balanced", SizeGb: 200},
+			volumeID:           testVolumeID,
+			mutableParameters:  map[string]string{"type": "hyperdisk-balanced", "iops": "3000"},
+			enablePdConversion: true,
+			expConvertCalled:   false,
+			expErrCode:         codes.OK,
+			// Tuning IOPS on a disk that was created with the type its
+			// VolumeAttributesClass names is not a migration, and must not leave
+			// the volume claiming it was converted.
+			expPVAnnotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: "",
+				constants.DiskTypeConvertedFromKey:       "",
+				constants.DiskTypeConvertedToKey:         "",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fcp, err := gce.CreateFakeCloudProvider(project, zone, []*gce.CloudDisk{gce.CloudDiskFromV1(tc.disk)})
+			if err != nil {
+				t.Fatalf("Failed to create fake cloud provider: %v", err)
+			}
+			fcp.ConversionTestParams.TypeConversionErr = tc.convertErr
+
+			oldGetKubeClient := k8sclient.GetClient
+			defer func() { k8sclient.GetClient = oldGetKubeClient }()
+			kubeClient := fake.NewSimpleClientset(&corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: tc.pvAnnotations},
+			})
+			k8sclient.GetClient = func() (kubernetes.Interface, error) { return kubeClient, nil }
+
+			gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{EnablePdConversion: tc.enablePdConversion})
+			defer gceDriver.cs.WaitForConversionWorkers()
+
+			_, err = gceDriver.cs.ControllerModifyVolume(context.Background(), &csi.ControllerModifyVolumeRequest{
+				VolumeId:          tc.volumeID,
+				MutableParameters: tc.mutableParameters,
+			})
+
+			if gotCode := status.Code(err); gotCode != tc.expErrCode {
+				t.Errorf("Expected error code %v, got %v (err: %v)", tc.expErrCode, gotCode, err)
+			}
+			if tc.expErrMessageSubstr != "" && (err == nil || !strings.Contains(err.Error(), tc.expErrMessageSubstr)) {
+				t.Errorf("Expected error containing %q, got: %v", tc.expErrMessageSubstr, err)
+			}
+
+			if tc.expPVAnnotations != nil {
+				pv, getErr := kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), name, metav1.GetOptions{})
+				if getErr != nil {
+					t.Fatalf("Failed to get PersistentVolume %s: %v", name, getErr)
+				}
+				for key, want := range tc.expPVAnnotations {
+					got, exists := pv.Annotations[key]
+					if want == "" {
+						if exists {
+							t.Errorf("Expected annotation %s to be absent, got %q", key, got)
+						}
+						continue
+					}
+					if got != want {
+						t.Errorf("Expected annotation %s to be %q, got %q", key, want, got)
+					}
+				}
+			}
+
+			gotCalled := fcp.ConversionTestParams.TypeConversionCalled
+			if gotCalled != tc.expConvertCalled {
+				t.Errorf("Expected conversion called to be %v, got %v", tc.expConvertCalled, gotCalled)
+			}
+			if !tc.expConvertCalled {
+				return
+			}
+			if got := fcp.ConversionTestParams.TypeConversionTargetType; got != tc.expTargetDiskType {
+				t.Errorf("Expected conversion target type %q, got %q", tc.expTargetDiskType, got)
+			}
+			if got := fcp.ConversionTestParams.TypeConversionIops; !equalInt64Ptr(got, tc.expIops) {
+				t.Errorf("Expected conversion IOPS %v, got %v", int64PtrStr(tc.expIops), int64PtrStr(got))
+			}
+			if got := fcp.ConversionTestParams.TypeConversionThroughput; !equalInt64Ptr(got, tc.expThroughput) {
+				t.Errorf("Expected conversion throughput %v, got %v", int64PtrStr(tc.expThroughput), int64PtrStr(got))
+			}
+		})
+	}
+}
+
+// conversionAPIError builds an error shaped like the one the convert API
+// returns, where the machine readable reason is carried in an ErrorInfo detail
+// rather than in the top level error item.
+func conversionAPIError(code int, reason, message string) *googleapi.Error {
+	return &googleapi.Error{
+		Code:    code,
+		Message: message,
+		Errors:  []googleapi.ErrorItem{{Reason: "badRequest", Message: message}},
+		Details: []interface{}{
+			map[string]interface{}{
+				"@type":  "type.googleapis.com/google.rpc.ErrorInfo",
+				"reason": reason,
+				"domain": "compute.googleapis.com",
+			},
+		},
+	}
+}
+
+func equalInt64Ptr(a, b *int64) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func int64PtrStr(v *int64) string {
+	if v == nil {
+		return "<nil>"
+	}
+	return strconv.FormatInt(*v, 10)
+}
+
 func TestVolumeModifyOperation(t *testing.T) {
 	testCases := []struct {
 		name          string
@@ -2587,7 +2917,9 @@ func TestVolumeModifyOperation(t *testing.T) {
 			t.Fatalf("Failed convert key: %v", err)
 		}
 
-		err = fcp.InsertDisk(context.Background(), project, volKey, *tc.params, 200000, nil, nil, "", "", false, "")
+		// Hyperdisk IOPS and throughput ceilings scale with disk size, so the
+		// disk is large enough to accept the values these cases request.
+		err = fcp.InsertDisk(context.Background(), project, volKey, *tc.params, 200*1024*1024*1024, nil, nil, "", "", false, "")
 		if err != nil {
 			t.Fatalf("Failed to insert disk: %v", err)
 		}
@@ -2670,7 +3002,8 @@ func TestVolumeModifyErrorHandling(t *testing.T) {
 		{
 			name: "Too Many Requests errors",
 			createReq: &csi.CreateVolumeRequest{
-				Name: name,
+				Name:          name,
+				CapacityRange: &csi.CapacityRange{RequiredBytes: 200 * 1024 * 1024 * 1024},
 				Parameters: map[string]string{
 					parameters.ParameterKeyType:                          "hyperdisk-balanced",
 					parameters.ParameterKeyProvisionedIOPSOnCreate:       "3000",
@@ -2706,7 +3039,8 @@ func TestVolumeModifyErrorHandling(t *testing.T) {
 		{
 			name: "InvalidArgument errors",
 			createReq: &csi.CreateVolumeRequest{
-				Name: name,
+				Name:          name,
+				CapacityRange: &csi.CapacityRange{RequiredBytes: 200 * 1024 * 1024 * 1024},
 				Parameters: map[string]string{
 					parameters.ParameterKeyType:                          "hyperdisk-balanced",
 					parameters.ParameterKeyProvisionedIOPSOnCreate:       "3000",
@@ -6390,4 +6724,1788 @@ func TestListSnapshots_Concurrent(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestControllerPublishVolume_ConversionGuard(t *testing.T) {
+	className := "vac-hyperdisk"
+	conversionPV := func(annotations map[string]string) *corev1.PersistentVolume {
+		return &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: annotations},
+			Spec: corev1.PersistentVolumeSpec{
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					CSI: &corev1.CSIPersistentVolumeSource{
+						Driver:       "pd.csi.storage.gke.io",
+						VolumeHandle: testVolumeID,
+					},
+				},
+			},
+		}
+	}
+	// conversionPVWithClaim is conversionPV plus a claimRef, for cases that need
+	// a VAC to still be resolvable from the PV.
+	conversionPVWithClaim := func(annotations map[string]string) *corev1.PersistentVolume {
+		pv := conversionPV(annotations)
+		pv.Spec.ClaimRef = &corev1.ObjectReference{Name: "test-pvc", Namespace: "default"}
+		return pv
+	}
+	requestsHyperdisk := &storagev1beta1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{Name: className},
+		DriverName: "pd.csi.storage.gke.io",
+		Parameters: map[string]string{"type": "hyperdisk-balanced"},
+	}
+	pvcWithClass := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pvc", Namespace: "default"},
+		Spec:       corev1.PersistentVolumeClaimSpec{VolumeAttributesClassName: &className},
+	}
+	// hyperdisk-throughput takes no IOPS, so this class describes a conversion
+	// that can never run.
+	requestsUnsupported := &storagev1beta1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{Name: className},
+		DriverName: "pd.csi.storage.gke.io",
+		Parameters: map[string]string{"type": "hyperdisk-throughput", "iops": "3000"},
+	}
+
+	testCases := []struct {
+		name               string
+		enablePdConversion bool
+		pv                 *corev1.PersistentVolume
+		pvc                *corev1.PersistentVolumeClaim
+		vac                *storagev1beta1.VolumeAttributesClass
+		// getClientErr makes the conversion state unreadable, standing in for an
+		// unreachable API server or missing RBAC.
+		getClientErr error
+		expErrCode   codes.Code
+	}{
+		{
+			name:               "attaches when no conversion annotation is set",
+			enablePdConversion: true,
+			pv:                 conversionPV(nil),
+			expErrCode:         codes.OK,
+		},
+		{
+			name:               "attaches when the conversion annotation was cleared",
+			enablePdConversion: true,
+			pv:                 conversionPV(map[string]string{constants.DiskTypeConversionOperationKey: ""}),
+			expErrCode:         codes.OK,
+		},
+		{
+			name:               "blocks attach while a conversion is queued and still requested",
+			enablePdConversion: true,
+			pv:                 conversionPVWithClaim(map[string]string{constants.DiskTypeConversionOperationKey: constants.ConversionStatePending}),
+			pvc:                pvcWithClass,
+			vac:                requestsHyperdisk,
+			expErrCode:         codes.Unavailable,
+		},
+		{
+			// The VAC was removed while the conversion was still queued and the
+			// volume never detached to reconcile it there, so this is the only
+			// place left that notices the conversion is no longer wanted.
+			name:               "unblocks attach when a queued conversion's VolumeAttributesClass was removed",
+			enablePdConversion: true,
+			pv:                 conversionPV(map[string]string{constants.DiskTypeConversionOperationKey: constants.ConversionStatePending}),
+			expErrCode:         codes.OK,
+		},
+		{
+			// A conversion that can never run must not keep the volume waiting,
+			// so the queued state is dropped and the attach goes ahead.
+			name:               "unblocks attach when the queued conversion can never run",
+			enablePdConversion: true,
+			pv:                 conversionPVWithClaim(map[string]string{constants.DiskTypeConversionOperationKey: constants.ConversionStatePending}),
+			pvc:                pvcWithClass,
+			vac:                requestsUnsupported,
+			expErrCode:         codes.OK,
+		},
+		{
+			name:               "blocks attach while a conversion is running",
+			enablePdConversion: true,
+			pv: conversionPV(map[string]string{
+				constants.DiskTypeConversionOperationKey: "https://www.googleapis.com/compute/alpha/projects/p/zones/z/operations/op-1",
+			}),
+			expErrCode: codes.Unavailable,
+		},
+		{
+			// Failing closed: an attach that cannot be shown to be safe is
+			// refused, because attaching mid-conversion can corrupt the disk.
+			name:               "blocks attach when the conversion state cannot be read",
+			enablePdConversion: true,
+			pv:                 conversionPV(nil),
+			getClientErr:       fmt.Errorf("connection refused"),
+			expErrCode:         codes.Unavailable,
+		},
+		{
+			// A disk is not required to have a PersistentVolume named after it,
+			// so a missing PV means there is no conversion, not an unknown state.
+			name:               "attaches when the volume has no PersistentVolume",
+			enablePdConversion: true,
+			expErrCode:         codes.OK,
+		},
+		{
+			name:               "does not consult the PV when conversion is disabled",
+			enablePdConversion: false,
+			pv:                 conversionPV(map[string]string{constants.DiskTypeConversionOperationKey: constants.ConversionStatePending}),
+			getClientErr:       fmt.Errorf("connection refused"),
+			expErrCode:         codes.OK,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldGetKubeClient := k8sclient.GetClient
+			defer func() { k8sclient.GetClient = oldGetKubeClient }()
+			k8sclient.GetClient = func() (kubernetes.Interface, error) {
+				if tc.getClientErr != nil {
+					return nil, tc.getClientErr
+				}
+				var objects []runtime.Object
+				if tc.pv != nil {
+					objects = append(objects, tc.pv)
+				}
+				if tc.pvc != nil {
+					objects = append(objects, tc.pvc)
+				}
+				if tc.vac != nil {
+					objects = append(objects, tc.vac)
+				}
+				return fake.NewSimpleClientset(objects...), nil
+			}
+
+			fakeCloudProvider, err := gce.CreateFakeCloudProvider(project, zone, []*gce.CloudDisk{createZonalCloudDisk(name)})
+			if err != nil {
+				t.Fatalf("failed to create fake cloud provider: %v", err)
+			}
+			fakeCloudProvider.InsertInstance(&compute.Instance{Name: node}, zone, node)
+
+			gceDriver := initGCEDriver(t, nil, &GCEControllerServerArgs{EnablePdConversion: tc.enablePdConversion})
+			gceDriver.cs.CloudProvider = fakeCloudProvider
+
+			req := &csi.ControllerPublishVolumeRequest{
+				VolumeId: testVolumeID,
+				NodeId:   testNodeID,
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+			}
+			_, err, _ = gceDriver.cs.executeControllerPublishVolume(context.Background(), req)
+
+			if tc.expErrCode == codes.OK {
+				if err != nil {
+					t.Fatalf("Expected attach to succeed, got error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Expected error code %v, got no error", tc.expErrCode)
+			}
+			serverError, ok := status.FromError(err)
+			if !ok {
+				t.Fatalf("Could not get error status code from error: %v", err)
+			}
+			if serverError.Code() != tc.expErrCode {
+				t.Fatalf("Expected error code %v, got %v: %v", tc.expErrCode, serverError.Code(), err)
+			}
+		})
+	}
+}
+
+func TestControllerPublishVolume_ConversionCompletionFallback(t *testing.T) {
+	const operation = "https://www.googleapis.com/compute/alpha/projects/p/zones/z/operations/op-1"
+	className := "vac-hyperdisk-extreme"
+
+	testCases := []struct {
+		name string
+		// diskType is the type the disk reports in GCE now.
+		diskType      string
+		pvAnnotations map[string]string
+		// withVACRequesting, if set, gives the PV a claimRef to a PVC whose
+		// VolumeAttributesClass still requests this type, so a queued
+		// conversion is still wanted rather than reconciled away.
+		withVACRequesting string
+		expErrCode        codes.Code
+		// expPVAnnotations are the annotations the PersistentVolume is expected
+		// to end with. A key mapped to the empty string is expected to be absent.
+		expPVAnnotations map[string]string
+	}{
+		{
+			// The conversion finished while nothing was watching it, which is
+			// what happens when the driver restarts mid-conversion. Without this
+			// the volume would stay unattachable for good.
+			name:     "records a conversion that finished unobserved and attaches",
+			diskType: "hyperdisk-balanced",
+			pvAnnotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: operation,
+				constants.DiskTypeConvertedFromKey:       "pd-balanced",
+			},
+			expErrCode: codes.OK,
+			expPVAnnotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: "",
+				constants.DiskTypeConvertedFromKey:       "pd-balanced",
+				constants.DiskTypeConvertedToKey:         "hyperdisk-balanced",
+			},
+		},
+		{
+			// The disk still reports the type it is being converted away from,
+			// so the conversion is still running and attaching is unsafe.
+			name:     "blocks the attach while the disk still has its original type",
+			diskType: "pd-balanced",
+			pvAnnotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: operation,
+				constants.DiskTypeConvertedFromKey:       "pd-balanced",
+			},
+			expErrCode: codes.Unavailable,
+			expPVAnnotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: operation,
+				constants.DiskTypeConvertedToKey:         "",
+			},
+		},
+		{
+			// A conversion waiting for a detach has not started, so a changed
+			// type cannot be attributed to it. The class still asks for a type
+			// other than what the disk already reports, so the conversion also
+			// stays genuinely queued rather than being reconciled away.
+			name:     "does not complete a conversion that is only queued",
+			diskType: "hyperdisk-balanced",
+			pvAnnotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: constants.ConversionStatePending,
+				constants.DiskTypeConvertedFromKey:       "pd-balanced",
+			},
+			withVACRequesting: "hyperdisk-extreme",
+			expErrCode:        codes.Unavailable,
+			expPVAnnotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: constants.ConversionStatePending,
+				constants.DiskTypeConvertedToKey:         "",
+			},
+		},
+		{
+			// Nothing records what the disk was before, so completion cannot be
+			// told apart from a conversion still in flight.
+			name:     "blocks the attach when the original type was not recorded",
+			diskType: "hyperdisk-balanced",
+			pvAnnotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: operation,
+			},
+			expErrCode: codes.Unavailable,
+			expPVAnnotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: operation,
+				constants.DiskTypeConvertedToKey:         "",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldGetKubeClient := k8sclient.GetClient
+			defer func() { k8sclient.GetClient = oldGetKubeClient }()
+			pv := &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: tc.pvAnnotations},
+			}
+			objects := []runtime.Object{pv}
+			if tc.withVACRequesting != "" {
+				pv.Spec.ClaimRef = &corev1.ObjectReference{Name: "test-pvc", Namespace: "default"}
+				objects = append(objects,
+					&corev1.PersistentVolumeClaim{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-pvc", Namespace: "default"},
+						Spec:       corev1.PersistentVolumeClaimSpec{VolumeAttributesClassName: &className},
+					},
+					&storagev1beta1.VolumeAttributesClass{
+						ObjectMeta: metav1.ObjectMeta{Name: className},
+						DriverName: "pd.csi.storage.gke.io",
+						Parameters: map[string]string{"type": tc.withVACRequesting},
+					},
+				)
+			}
+			kubeClient := fake.NewSimpleClientset(objects...)
+			k8sclient.GetClient = func() (kubernetes.Interface, error) { return kubeClient, nil }
+
+			disk := &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: tc.diskType, SizeGb: 200}
+			fcp, err := gce.CreateFakeCloudProvider(project, zone, []*gce.CloudDisk{gce.CloudDiskFromV1(disk)})
+			if err != nil {
+				t.Fatalf("Failed to create fake cloud provider: %v", err)
+			}
+			fcp.InsertInstance(&compute.Instance{Name: node}, zone, node)
+
+			gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{EnablePdConversion: true})
+			defer gceDriver.cs.WaitForConversionWorkers()
+
+			_, err, _ = gceDriver.cs.executeControllerPublishVolume(context.Background(), &csi.ControllerPublishVolumeRequest{
+				VolumeId: testVolumeID,
+				NodeId:   testNodeID,
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+			})
+
+			if gotCode := status.Code(err); gotCode != tc.expErrCode {
+				t.Errorf("Expected error code %v, got %v (err: %v)", tc.expErrCode, gotCode, err)
+			}
+
+			pv, getErr := kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), name, metav1.GetOptions{})
+			if getErr != nil {
+				t.Fatalf("Failed to get PersistentVolume %s: %v", name, getErr)
+			}
+			for key, want := range tc.expPVAnnotations {
+				got, exists := pv.Annotations[key]
+				if want == "" {
+					if exists {
+						t.Errorf("Expected annotation %s to be absent, got %q", key, got)
+					}
+					continue
+				}
+				if got != want {
+					t.Errorf("Expected annotation %s to be %q, got %q", key, want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestRunQueuedConversion(t *testing.T) {
+	className := "vac-hyperdisk"
+	emptyClassName := ""
+
+	pv := func() *corev1.PersistentVolume {
+		return &corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Annotations: map[string]string{constants.DiskTypeConversionOperationKey: constants.ConversionStatePending},
+			},
+			Spec: corev1.PersistentVolumeSpec{
+				ClaimRef: &corev1.ObjectReference{Name: "test-pvc", Namespace: "default"},
+			},
+		}
+	}
+	pvc := func(class *string) *corev1.PersistentVolumeClaim {
+		return &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pvc", Namespace: "default"},
+			Spec:       corev1.PersistentVolumeClaimSpec{VolumeAttributesClassName: class},
+		}
+	}
+	vac := func(params map[string]string) *storagev1.VolumeAttributesClass {
+		return &storagev1.VolumeAttributesClass{
+			ObjectMeta: metav1.ObjectMeta{Name: className},
+			DriverName: "pd.csi.storage.gke.io",
+			Parameters: params,
+		}
+	}
+
+	testCases := []struct {
+		name       string
+		disk       *compute.Disk
+		objects    []runtime.Object
+		convertErr error
+		// expConvertCalled is whether the conversion was started in GCE.
+		expConvertCalled bool
+		// expStillQueued is whether the volume is left waiting for another try.
+		expStillQueued bool
+		expConvertedTo bool
+	}{
+		{
+			name:             "starts the conversion the class asks for",
+			disk:             &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 200},
+			objects:          []runtime.Object{pv(), pvc(&className), vac(map[string]string{"type": "hyperdisk-balanced"})},
+			expConvertCalled: true,
+			// The operation annotation replaces the queued marker.
+			expStillQueued: false,
+		},
+		{
+			// Clearing the class on the claim is how a user cancels a conversion
+			// that has not started yet.
+			name:             "cancels the conversion when the class was removed",
+			disk:             &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 200},
+			objects:          []runtime.Object{pv(), pvc(nil), vac(map[string]string{"type": "hyperdisk-balanced"})},
+			expConvertCalled: false,
+			expStillQueued:   false,
+		},
+		{
+			name:             "cancels the conversion when the class names an empty value",
+			disk:             &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 200},
+			objects:          []runtime.Object{pv(), pvc(&emptyClassName), vac(map[string]string{"type": "hyperdisk-balanced"})},
+			expConvertCalled: false,
+			expStillQueued:   false,
+		},
+		{
+			// A class that only tunes IOPS is not a conversion request.
+			name:             "cancels the conversion when the class no longer names a type",
+			disk:             &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 200},
+			objects:          []runtime.Object{pv(), pvc(&className), vac(map[string]string{"iops": "3000"})},
+			expConvertCalled: false,
+			expStillQueued:   false,
+		},
+		{
+			name:             "cancels the conversion when the disk already has the target type",
+			disk:             &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "hyperdisk-balanced", SizeGb: 200},
+			objects:          []runtime.Object{pv(), pvc(&className), vac(map[string]string{"type": "hyperdisk-balanced"})},
+			expConvertCalled: false,
+			expStillQueued:   false,
+		},
+		{
+			// Nothing about a multi-writer disk will change, so leaving it queued
+			// would block the volume on a conversion that can never run.
+			name: "cancels the conversion for a multi-writer disk",
+			disk: &compute.Disk{
+				Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 200,
+				AccessMode: constants.GCEReadWriteManyAccessMode,
+			},
+			objects:          []runtime.Object{pv(), pvc(&className), vac(map[string]string{"type": "hyperdisk-balanced"})},
+			expConvertCalled: false,
+			expStillQueued:   false,
+		},
+		{
+			// Something attached the disk again before the conversion could run.
+			name: "leaves the conversion queued when the disk is attached again",
+			disk: &compute.Disk{
+				Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 200,
+				Users: []string{"projects/test-project/zones/country-region-zone/instances/test-node"},
+			},
+			objects:          []runtime.Object{pv(), pvc(&className), vac(map[string]string{"type": "hyperdisk-balanced"})},
+			expConvertCalled: false,
+			expStillQueued:   true,
+		},
+		{
+			name:             "leaves the conversion queued after a retriable failure",
+			disk:             &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 200},
+			objects:          []runtime.Object{pv(), pvc(&className), vac(map[string]string{"type": "hyperdisk-balanced"})},
+			convertErr:       conversionAPIError(429, "rateLimitExceeded", "too many conversions"),
+			expConvertCalled: true,
+			expStillQueued:   true,
+		},
+		{
+			// Retrying cannot help, so the volume must not stay blocked.
+			name:             "cancels the conversion after a terminal failure",
+			disk:             &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 200},
+			objects:          []runtime.Object{pv(), pvc(&className), vac(map[string]string{"type": "hyperdisk-throughput"})},
+			convertErr:       conversionAPIError(400, "DISK_TYPE_CONVERSION_UNSUPPORTED", "unsupported conversion"),
+			expConvertCalled: true,
+			expStillQueued:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldGetKubeClient := k8sclient.GetClient
+			defer func() { k8sclient.GetClient = oldGetKubeClient }()
+			kubeClient := fake.NewSimpleClientset(tc.objects...)
+			k8sclient.GetClient = func() (kubernetes.Interface, error) { return kubeClient, nil }
+
+			// The fake applies the new type to the disk, so the type it started
+			// with has to be kept to check what was recorded.
+			originalDiskType := tc.disk.Type
+
+			fcp, err := gce.CreateFakeCloudProvider(project, zone, []*gce.CloudDisk{gce.CloudDiskFromV1(tc.disk)})
+			if err != nil {
+				t.Fatalf("Failed to create fake cloud provider: %v", err)
+			}
+			fcp.ConversionTestParams.TypeConversionErr = tc.convertErr
+
+			gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{EnablePdConversion: true})
+			defer gceDriver.cs.WaitForConversionWorkers()
+			_, volKey, err := common.VolumeIDToKey(testVolumeID)
+			if err != nil {
+				t.Fatalf("Failed to convert volume id to key: %v", err)
+			}
+
+			gceDriver.cs.runQueuedConversion(context.Background(), project, volKey)
+
+			if got := fcp.ConversionTestParams.TypeConversionCalled; got != tc.expConvertCalled {
+				t.Errorf("Expected conversion called to be %v, got %v", tc.expConvertCalled, got)
+			}
+
+			pvObj, getErr := kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), name, metav1.GetOptions{})
+			if getErr != nil {
+				t.Fatalf("Failed to get PersistentVolume %s: %v", name, getErr)
+			}
+			operation := pvObj.Annotations[constants.DiskTypeConversionOperationKey]
+			if tc.expStillQueued {
+				if operation != constants.ConversionStatePending {
+					t.Errorf("Expected the conversion to stay queued, got annotation %q", operation)
+				}
+			} else if operation == constants.ConversionStatePending {
+				t.Errorf("Expected the conversion to no longer be queued, got annotation %q", operation)
+			}
+			// A conversion that started replaces the queued marker with the
+			// operation to track it by.
+			if tc.expConvertCalled && tc.convertErr == nil {
+				if operation == "" || operation == constants.ConversionStatePending {
+					t.Errorf("Expected the conversion operation to be recorded, got annotation %q", operation)
+				}
+				if got := pvObj.Annotations[constants.DiskTypeConvertedFromKey]; got != originalDiskType {
+					t.Errorf("Expected converted-from annotation %q, got %q", originalDiskType, got)
+				}
+			}
+		})
+	}
+}
+
+// waitFor polls a condition, so that tests do not depend on how quickly a
+// background watcher runs.
+func waitFor(t *testing.T, timeout time.Duration, desc string, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Errorf("Timed out waiting for %s", desc)
+	return false
+}
+
+func TestConversionWatcher(t *testing.T) {
+	const operation = "https://www.googleapis.com/compute/alpha/projects/p/zones/z/operations/op-convert-1"
+
+	testCases := []struct {
+		name string
+		// notDoneTimes is how many checks report the conversion as running.
+		notDoneTimes int
+		// pollErr fails the check itself, which must not be mistaken for the
+		// conversion failing.
+		pollErr error
+		// operationErr is the conversion's own failure.
+		operationErr error
+		// diskTypeAfter is the type the disk reports once the conversion ends.
+		diskTypeAfter    string
+		expConvertedTo   string
+		expConvertedFrom string
+		// expOperation is the operation annotation the volume ends up with, or
+		// the empty string when the volume ends up unblocked.
+		expOperation string
+		// expLastError is whether the failure is kept to be reported on the
+		// claim at the next attempt.
+		expLastError bool
+		// expEvent is the event reason the watcher must report for the outcome.
+		expEvent string
+	}{
+		{
+			name:             "records the conversion when the operation finishes",
+			diskTypeAfter:    "hyperdisk-balanced",
+			expConvertedTo:   "hyperdisk-balanced",
+			expConvertedFrom: "pd-balanced",
+			expEvent:         constants.DiskTypeConversionCompleteReason,
+		},
+		{
+			// The watcher has to keep checking rather than treating the first
+			// unfinished answer as the end of the conversion.
+			name:             "keeps checking while the operation is running",
+			notDoneTimes:     3,
+			diskTypeAfter:    "hyperdisk-balanced",
+			expConvertedTo:   "hyperdisk-balanced",
+			expConvertedFrom: "pd-balanced",
+			expEvent:         constants.DiskTypeConversionCompleteReason,
+		},
+		{
+			// A failure with no recognised reason is retriable, so the volume
+			// goes back to waiting for a conversion and stays blocked.
+			name:          "requeues the conversion when it fails for an unclassified reason",
+			operationErr:  &googleapi.Error{Code: 500, Message: "conversion failed", Errors: []googleapi.ErrorItem{{Reason: "INTERNAL_ERROR"}}},
+			diskTypeAfter: "pd-balanced",
+			expOperation:  constants.ConversionStatePending,
+			expLastError:  true,
+			expEvent:      constants.DiskTypeConversionRetryReason,
+		},
+		{
+			// A failure the target configuration can never recover from is
+			// terminal, so the volume is released and not converted.
+			name:          "clears the state when the conversion fails terminally",
+			operationErr:  &googleapi.Error{Code: 400, Message: "unsupported", Errors: []googleapi.ErrorItem{{Reason: "badRequest"}}},
+			diskTypeAfter: "pd-balanced",
+			expEvent:      constants.DiskTypeConversionFailedReason,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldGetKubeClient := k8sclient.GetClient
+			defer func() { k8sclient.GetClient = oldGetKubeClient }()
+			kubeClient := fake.NewSimpleClientset(&corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+					Annotations: map[string]string{
+						constants.DiskTypeConversionOperationKey: operation,
+						constants.DiskTypeConvertedFromKey:       "pd-balanced",
+					},
+				},
+			})
+			k8sclient.GetClient = func() (kubernetes.Interface, error) { return kubeClient, nil }
+
+			disk := &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: tc.diskTypeAfter, SizeGb: 200}
+			fcp, err := gce.CreateFakeCloudProvider(project, zone, []*gce.CloudDisk{gce.CloudDiskFromV1(disk)})
+			if err != nil {
+				t.Fatalf("Failed to create fake cloud provider: %v", err)
+			}
+			fcp.PollNotDoneTimes = tc.notDoneTimes
+			fcp.PollErr = tc.pollErr
+			fcp.PollOperationErr = tc.operationErr
+
+			gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{EnablePdConversion: true})
+			defer waitForNoConversionWatchers(gceDriver.cs)
+			_, volKey, err := common.VolumeIDToKey(testVolumeID)
+			if err != nil {
+				t.Fatalf("Failed to convert volume id to key: %v", err)
+			}
+
+			// Keep the test quick; the real interval is minutes.
+			gceDriver.cs.conversionPollBackoffOverride = wait.Backoff{Duration: time.Millisecond, Factor: 1.0, Steps: math.MaxInt32}
+
+			gceDriver.cs.watchConversion(project, volKey, operation)
+
+			waitFor(t, 5*time.Second, "the conversion state to settle", func() bool {
+				pv, err := kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), name, metav1.GetOptions{})
+				if err != nil {
+					return false
+				}
+				return pv.Annotations[constants.DiskTypeConversionOperationKey] == tc.expOperation
+			})
+
+			pv, err := kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Failed to get PersistentVolume: %v", err)
+			}
+			if got := pv.Annotations[constants.DiskTypeConversionOperationKey]; got != tc.expOperation {
+				t.Errorf("Got operation annotation %q; want %q", got, tc.expOperation)
+			}
+			if _, ok := pv.Annotations[constants.DiskTypeConversionLastErrorKey]; ok != tc.expLastError {
+				t.Errorf("Recorded failure present=%v; want %v", ok, tc.expLastError)
+			}
+			if got := pv.Annotations[constants.DiskTypeConvertedToKey]; got != tc.expConvertedTo {
+				t.Errorf("Got converted-to %q; want %q", got, tc.expConvertedTo)
+			}
+			if got := pv.Annotations[constants.DiskTypeConvertedFromKey]; got != tc.expConvertedFrom {
+				t.Errorf("Got converted-from %q; want %q", got, tc.expConvertedFrom)
+			}
+			// The watcher records the outcome on the volume and reports it, so a
+			// user watching the volume sees what happened to the conversion.
+			if tc.expEvent != "" {
+				events, evErr := kubeClient.CoreV1().Events(metav1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
+				if evErr != nil {
+					t.Fatalf("Failed to list events: %v", evErr)
+				}
+				found := 0
+				for _, ev := range events.Items {
+					if ev.Reason == tc.expEvent {
+						found++
+					}
+				}
+				if found != 1 {
+					t.Errorf("Got %d %s events; want exactly 1", found, tc.expEvent)
+				}
+			}
+
+			// The watcher must only poll the operation, not the self link.
+			if got := fcp.PolledOperation(); got != "op-convert-1" {
+				t.Errorf("Polled operation %q; want op-convert-1", got)
+			}
+			if tc.notDoneTimes > 0 && fcp.PollCalls() <= tc.notDoneTimes {
+				t.Errorf("Made %d checks; want more than %d", fcp.PollCalls(), tc.notDoneTimes)
+			}
+			// The watcher must not outlive the conversion it was following.
+			waitFor(t, 2*time.Second, "the watcher to deregister", func() bool {
+				gceDriver.cs.conversionWatchersLock.Lock()
+				defer gceDriver.cs.conversionWatchersLock.Unlock()
+				return len(gceDriver.cs.conversionWatchers) == 0
+			})
+		})
+	}
+}
+
+func TestConversionWatcherStopsOnVolumeDelete(t *testing.T) {
+	const operation = "https://www.googleapis.com/compute/alpha/projects/p/zones/z/operations/op-convert-2"
+
+	oldGetKubeClient := k8sclient.GetClient
+	defer func() { k8sclient.GetClient = oldGetKubeClient }()
+	kubeClient := fake.NewSimpleClientset(&corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: map[string]string{constants.DiskTypeConversionOperationKey: operation},
+		},
+	})
+	k8sclient.GetClient = func() (kubernetes.Interface, error) { return kubeClient, nil }
+
+	disk := &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 200}
+	fcp, err := gce.CreateFakeCloudProvider(project, zone, []*gce.CloudDisk{gce.CloudDiskFromV1(disk)})
+	if err != nil {
+		t.Fatalf("Failed to create fake cloud provider: %v", err)
+	}
+	// The conversion never finishes, so only a cancellation can end the watcher.
+	fcp.PollNotDoneTimes = math.MaxInt32
+
+	gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{EnablePdConversion: true})
+	defer waitForNoConversionWatchers(gceDriver.cs)
+	_, volKey, err := common.VolumeIDToKey(testVolumeID)
+	if err != nil {
+		t.Fatalf("Failed to convert volume id to key: %v", err)
+	}
+
+	gceDriver.cs.conversionPollBackoffOverride = wait.Backoff{Duration: time.Millisecond, Factor: 1.0, Steps: math.MaxInt32}
+
+	gceDriver.cs.watchConversion(project, volKey, operation)
+	waitFor(t, 5*time.Second, "the watcher to start polling", func() bool { return fcp.PollCalls() > 0 })
+
+	// A conversion rebuilds the disk through a temporary snapshot, so the delete
+	// is refused while one is running and the watcher keeps following it.
+	if _, err := gceDriver.cs.DeleteVolume(context.Background(), &csi.DeleteVolumeRequest{VolumeId: testVolumeID}); status.Code(err) != codes.Unavailable {
+		t.Fatalf("DeleteVolume during a conversion: got %v; want Unavailable", err)
+	}
+	gceDriver.cs.conversionWatchersLock.Lock()
+	stillWatching := len(gceDriver.cs.conversionWatchers)
+	gceDriver.cs.conversionWatchersLock.Unlock()
+	if stillWatching != 1 {
+		t.Fatalf("Watchers after a refused delete = %d; want 1", stillWatching)
+	}
+
+	// Once the conversion is no longer recorded the delete proceeds, and it must
+	// stop the watcher, or it polls an operation for a disk that no longer
+	// exists for as long as the driver runs.
+	if err := k8sclient.RemovePVAnnotation(context.Background(), name, constants.DiskTypeConversionOperationKey); err != nil {
+		t.Fatalf("Failed to clear the conversion annotation: %v", err)
+	}
+	if _, err := gceDriver.cs.DeleteVolume(context.Background(), &csi.DeleteVolumeRequest{VolumeId: testVolumeID}); err != nil {
+		t.Fatalf("DeleteVolume failed: %v", err)
+	}
+
+	if !waitFor(t, 5*time.Second, "the watcher to deregister", func() bool {
+		gceDriver.cs.conversionWatchersLock.Lock()
+		defer gceDriver.cs.conversionWatchersLock.Unlock()
+		return len(gceDriver.cs.conversionWatchers) == 0
+	}) {
+		return
+	}
+
+	// Once cancelled the watcher must stop making calls entirely.
+	settled := fcp.PollCalls()
+	time.Sleep(100 * time.Millisecond)
+	if after := fcp.PollCalls(); after != settled {
+		t.Errorf("Watcher kept polling after the volume was deleted: %d then %d checks", settled, after)
+	}
+}
+
+func TestConversionWatcherReplacesExisting(t *testing.T) {
+	oldGetKubeClient := k8sclient.GetClient
+	defer func() { k8sclient.GetClient = oldGetKubeClient }()
+	kubeClient := fake.NewSimpleClientset(&corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	})
+	k8sclient.GetClient = func() (kubernetes.Interface, error) { return kubeClient, nil }
+
+	disk := &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 200}
+	fcp, err := gce.CreateFakeCloudProvider(project, zone, []*gce.CloudDisk{gce.CloudDiskFromV1(disk)})
+	if err != nil {
+		t.Fatalf("Failed to create fake cloud provider: %v", err)
+	}
+	fcp.PollNotDoneTimes = math.MaxInt32
+
+	gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{EnablePdConversion: true})
+	defer waitForNoConversionWatchers(gceDriver.cs)
+	_, volKey, err := common.VolumeIDToKey(testVolumeID)
+	if err != nil {
+		t.Fatalf("Failed to convert volume id to key: %v", err)
+	}
+
+	gceDriver.cs.conversionPollBackoffOverride = wait.Backoff{Duration: time.Millisecond, Factor: 1.0, Steps: math.MaxInt32}
+
+	// Retries can start a second conversion for the same volume. Only one
+	// watcher may survive, or each retry leaks another goroutine.
+	for i := 0; i < 5; i++ {
+		gceDriver.cs.watchConversion(project, volKey, fmt.Sprintf("https://example.com/operations/op-%d", i))
+	}
+	waitFor(t, 5*time.Second, "the watcher to start polling", func() bool { return fcp.PollCalls() > 0 })
+
+	gceDriver.cs.conversionWatchersLock.Lock()
+	watchers := len(gceDriver.cs.conversionWatchers)
+	gceDriver.cs.conversionWatchersLock.Unlock()
+	if watchers != 1 {
+		t.Errorf("Got %d watchers for one volume; want 1", watchers)
+	}
+
+	gceDriver.cs.stopConversionWatcher(volKey)
+	waitFor(t, 2*time.Second, "the watcher to deregister", func() bool {
+		gceDriver.cs.conversionWatchersLock.Lock()
+		defer gceDriver.cs.conversionWatchersLock.Unlock()
+		return len(gceDriver.cs.conversionWatchers) == 0
+	})
+}
+
+func TestConversionOperationName(t *testing.T) {
+	testCases := []struct {
+		name      string
+		operation string
+		expected  string
+	}{
+		{
+			// What the annotation holds while a conversion runs.
+			name:      "self link yields the operation name",
+			operation: "https://www.googleapis.com/compute/alpha/projects/p/zones/us-central1-b/operations/operation-1785623095260-658404f80mm8e",
+			expected:  "operation-1785623095260-658404f80mm8e",
+		},
+		{
+			name:      "a bare operation name is returned unchanged",
+			operation: "operation-1785623095260",
+			expected:  "operation-1785623095260",
+		},
+		{
+			// A queued conversion has no operation to poll.
+			name:      "pending is not an operation",
+			operation: constants.ConversionStatePending,
+			expected:  "",
+		},
+		{
+			name:      "empty is not an operation",
+			operation: "",
+			expected:  "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := conversionOperationName(tc.operation); got != tc.expected {
+				t.Errorf("conversionOperationName(%q) = %q; want %q", tc.operation, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestUnsupportedConversionReason(t *testing.T) {
+	zonalKey := meta.ZonalKey(name, zone)
+	regionalKey := meta.RegionalKey(name, region)
+
+	testCases := []struct {
+		name           string
+		volKey         *meta.Key
+		disk           *gce.CloudDisk
+		expUnsupported bool
+		expSubstr      string
+	}{
+		{
+			name:   "a zonal single writer disk can be converted",
+			volKey: zonalKey,
+			disk:   gce.CloudDiskFromV1(&compute.Disk{Name: name, Type: "pd-balanced"}),
+		},
+		{
+			// There is no conversion API for regional disks.
+			name:           "regional disks cannot be converted",
+			volKey:         regionalKey,
+			disk:           gce.CloudDiskFromV1(&compute.Disk{Name: name, Type: "pd-balanced"}),
+			expUnsupported: true,
+			expSubstr:      "regional",
+		},
+		{
+			// The access mode is how a v1 disk reports shared write access.
+			name:           "disks with many writers cannot be converted",
+			volKey:         zonalKey,
+			disk:           gce.CloudDiskFromV1(&compute.Disk{Name: name, Type: "pd-balanced", AccessMode: constants.GCEReadWriteManyAccessMode}),
+			expUnsupported: true,
+			expSubstr:      "multi-writer",
+		},
+		{
+			// A beta disk reports the same thing through multiWriter instead.
+			name:           "multi writer beta disks cannot be converted",
+			volKey:         zonalKey,
+			disk:           gce.CloudDiskFromBeta(&computebeta.Disk{Name: name, Type: "pd-balanced", MultiWriter: true}),
+			expUnsupported: true,
+			expSubstr:      "multi-writer",
+		},
+		{
+			// The zone check must not depend on having read the disk.
+			name:           "regional is rejected even without a disk",
+			volKey:         regionalKey,
+			disk:           nil,
+			expUnsupported: true,
+			expSubstr:      "regional",
+		},
+		{
+			name:   "a missing disk is not itself a reason to refuse",
+			volKey: zonalKey,
+			disk:   nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := unsupportedConversionReason(tc.volKey, tc.disk)
+			if tc.expUnsupported {
+				if got == "" {
+					t.Fatalf("unsupportedConversionReason = \"\"; want a reason")
+				}
+				if !strings.Contains(got, tc.expSubstr) {
+					t.Errorf("Got reason %q; want it to mention %q", got, tc.expSubstr)
+				}
+				return
+			}
+			if got != "" {
+				t.Errorf("unsupportedConversionReason = %q; want \"\"", got)
+			}
+		})
+	}
+}
+
+func TestConversionErrorClassification(t *testing.T) {
+	testCases := []struct {
+		name           string
+		err            error
+		expTerminal    bool
+		expInProgress  bool
+		expRetrySubstr string
+	}{
+		{
+			// The only reason that means the conversion can never succeed.
+			name:        "unsupported conversion intent is terminal",
+			err:         conversionAPIError(400, "DISK_TYPE_CONVERSION_UNSUPPORTED", "unsupported"),
+			expTerminal: true,
+		},
+		{
+			// Shares its status with the terminal case, so the reason decides.
+			name:           "a busy disk means a conversion is already running",
+			err:            conversionAPIError(400, "resourceNotReady", "disk is busy"),
+			expInProgress:  true,
+			expRetrySubstr: "not ready",
+		},
+		{
+			name:           "a rate limit is explained and retried",
+			err:            conversionAPIError(429, "rateLimitExceeded", "too many requests"),
+			expRetrySubstr: "limit on disk conversion calls",
+		},
+		{
+			name:           "a snapshot still holding the disk is explained and retried",
+			err:            conversionAPIError(400, "RESOURCE_IN_USE_BY_ANOTHER_RESOURCE", "in use"),
+			expRetrySubstr: "a snapshot of the disk is still in use",
+		},
+		{
+			// Returned when more than the allowed number of disk conversions run
+			// at once in a project and region. Observed as the ErrorInfo reason
+			// alongside an outer rateLimitExceeded.
+			name:           "the concurrent operations limit is explained and retried",
+			err:            conversionAPIError(429, "CONCURRENT_OPERATIONS_QUOTA_EXCEEDED", "quota on concurrent operations exceeded"),
+			expRetrySubstr: "limit on concurrent operations",
+		},
+		{
+			name:           "a stockout is explained and retried",
+			err:            conversionAPIError(503, "ZONE_RESOURCE_POOL_EXHAUSTED", "no capacity"),
+			expRetrySubstr: "capacity",
+		},
+		{
+			// The 412 seen when the project is not allowed to convert disks. It
+			// has no specific explanation but must not be treated as terminal,
+			// or the volume would give up on a conversion that can still happen.
+			name: "an unrecognised reason is retried without an explanation",
+			err:  conversionAPIError(412, "conditionNotMet", "feature is not available for this project"),
+		},
+		{
+			name: "an error that is not from the API is retried",
+			err:  fmt.Errorf("connection refused"),
+		},
+		{
+			name: "no error is not a failure",
+			err:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUnsupportedConversionIntentError(tc.err); got != tc.expTerminal {
+				t.Errorf("isUnsupportedConversionIntentError = %v; want %v", got, tc.expTerminal)
+			}
+			if got := isConversionInProgressError(tc.err); got != tc.expInProgress {
+				t.Errorf("isConversionInProgressError = %v; want %v", got, tc.expInProgress)
+			}
+			got := conversionRetryReason(tc.err)
+			if tc.expRetrySubstr == "" {
+				if got != "" {
+					t.Errorf("conversionRetryReason = %q; want \"\"", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.expRetrySubstr) {
+				t.Errorf("Got retry reason %q; want it to mention %q", got, tc.expRetrySubstr)
+			}
+		})
+	}
+}
+
+func TestConversionErrorReasonPrefersErrorInfo(t *testing.T) {
+	// The top level error item carries only a generic reason, so the machine
+	// readable one in the details has to win.
+	err := conversionAPIError(400, "DISK_TYPE_CONVERSION_UNSUPPORTED", "unsupported")
+	if got := conversionErrorReason(err); got != "DISK_TYPE_CONVERSION_UNSUPPORTED" {
+		t.Errorf("Got reason %q; want the ErrorInfo reason", got)
+	}
+
+	// With no details the top level reason is all there is.
+	onlyTopLevel := &googleapi.Error{
+		Code:   400,
+		Errors: []googleapi.ErrorItem{{Reason: "badRequest", Message: "bad"}},
+	}
+	if got := conversionErrorReason(onlyTopLevel); got != "badRequest" {
+		t.Errorf("Got reason %q; want badRequest", got)
+	}
+
+	if got := conversionErrorReason(fmt.Errorf("not an api error")); got != "" {
+		t.Errorf("Got reason %q; want \"\" for a non API error", got)
+	}
+}
+
+func TestControllerExpandVolume_ConversionGuard(t *testing.T) {
+	className := "vac-hyperdisk"
+	requestsHyperdisk := &storagev1beta1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{Name: className},
+		DriverName: "pd.csi.storage.gke.io",
+		Parameters: map[string]string{"type": "hyperdisk-balanced"},
+	}
+
+	testCases := []struct {
+		name               string
+		enablePdConversion bool
+		annotations        map[string]string
+		// pvc is the PVC the PV's claimRef points at, or nil if the PV should
+		// have no claimRef, as if the PVC or its VAC reference were removed.
+		pvc        *corev1.PersistentVolumeClaim
+		vac        *storagev1beta1.VolumeAttributesClass
+		expErrCode codes.Code
+	}{
+		{
+			name:               "expands when no conversion is recorded",
+			enablePdConversion: true,
+			expErrCode:         codes.OK,
+		},
+		{
+			// Resizing mid conversion races the copy the conversion is making.
+			name:               "blocks expand while a conversion is queued and still requested",
+			enablePdConversion: true,
+			annotations:        map[string]string{constants.DiskTypeConversionOperationKey: constants.ConversionStatePending},
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pvc", Namespace: "default"},
+				Spec:       corev1.PersistentVolumeClaimSpec{VolumeAttributesClassName: &className},
+			},
+			vac:        requestsHyperdisk,
+			expErrCode: codes.Unavailable,
+		},
+		{
+			// The VAC was deleted (or the PVC no longer references one) while
+			// the conversion was still queued, and the volume never detached
+			// to run startQueuedConversionOnDetach. Without this reconciling
+			// here too, the volume would stay blocked forever.
+			name:               "unblocks expand when a queued conversion's VolumeAttributesClass was removed",
+			enablePdConversion: true,
+			annotations:        map[string]string{constants.DiskTypeConversionOperationKey: constants.ConversionStatePending},
+			expErrCode:         codes.OK,
+		},
+		{
+			// The VAC still exists but no longer asks for a different type,
+			// e.g. it was edited back to the disk's current type.
+			name:               "unblocks expand when a queued conversion's VolumeAttributesClass no longer requests a different type",
+			enablePdConversion: true,
+			annotations:        map[string]string{constants.DiskTypeConversionOperationKey: constants.ConversionStatePending},
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pvc", Namespace: "default"},
+				Spec:       corev1.PersistentVolumeClaimSpec{VolumeAttributesClassName: &className},
+			},
+			vac: &storagev1beta1.VolumeAttributesClass{
+				ObjectMeta: metav1.ObjectMeta{Name: className},
+				DriverName: "pd.csi.storage.gke.io",
+				Parameters: map[string]string{"type": "pd-balanced"},
+			},
+			expErrCode: codes.OK,
+		},
+		{
+			name:               "blocks expand while a conversion is running",
+			enablePdConversion: true,
+			annotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: "https://www.googleapis.com/compute/alpha/projects/p/zones/z/operations/op-1",
+				constants.DiskTypeConvertedFromKey:       "pd-balanced",
+			},
+			expErrCode: codes.Unavailable,
+		},
+		{
+			// The conversion finished unobserved, so the volume is usable again.
+			name:               "expands once the conversion has finished",
+			enablePdConversion: true,
+			annotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: "https://www.googleapis.com/compute/alpha/projects/p/zones/z/operations/op-1",
+				constants.DiskTypeConvertedFromKey:       "pd-standard",
+			},
+			expErrCode: codes.OK,
+		},
+		{
+			name:               "does not consult the PV when conversion is disabled",
+			enablePdConversion: false,
+			annotations:        map[string]string{constants.DiskTypeConversionOperationKey: constants.ConversionStatePending},
+			expErrCode:         codes.OK,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldGetKubeClient := k8sclient.GetClient
+			defer func() { k8sclient.GetClient = oldGetKubeClient }()
+
+			pv := &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: tc.annotations},
+			}
+			objects := []runtime.Object{pv}
+			if tc.pvc != nil {
+				pv.Spec.ClaimRef = &corev1.ObjectReference{Name: tc.pvc.Name, Namespace: tc.pvc.Namespace}
+				objects = append(objects, tc.pvc)
+			}
+			if tc.vac != nil {
+				objects = append(objects, tc.vac)
+			}
+			kubeClient := fake.NewSimpleClientset(objects...)
+			k8sclient.GetClient = func() (kubernetes.Interface, error) { return kubeClient, nil }
+
+			disk := &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 20}
+			fcp, err := gce.CreateFakeCloudProvider(project, zone, []*gce.CloudDisk{gce.CloudDiskFromV1(disk)})
+			if err != nil {
+				t.Fatalf("Failed to create fake cloud provider: %v", err)
+			}
+			gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{EnablePdConversion: tc.enablePdConversion})
+			defer gceDriver.cs.WaitForConversionWorkers()
+
+			_, err = gceDriver.cs.ControllerExpandVolume(context.Background(), &csi.ControllerExpandVolumeRequest{
+				VolumeId:      testVolumeID,
+				CapacityRange: &csi.CapacityRange{RequiredBytes: common.GbToBytes(30)},
+			})
+
+			if gotCode := status.Code(err); gotCode != tc.expErrCode {
+				t.Errorf("Expected error code %v, got %v (err: %v)", tc.expErrCode, gotCode, err)
+			}
+		})
+	}
+}
+
+func TestCreateSnapshot_ConversionGuard(t *testing.T) {
+	testCases := []struct {
+		name               string
+		enablePdConversion bool
+		annotations        map[string]string
+		expErrCode         codes.Code
+	}{
+		{
+			name:               "creates a snapshot when no conversion is recorded",
+			enablePdConversion: true,
+			expErrCode:         codes.OK,
+		},
+		{
+			// The conversion snapshots the disk behind the scenes, so a
+			// concurrent snapshot request races it for the same resource.
+			name:               "blocks snapshot while a conversion is running",
+			enablePdConversion: true,
+			annotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: "https://www.googleapis.com/compute/alpha/projects/p/zones/z/operations/op-1",
+				constants.DiskTypeConvertedFromKey:       "pd-balanced",
+			},
+			expErrCode: codes.Unavailable,
+		},
+		{
+			name:               "does not consult the PV when conversion is disabled",
+			enablePdConversion: false,
+			annotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: "https://www.googleapis.com/compute/alpha/projects/p/zones/z/operations/op-1",
+				constants.DiskTypeConvertedFromKey:       "pd-balanced",
+			},
+			expErrCode: codes.OK,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldGetKubeClient := k8sclient.GetClient
+			defer func() { k8sclient.GetClient = oldGetKubeClient }()
+
+			pv := &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: tc.annotations},
+			}
+			kubeClient := fake.NewSimpleClientset(pv)
+			k8sclient.GetClient = func() (kubernetes.Interface, error) { return kubeClient, nil }
+
+			disk := &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 20}
+			fcp, err := gce.CreateFakeCloudProvider(project, zone, []*gce.CloudDisk{gce.CloudDiskFromV1(disk)})
+			if err != nil {
+				t.Fatalf("Failed to create fake cloud provider: %v", err)
+			}
+			gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{EnablePdConversion: tc.enablePdConversion})
+			defer gceDriver.cs.WaitForConversionWorkers()
+
+			_, err = gceDriver.cs.CreateSnapshot(context.Background(), &csi.CreateSnapshotRequest{
+				Name:           name,
+				SourceVolumeId: testVolumeID,
+			})
+
+			if gotCode := status.Code(err); gotCode != tc.expErrCode {
+				t.Errorf("Expected error code %v, got %v (err: %v)", tc.expErrCode, gotCode, err)
+			}
+		})
+	}
+}
+
+func TestStartQueuedConversionOnDetach(t *testing.T) {
+	testCases := []struct {
+		name               string
+		enablePdConversion bool
+		annotations        map[string]string
+		// expStarted is whether the queued conversion should be acted on.
+		expStarted bool
+	}{
+		{
+			name:               "starts a queued conversion",
+			enablePdConversion: true,
+			annotations:        map[string]string{constants.DiskTypeConversionOperationKey: constants.ConversionStatePending},
+			expStarted:         true,
+		},
+		{
+			name:               "does nothing when no conversion is queued",
+			enablePdConversion: true,
+			annotations:        nil,
+		},
+		{
+			// A self link means a conversion is already running, so starting
+			// another would convert the disk twice.
+			name:               "does not restart a conversion that is already running",
+			enablePdConversion: true,
+			annotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: "https://www.googleapis.com/compute/alpha/projects/p/zones/z/operations/op-1",
+			},
+		},
+		{
+			name:               "does nothing when conversion is disabled",
+			enablePdConversion: false,
+			annotations:        map[string]string{constants.DiskTypeConversionOperationKey: constants.ConversionStatePending},
+		},
+	}
+
+	className := "vac-hyperdisk"
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldGetKubeClient := k8sclient.GetClient
+			defer func() { k8sclient.GetClient = oldGetKubeClient }()
+			kubeClient := fake.NewSimpleClientset(
+				&corev1.PersistentVolume{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: tc.annotations},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{Name: "test-pvc", Namespace: "default"},
+					},
+				},
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-pvc", Namespace: "default"},
+					Spec:       corev1.PersistentVolumeClaimSpec{VolumeAttributesClassName: &className},
+				},
+				&storagev1beta1.VolumeAttributesClass{
+					ObjectMeta: metav1.ObjectMeta{Name: className},
+					DriverName: "pd.csi.storage.gke.io",
+					Parameters: map[string]string{"type": "hyperdisk-balanced"},
+				},
+			)
+			k8sclient.GetClient = func() (kubernetes.Interface, error) { return kubeClient, nil }
+
+			disk := &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 200}
+			fcp, err := gce.CreateFakeCloudProvider(project, zone, []*gce.CloudDisk{gce.CloudDiskFromV1(disk)})
+			if err != nil {
+				t.Fatalf("Failed to create fake cloud provider: %v", err)
+			}
+			gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{EnablePdConversion: tc.enablePdConversion})
+			defer gceDriver.cs.WaitForConversionWorkers()
+			_, volKey, err := common.VolumeIDToKey(testVolumeID)
+			if err != nil {
+				t.Fatalf("Failed to convert volume id to key: %v", err)
+			}
+
+			gceDriver.cs.startQueuedConversionOnDetach(context.Background(), project, volKey)
+			// The conversion runs in the background, so wait for it rather than
+			// guessing how long it needs.
+			gceDriver.cs.WaitForConversionWorkers()
+			defer gceDriver.cs.stopConversionWatcher(volKey)
+
+			if started := fcp.ConversionCalled(); started != tc.expStarted {
+				t.Errorf("Conversion started = %v; want %v", started, tc.expStarted)
+			}
+		})
+	}
+}
+
+// waitForCondition reports whether cond became true within timeout.
+func waitForCondition(timeout time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
+}
+
+func TestMarkConversionPendingKeepsRunningOperation(t *testing.T) {
+	const operation = "https://www.googleapis.com/compute/alpha/projects/p/zones/z/operations/op-running"
+
+	testCases := []struct {
+		name string
+		// existing is the conversion annotation the volume starts with.
+		existing string
+		expected string
+	}{
+		{
+			// Losing the operation would leave nothing to track or poll, and the
+			// completion checks would treat the finished conversion as one that
+			// never ran.
+			name:     "a running conversion keeps its operation",
+			existing: operation,
+			expected: operation,
+		},
+		{
+			name:     "a queued conversion stays queued",
+			existing: constants.ConversionStatePending,
+			expected: constants.ConversionStatePending,
+		},
+		{
+			name:     "a volume with no conversion is marked pending",
+			existing: "",
+			expected: constants.ConversionStatePending,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldGetKubeClient := k8sclient.GetClient
+			defer func() { k8sclient.GetClient = oldGetKubeClient }()
+			annotations := map[string]string{}
+			if tc.existing != "" {
+				annotations[constants.DiskTypeConversionOperationKey] = tc.existing
+			}
+			kubeClient := fake.NewSimpleClientset(&corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: annotations},
+			})
+			k8sclient.GetClient = func() (kubernetes.Interface, error) { return kubeClient, nil }
+
+			fcp, err := gce.CreateFakeCloudProvider(project, zone, []*gce.CloudDisk{createZonalCloudDisk(name)})
+			if err != nil {
+				t.Fatalf("Failed to create fake cloud provider: %v", err)
+			}
+			gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{EnablePdConversion: true})
+			defer gceDriver.cs.WaitForConversionWorkers()
+			_, volKey, err := common.VolumeIDToKey(testVolumeID)
+			if err != nil {
+				t.Fatalf("Failed to convert volume id to key: %v", err)
+			}
+
+			gceDriver.cs.markConversionPending(context.Background(), volKey, testVolumeID)
+
+			pv, err := kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Failed to get PersistentVolume: %v", err)
+			}
+			if got := pv.Annotations[constants.DiskTypeConversionOperationKey]; got != tc.expected {
+				t.Errorf("Got conversion annotation %q; want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestConversionInProgressKeepsOperation(t *testing.T) {
+	// A retry that races a conversion the driver already started gets
+	// resourceNotReady back. The operation already recorded must survive it.
+	const operation = "https://www.googleapis.com/compute/alpha/projects/p/zones/z/operations/op-running"
+
+	oldGetKubeClient := k8sclient.GetClient
+	defer func() { k8sclient.GetClient = oldGetKubeClient }()
+	kubeClient := fake.NewSimpleClientset(&corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: operation,
+				constants.DiskTypeConvertedFromKey:       "pd-balanced",
+			},
+		},
+	})
+	k8sclient.GetClient = func() (kubernetes.Interface, error) { return kubeClient, nil }
+
+	disk := &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 200}
+	fcp, err := gce.CreateFakeCloudProvider(project, zone, []*gce.CloudDisk{gce.CloudDiskFromV1(disk)})
+	if err != nil {
+		t.Fatalf("Failed to create fake cloud provider: %v", err)
+	}
+	fcp.ConversionTestParams.TypeConversionErr = conversionAPIError(400, "resourceNotReady", "disk is busy")
+
+	gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{EnablePdConversion: true})
+	defer gceDriver.cs.WaitForConversionWorkers()
+
+	_, err = gceDriver.cs.ControllerModifyVolume(context.Background(), &csi.ControllerModifyVolumeRequest{
+		VolumeId:          testVolumeID,
+		MutableParameters: map[string]string{"type": "hyperdisk-balanced"},
+	})
+	if gotCode := status.Code(err); gotCode != codes.Unavailable {
+		t.Errorf("Expected Unavailable, got %v (err: %v)", gotCode, err)
+	}
+
+	pv, getErr := kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), name, metav1.GetOptions{})
+	if getErr != nil {
+		t.Fatalf("Failed to get PersistentVolume: %v", getErr)
+	}
+	if got := pv.Annotations[constants.DiskTypeConversionOperationKey]; got != operation {
+		t.Errorf("Got conversion annotation %q; want the running operation %q", got, operation)
+	}
+}
+
+func TestConversionClassificationIsByReasonNotStatus(t *testing.T) {
+	// Every case here is an HTTP 400 or 403, so classifying on the status alone
+	// cannot tell them apart. Only the first can never succeed.
+	testCases := []struct {
+		name        string
+		err         error
+		expTerminal bool
+		reason      string
+	}{
+		{
+			name:        "a rejected parameter value is terminal",
+			err:         conversionAPIError(400, "badRequest", "Requested provisioned IOPS cannot be smaller than 3000."),
+			expTerminal: true,
+			reason:      "retrying sends the same rejected value again",
+		},
+		{
+			name:        "a conversion already running is not terminal",
+			err:         conversionAPIError(400, "resourceNotReady", "disk is busy"),
+			expTerminal: false,
+			reason:      "the disk is being rebuilt and the volume must stay blocked",
+		},
+		{
+			name:        "a snapshot still holding the disk is not terminal",
+			err:         conversionAPIError(400, "RESOURCE_IN_USE_BY_ANOTHER_RESOURCE", "in use"),
+			expTerminal: false,
+			reason:      "the user can delete the snapshot and the conversion then proceeds",
+		},
+		{
+			name:        "a quota denial is not terminal",
+			err:         conversionAPIError(403, "quotaExceeded", "Quota exceeded"),
+			expTerminal: false,
+			reason:      "the PRD requires retrying until the limit clears",
+		},
+		{
+			name:        "a rate limit is not terminal",
+			err:         conversionAPIError(403, "rateLimitExceeded", "too many requests"),
+			expTerminal: false,
+			reason:      "the PRD requires retrying until the limit clears",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUnsupportedConversionIntentError(tc.err); got != tc.expTerminal {
+				t.Errorf("isUnsupportedConversionIntentError = %v; want %v because %s", got, tc.expTerminal, tc.reason)
+			}
+		})
+	}
+}
+
+func TestInProgressIsCheckedBeforeTerminal(t *testing.T) {
+	// resourceNotReady shares its status with the terminal cases, so if the
+	// terminal check ran first the volume would be released while GCE was still
+	// rebuilding its disk.
+	oldGetKubeClient := k8sclient.GetClient
+	defer func() { k8sclient.GetClient = oldGetKubeClient }()
+	kubeClient := fake.NewSimpleClientset(&corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	})
+	k8sclient.GetClient = func() (kubernetes.Interface, error) { return kubeClient, nil }
+
+	disk := &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 200}
+	fcp, err := gce.CreateFakeCloudProvider(project, zone, []*gce.CloudDisk{gce.CloudDiskFromV1(disk)})
+	if err != nil {
+		t.Fatalf("Failed to create fake cloud provider: %v", err)
+	}
+	fcp.ConversionTestParams.TypeConversionErr = conversionAPIError(400, "resourceNotReady", "disk is busy")
+
+	gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{EnablePdConversion: true})
+	defer gceDriver.cs.WaitForConversionWorkers()
+	_, err = gceDriver.cs.ControllerModifyVolume(context.Background(), &csi.ControllerModifyVolumeRequest{
+		VolumeId:          testVolumeID,
+		MutableParameters: map[string]string{"type": "hyperdisk-balanced"},
+	})
+
+	// Unavailable means "still going, ask again"; InvalidArgument would mean the
+	// modification had been abandoned.
+	if gotCode := status.Code(err); gotCode != codes.Unavailable {
+		t.Errorf("Expected Unavailable for a conversion already running, got %v (err: %v)", gotCode, err)
+	}
+
+	pv, getErr := kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), name, metav1.GetOptions{})
+	if getErr != nil {
+		t.Fatalf("Failed to get PersistentVolume: %v", getErr)
+	}
+	// The volume has to stay blocked while the disk is being rebuilt.
+	if got := pv.Annotations[constants.DiskTypeConversionOperationKey]; got == "" {
+		t.Errorf("Volume was left unblocked while a conversion was running")
+	}
+}
+
+// waitForNoConversionWatchers blocks until no conversion watcher is running, so
+// that a test does not restore package globals while a watcher is still using
+// them. A watcher deregisters only after it has finished, including the event it
+// emits after clearing the annotation.
+func waitForNoConversionWatchers(cs *GCEControllerServer) {
+	cs.WaitForConversionWorkers()
+}
+
+func TestConversionFailureIsReportedOnRetry(t *testing.T) {
+	// A conversion that ran and failed for a retriable reason is reported when
+	// the next conversion starts, so that the reason reaches the claim rather
+	// than being visible only as an event.
+	const lastError = "operation op-1 failed: ZONE_RESOURCE_POOL_EXHAUSTED: no capacity"
+
+	oldGetKubeClient := k8sclient.GetClient
+	defer func() { k8sclient.GetClient = oldGetKubeClient }()
+	kubeClient := fake.NewSimpleClientset(&corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: constants.ConversionStatePending,
+				constants.DiskTypeConversionLastErrorKey: lastError,
+			},
+		},
+	})
+	k8sclient.GetClient = func() (kubernetes.Interface, error) { return kubeClient, nil }
+
+	disk := &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "pd-balanced", SizeGb: 200}
+	fcp, err := gce.CreateFakeCloudProvider(project, zone, []*gce.CloudDisk{gce.CloudDiskFromV1(disk)})
+	if err != nil {
+		t.Fatalf("Failed to create fake cloud provider: %v", err)
+	}
+
+	gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{EnablePdConversion: true})
+	defer gceDriver.cs.WaitForConversionWorkers()
+
+	_, err = gceDriver.cs.ControllerModifyVolume(context.Background(), &csi.ControllerModifyVolumeRequest{
+		VolumeId:          testVolumeID,
+		MutableParameters: map[string]string{"type": "hyperdisk-balanced"},
+	})
+	if gotCode := status.Code(err); gotCode != codes.Unavailable {
+		t.Fatalf("Expected Unavailable, got %v (err: %v)", gotCode, err)
+	}
+	if !strings.Contains(err.Error(), lastError) {
+		t.Errorf("Error %q does not report the failure of the previous conversion", err)
+	}
+
+	pv, getErr := kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), name, metav1.GetOptions{})
+	if getErr != nil {
+		t.Fatalf("Failed to get PersistentVolume: %v", getErr)
+	}
+	if _, ok := pv.Annotations[constants.DiskTypeConversionLastErrorKey]; ok {
+		t.Errorf("The failure was reported but not cleared, so it will be reported again")
+	}
+	_, volKey, keyErr := common.VolumeIDToKey(testVolumeID)
+	if keyErr != nil {
+		t.Fatalf("Failed to convert volume id to key: %v", keyErr)
+	}
+	gceDriver.cs.stopConversionWatcher(volKey)
+}
+
+func TestStaleWatcherDoesNotClearNewerConversion(t *testing.T) {
+	// A conversion that has been superseded must not write its outcome: doing so
+	// would release a volume whose newer conversion is still running.
+	const oldOp = "https://www.googleapis.com/compute/alpha/projects/p/zones/z/operations/op-old"
+	const newOp = "https://www.googleapis.com/compute/alpha/projects/p/zones/z/operations/op-new"
+
+	oldGetKubeClient := k8sclient.GetClient
+	defer func() { k8sclient.GetClient = oldGetKubeClient }()
+	kubeClient := fake.NewSimpleClientset(&corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				constants.DiskTypeConversionOperationKey: newOp,
+				constants.DiskTypeConvertedFromKey:       "pd-balanced",
+			},
+		},
+	})
+	k8sclient.GetClient = func() (kubernetes.Interface, error) { return kubeClient, nil }
+
+	gceDriver := initGCEDriver(t, nil, &GCEControllerServerArgs{EnablePdConversion: true})
+	_, volKey, err := common.VolumeIDToKey(testVolumeID)
+	if err != nil {
+		t.Fatalf("Failed to convert volume id to key: %v", err)
+	}
+
+	// The superseded conversion reports its outcome and must be ignored.
+	if err := gceDriver.cs.recordCompletedConversion(context.Background(), volKey, oldOp, "hyperdisk-balanced"); err != nil {
+		t.Fatalf("recordCompletedConversion returned an error: %v", err)
+	}
+
+	pv, getErr := kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), name, metav1.GetOptions{})
+	if getErr != nil {
+		t.Fatalf("Failed to get PersistentVolume: %v", getErr)
+	}
+	if got := pv.Annotations[constants.DiskTypeConversionOperationKey]; got != newOp {
+		t.Errorf("The running conversion was cleared by a superseded one: got %q; want %q", got, newOp)
+	}
+	if _, ok := pv.Annotations[constants.DiskTypeConvertedToKey]; ok {
+		t.Errorf("A superseded conversion recorded converted-to")
+	}
+
+	// The conversion the volume is actually on still records normally.
+	if err := gceDriver.cs.recordCompletedConversion(context.Background(), volKey, newOp, "hyperdisk-balanced"); err != nil {
+		t.Fatalf("recordCompletedConversion returned an error: %v", err)
+	}
+	pv, getErr = kubeClient.CoreV1().PersistentVolumes().Get(context.Background(), name, metav1.GetOptions{})
+	if getErr != nil {
+		t.Fatalf("Failed to get PersistentVolume: %v", getErr)
+	}
+	if _, ok := pv.Annotations[constants.DiskTypeConversionOperationKey]; ok {
+		t.Errorf("The current conversion did not clear the operation annotation")
+	}
+	if got := pv.Annotations[constants.DiskTypeConvertedToKey]; got != "hyperdisk-balanced" {
+		t.Errorf("Got converted-to %q; want hyperdisk-balanced", got)
+	}
+	// The PRD requires both annotations after a conversion, so the record of
+	// what the disk was converted from has to survive.
+	if got := pv.Annotations[constants.DiskTypeConvertedFromKey]; got != "pd-balanced" {
+		t.Errorf("Got converted-from %q; want pd-balanced", got)
+	}
+}
+
+func TestVACChangedDuringConversionStartsAnother(t *testing.T) {
+	// The class can be changed while a conversion is running, so what it asks
+	// for when the conversion ends decides whether another one follows.
+	className := "vac-hd-extreme"
+	testCases := []struct {
+		name string
+		// vacType is what the class asks for once the first conversion ends.
+		vacType string
+		// diskTypeAfter is what the disk is after the first conversion.
+		diskTypeAfter  string
+		expectSecond   bool
+		expectedTarget string
+	}{
+		{
+			name:           "a class asking for a different type starts another conversion",
+			vacType:        "hyperdisk-extreme",
+			diskTypeAfter:  "hyperdisk-balanced",
+			expectSecond:   true,
+			expectedTarget: "hyperdisk-extreme",
+		},
+		{
+			name:          "a class matching the disk starts nothing",
+			vacType:       "hyperdisk-balanced",
+			diskTypeAfter: "hyperdisk-balanced",
+			expectSecond:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldGetKubeClient := k8sclient.GetClient
+			defer func() { k8sclient.GetClient = oldGetKubeClient }()
+			kubeClient := fake.NewSimpleClientset(
+				&corev1.PersistentVolume{
+					ObjectMeta: metav1.ObjectMeta{Name: name},
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{Name: "test-pvc", Namespace: "default"},
+					},
+				},
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-pvc", Namespace: "default"},
+					Spec:       corev1.PersistentVolumeClaimSpec{VolumeAttributesClassName: &className},
+				},
+				&storagev1beta1.VolumeAttributesClass{
+					ObjectMeta: metav1.ObjectMeta{Name: className},
+					DriverName: "pd.csi.storage.gke.io",
+					Parameters: map[string]string{"type": tc.vacType},
+				},
+			)
+			k8sclient.GetClient = func() (kubernetes.Interface, error) { return kubeClient, nil }
+
+			disk := &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: tc.diskTypeAfter, SizeGb: 200}
+			fcp, err := gce.CreateFakeCloudProvider(project, zone, []*gce.CloudDisk{gce.CloudDiskFromV1(disk)})
+			if err != nil {
+				t.Fatalf("Failed to create fake cloud provider: %v", err)
+			}
+
+			gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{EnablePdConversion: true})
+			defer gceDriver.cs.WaitForConversionWorkers()
+			_, volKey, err := common.VolumeIDToKey(testVolumeID)
+			if err != nil {
+				t.Fatalf("Failed to convert volume id to key: %v", err)
+			}
+
+			if err := gceDriver.cs.reconcileLatestVACAfterConversion(context.Background(), project, volKey, gce.CloudDiskFromV1(disk)); err != nil {
+				t.Fatalf("reconcileLatestVACAfterConversion returned an error: %v", err)
+			}
+
+			if got := fcp.ConversionTestParams.TypeConversionCalled; got != tc.expectSecond {
+				t.Errorf("Second conversion started=%v; want %v", got, tc.expectSecond)
+			}
+			if tc.expectSecond {
+				if got := fcp.ConversionTestParams.TypeConversionTargetType; got != tc.expectedTarget {
+					t.Errorf("Second conversion targeted %q; want %q", got, tc.expectedTarget)
+				}
+			}
+			gceDriver.cs.stopConversionWatcher(volKey)
+		})
+	}
+}
+
+func TestReconcileAfterConversionSurvivesWatcherCancellation(t *testing.T) {
+	// Recording a completion stops the watcher, which cancels the context the
+	// poll was using. The work that follows has to run on a context that
+	// outlives it, or it fails before it reads the class.
+	className := "vac-hd-extreme-reconcile"
+	oldGetKubeClient := k8sclient.GetClient
+	defer func() { k8sclient.GetClient = oldGetKubeClient }()
+	kubeClient := fake.NewSimpleClientset(
+		&corev1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: corev1.PersistentVolumeSpec{
+				ClaimRef: &corev1.ObjectReference{Name: "test-pvc", Namespace: "default"},
+			},
+		},
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pvc", Namespace: "default"},
+			Spec:       corev1.PersistentVolumeClaimSpec{VolumeAttributesClassName: &className},
+		},
+		&storagev1beta1.VolumeAttributesClass{
+			ObjectMeta: metav1.ObjectMeta{Name: className},
+			DriverName: "pd.csi.storage.gke.io",
+			Parameters: map[string]string{"type": "hyperdisk-extreme"},
+		},
+	)
+	k8sclient.GetClient = func() (kubernetes.Interface, error) { return kubeClient, nil }
+
+	disk := &compute.Disk{Name: name, Zone: zone, SelfLink: testVolumeID, Type: "hyperdisk-balanced", SizeGb: 200}
+	fcp, err := gce.CreateFakeCloudProvider(project, zone, []*gce.CloudDisk{gce.CloudDiskFromV1(disk)})
+	if err != nil {
+		t.Fatalf("Failed to create fake cloud provider: %v", err)
+	}
+
+	gceDriver := initGCEDriverWithCloudProvider(t, fcp, &GCEControllerServerArgs{EnablePdConversion: true})
+	defer gceDriver.cs.WaitForConversionWorkers()
+	_, volKey, err := common.VolumeIDToKey(testVolumeID)
+	if err != nil {
+		t.Fatalf("Failed to convert volume id to key: %v", err)
+	}
+
+	// A context in the state the watcher's own context is left in.
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := gceDriver.cs.reconcileLatestVACAfterConversion(cancelledCtx, project, volKey, gce.CloudDiskFromV1(disk)); err == nil {
+		t.Log("reconcile on a cancelled context returned no error")
+	}
+	if fcp.ConversionTestParams.TypeConversionCalled {
+		t.Errorf("A cancelled context started a conversion")
+	}
+
+	// The same call on a live context must reach the class and act on it.
+	if err := gceDriver.cs.reconcileLatestVACAfterConversion(context.Background(), project, volKey, gce.CloudDiskFromV1(disk)); err != nil {
+		t.Fatalf("reconcile on a live context failed: %v", err)
+	}
+	if !fcp.ConversionTestParams.TypeConversionCalled {
+		t.Errorf("The class asked for hyperdisk-extreme but no conversion was started")
+	}
+	if got := fcp.ConversionTestParams.TypeConversionTargetType; got != "hyperdisk-extreme" {
+		t.Errorf("Conversion targeted %q; want hyperdisk-extreme", got)
+	}
+	gceDriver.cs.stopConversionWatcher(volKey)
 }

--- a/pkg/k8sclient/client.go
+++ b/pkg/k8sclient/client.go
@@ -421,3 +421,47 @@ func isRetriableAPIError(err error) bool {
 		return true
 	}
 }
+
+// ClearVolumeAttributesClassForPV removes the VolumeAttributesClass from the
+// claim a volume is bound to, reporting whether it was removed.
+//
+// Kubernetes only allows the class to be cleared while the claim has never had
+// one applied, which is the state a claim is left in by a class it could not
+// act on. A claim that has had a class applied keeps it, and a cluster before
+// 1.34 refuses the change outright; neither is an error here, because the
+// caller is withdrawing a class the volume could not use rather than relying on
+// it being gone.
+func ClearVolumeAttributesClassForPV(ctx context.Context, pvName string) (bool, error) {
+	kubeClient, err := GetClient()
+	if err != nil {
+		return false, fmt.Errorf("failed to get kubernetes client: %w", err)
+	}
+
+	pv, err := GetPersistentVolumeWithRetry(ctx, pvName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if pv.Spec.ClaimRef == nil || pv.Spec.ClaimRef.Name == "" {
+		return false, nil
+	}
+
+	namespace, name := pv.Spec.ClaimRef.Namespace, pv.Spec.ClaimRef.Name
+	patch := []byte(`{"spec":{"volumeAttributesClassName":null}}`)
+	_, err = kubeClient.CoreV1().PersistentVolumeClaims(namespace).Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		if apierrors.IsInvalid(err) || apierrors.IsForbidden(err) {
+			klog.V(4).Infof("The VolumeAttributesClass of PersistentVolumeClaim %s/%s was left in place: %v", namespace, name, err)
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to clear the VolumeAttributesClass of PersistentVolumeClaim %s/%s: %w", namespace, name, err)
+	}
+
+	klog.V(4).Infof("Cleared the VolumeAttributesClass of PersistentVolumeClaim %s/%s", namespace, name)
+	return true, nil
+}

--- a/pkg/k8sclient/client.go
+++ b/pkg/k8sclient/client.go
@@ -2,17 +2,24 @@ package k8sclient
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 )
+
+// EventComponent identifies the GCE PD CSI driver as the source of the events
+// it emits.
+const EventComponent = "pdcsi"
 
 var (
 	backoff = wait.Backoff{
@@ -106,9 +113,17 @@ func getStorageClassWithRetry(ctx context.Context, kubeClient kubernetes.Interfa
 
 func getPersistentVolumeWithRetry(ctx context.Context, kubeClient kubernetes.Interface, pvName string) (*v1.PersistentVolume, error) {
 	var pvObj *v1.PersistentVolume
+	var lastErr error
 	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(_ context.Context) (bool, error) {
 		pv, err := kubeClient.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
 		if err != nil {
+			lastErr = err
+			// A PersistentVolume that does not exist will not start existing
+			// during the backoff, and callers need that answer promptly to tell
+			// it apart from an API server they could not reach.
+			if !isRetriableAPIError(err) {
+				return false, err
+			}
 			klog.Warningf("Error getting PersistentVolume %s: %v, retrying...\n", pvName, err)
 			return false, nil
 		}
@@ -118,9 +133,15 @@ func getPersistentVolumeWithRetry(ctx context.Context, kubeClient kubernetes.Int
 	})
 
 	if err != nil {
-		klog.Errorf("Failed to get PersistentVolume %s after retries: %v\n", pvName, err)
+		// On timeout the backoff reports only that it gave up, so surface the
+		// error that actually caused the retries.
+		if lastErr != nil {
+			err = lastErr
+		}
+		klog.Errorf("Failed to get PersistentVolume %s: %v\n", pvName, err)
+		return nil, err
 	}
-	return pvObj, err
+	return pvObj, nil
 }
 
 func listPodsInNamespace(ctx context.Context, kubeClient kubernetes.Interface, namespace string) (*v1.PodList, error) {
@@ -140,4 +161,263 @@ func listPodsInNamespace(ctx context.Context, kubeClient kubernetes.Interface, n
 		klog.Errorf("Failed to list pods in namespace %s after retries: %v\n", namespace, err)
 	}
 	return podList, err
+}
+
+// GetVolumeAttributesClassForPV returns the parameters of the
+// VolumeAttributesClass currently named by the claim a PersistentVolume is bound
+// to, and whether the claim names one at all.
+//
+// This reads the class the user asks for now rather than one recorded earlier,
+// so that work the driver picks up later acts on the current intent. A user who
+// clears the class on their claim cancels that work, which is the behaviour a
+// recorded copy of the parameters could not offer.
+//
+// A volume with no PersistentVolume, no claim, or no class reports no class
+// rather than failing, since none of those are errors: they all mean there is
+// nothing the user is currently asking for.
+func GetVolumeAttributesClassForPV(ctx context.Context, pvName string) (map[string]string, bool, error) {
+	kubeClient, err := GetClient()
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get kubernetes client: %w", err)
+	}
+
+	pv, err := GetPersistentVolumeWithRetry(ctx, pvName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	if pv.Spec.ClaimRef == nil || pv.Spec.ClaimRef.Name == "" {
+		return nil, false, nil
+	}
+
+	pvc, err := kubeClient.CoreV1().PersistentVolumeClaims(pv.Spec.ClaimRef.Namespace).Get(ctx, pv.Spec.ClaimRef.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("failed to get PersistentVolumeClaim %s/%s: %w", pv.Spec.ClaimRef.Namespace, pv.Spec.ClaimRef.Name, err)
+	}
+	if pvc.Spec.VolumeAttributesClassName == nil || *pvc.Spec.VolumeAttributesClassName == "" {
+		return nil, false, nil
+	}
+
+	vacName := *pvc.Spec.VolumeAttributesClassName
+	return getVolumeAttributesClassParameters(ctx, kubeClient, vacName)
+}
+
+// getVolumeAttributesClassParameters reads a VolumeAttributesClass, from
+// whichever version of the API the cluster serves it at.
+//
+// VolumeAttributesClass reached storage.k8s.io/v1 in Kubernetes 1.34, and
+// clusters before that serve it at v1beta1 only. Asking the unserved version
+// returns the same not found as a class that does not exist, so both versions
+// have to be tried before concluding there is no class: treating an unserved API
+// as a missing class would silently withdraw every conversion on those clusters.
+func getVolumeAttributesClassParameters(ctx context.Context, kubeClient kubernetes.Interface, vacName string) (map[string]string, bool, error) {
+	vac, err := kubeClient.StorageV1().VolumeAttributesClasses().Get(ctx, vacName, metav1.GetOptions{})
+	if err == nil {
+		return vac.Parameters, true, nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return nil, false, fmt.Errorf("failed to get VolumeAttributesClass %s: %w", vacName, err)
+	}
+
+	betaVac, betaErr := kubeClient.StorageV1beta1().VolumeAttributesClasses().Get(ctx, vacName, metav1.GetOptions{})
+	if betaErr == nil {
+		return betaVac.Parameters, true, nil
+	}
+	if !apierrors.IsNotFound(betaErr) {
+		return nil, false, fmt.Errorf("failed to get VolumeAttributesClass %s: %w", vacName, betaErr)
+	}
+	// Neither version has it, so the class really is gone.
+	return nil, false, nil
+}
+
+// EmitPVEvent records an event against a PersistentVolume, so that the progress
+// of work the driver does outside of a single call is visible to a user running
+// kubectl describe or kubectl get events.
+//
+// The event is created directly rather than through an event broadcaster. The
+// driver emits these one at a time on volume lifecycle events, so it has no use
+// for the batching and deduplication a broadcaster adds, and creating the event
+// inline avoids a background sender whose buffer can silently drop events when
+// the driver shuts down.
+//
+// Events are a best effort notification, never the record of what happened:
+// that is what the annotations are for. A volume with no PersistentVolume, or an
+// event that could not be created, is logged and otherwise ignored.
+func EmitPVEvent(ctx context.Context, pvName string, eventType, reason, action, message string) {
+	kubeClient, err := GetClient()
+	if err != nil {
+		klog.Warningf("Could not emit %s event for PersistentVolume %s: %v\n", reason, pvName, err)
+		return
+	}
+
+	pv, err := GetPersistentVolumeWithRetry(ctx, pvName)
+	if err != nil {
+		klog.Warningf("Could not emit %s event for PersistentVolume %s: %v\n", reason, pvName, err)
+		return
+	}
+
+	now := metav1.Now()
+	event := &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			// Event names have to be unique within a namespace, and this is the
+			// naming the API server's own recorders use.
+			Name:      fmt.Sprintf("%s.%x", pvName, now.UnixNano()),
+			Namespace: metav1.NamespaceDefault,
+		},
+		InvolvedObject: v1.ObjectReference{
+			APIVersion: "v1",
+			Kind:       "PersistentVolume",
+			Name:       pv.Name,
+			UID:        pv.UID,
+		},
+		Reason:              reason,
+		Message:             message,
+		Action:              action,
+		Type:                eventType,
+		Source:              v1.EventSource{Component: EventComponent},
+		ReportingController: EventComponent,
+		FirstTimestamp:      now,
+		LastTimestamp:       now,
+		Count:               1,
+	}
+
+	// A PersistentVolume is not namespaced, so its events are recorded in the
+	// default namespace, the same as the events other cluster scoped objects get.
+	if _, err := kubeClient.CoreV1().Events(metav1.NamespaceDefault).Create(ctx, event, metav1.CreateOptions{}); err != nil {
+		klog.Warningf("Failed to emit %s event for PersistentVolume %s: %v\n", reason, pvName, err)
+		return
+	}
+	klog.V(4).Infof("Emitted %s event for PersistentVolume %s\n", reason, pvName)
+}
+
+// GetPVAnnotation returns the value of a single annotation on a
+// PersistentVolume, and whether the annotation is set at all.
+//
+// A PersistentVolume that does not exist reports the annotation as unset rather
+// than failing, because a disk is not required to have a PersistentVolume named
+// after it. Any other failure is returned, so callers that need to know the
+// state for a safety decision can tell "there is no such annotation" apart from
+// "the annotation could not be read".
+func GetPVAnnotation(ctx context.Context, pvName string, annotationKey string) (string, bool, error) {
+	pv, err := GetPersistentVolumeWithRetry(ctx, pvName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	value, exists := pv.Annotations[annotationKey]
+	return value, exists, nil
+}
+
+// SetPVAnnotation adds or updates an annotation on a PersistentVolume.
+func SetPVAnnotation(ctx context.Context, pvName string, annotationKey string, annotationValue string) error {
+	return patchPVAnnotation(ctx, pvName, annotationKey, &annotationValue)
+}
+
+// RemovePVAnnotation removes an annotation from a PersistentVolume. Removing an
+// annotation that is not present succeeds without doing anything.
+func RemovePVAnnotation(ctx context.Context, pvName string, annotationKey string) error {
+	return patchPVAnnotation(ctx, pvName, annotationKey, nil)
+}
+
+// UpdatePVAnnotation adds, updates, or removes an annotation on a PersistentVolume.
+// Pass "" or "null" as the annotationValue to remove the annotation.
+//
+// Prefer SetPVAnnotation and RemovePVAnnotation, which say which of the two is
+// intended instead of overloading the value.
+func UpdatePVAnnotation(ctx context.Context, pvName string, annotationKey string, annotationValue string) error {
+	if annotationValue == "" || annotationValue == "null" {
+		return RemovePVAnnotation(ctx, pvName, annotationKey)
+	}
+	return SetPVAnnotation(ctx, pvName, annotationKey, annotationValue)
+}
+
+// patchPVAnnotation sets annotationKey to annotationValue on a PersistentVolume,
+// or removes it when annotationValue is nil.
+//
+// Both cases use a merge patch (RFC 7386), where a null value deletes the key.
+// A JSON patch "remove" would be rejected with a 422 when the annotation is not
+// present, so removal would burn the whole backoff on what should be a no-op.
+func patchPVAnnotation(ctx context.Context, pvName string, annotationKey string, annotationValue *string) error {
+	if pvName == "" {
+		return fmt.Errorf("PersistentVolume name is empty")
+	}
+	if annotationKey == "" {
+		return fmt.Errorf("annotation key is empty")
+	}
+
+	kubeClient, err := GetClient()
+	if err != nil {
+		return fmt.Errorf("failed to get kubernetes client: %w", err)
+	}
+
+	// A nil value marshals to null, which merge patch semantics treat as a
+	// deletion of the key.
+	var value interface{}
+	if annotationValue != nil {
+		value = *annotationValue
+	}
+	patchPayload, err := json.Marshal(map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				annotationKey: value,
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to build annotation patch for PersistentVolume %s: %w", pvName, err)
+	}
+
+	var lastErr error
+	err = wait.ExponentialBackoffWithContext(ctx, backoff, func(_ context.Context) (bool, error) {
+		_, patchErr := kubeClient.CoreV1().PersistentVolumes().Patch(ctx, pvName, types.MergePatchType, patchPayload, metav1.PatchOptions{})
+		if patchErr != nil {
+			lastErr = patchErr
+			// Retrying a request the API server has already rejected on its
+			// merits only delays the caller, which for the conversion hooks
+			// runs inside a CSI call.
+			if !isRetriableAPIError(patchErr) {
+				return false, patchErr
+			}
+			klog.Warningf("Error patching annotation %s on PersistentVolume %s: %v, retrying...\n", annotationKey, pvName, patchErr)
+			return false, nil
+		}
+		klog.V(4).Infof("Successfully patched annotation %s on PersistentVolume %s\n", annotationKey, pvName)
+		return true, nil
+	})
+
+	if err != nil {
+		// On timeout the backoff reports only that it gave up, so surface the
+		// error that actually caused the retries.
+		if lastErr != nil {
+			err = lastErr
+		}
+		klog.Errorf("Failed to patch annotation %s on PersistentVolume %s: %v\n", annotationKey, pvName, err)
+		return fmt.Errorf("failed to patch annotation %s on PersistentVolume %s: %w", annotationKey, pvName, err)
+	}
+	return nil
+}
+
+// isRetriableAPIError reports whether a failed request could succeed if tried
+// again. Errors where the API server understood the request and refused it are
+// not retried.
+func isRetriableAPIError(err error) bool {
+	switch {
+	case apierrors.IsNotFound(err),
+		apierrors.IsForbidden(err),
+		apierrors.IsUnauthorized(err),
+		apierrors.IsInvalid(err),
+		apierrors.IsBadRequest(err),
+		apierrors.IsMethodNotSupported(err),
+		apierrors.IsRequestEntityTooLargeError(err):
+		return false
+	default:
+		return true
+	}
 }

--- a/pkg/k8sclient/client_test.go
+++ b/pkg/k8sclient/client_test.go
@@ -1,0 +1,506 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sclient
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+const testAnnotationKey = "pdcsi.gke.io/disk-type-conversion-operation"
+
+// withFakeClient points GetClient at clientset for the duration of a test, and
+// shortens the backoff so failure cases don't spend seconds sleeping.
+func withFakeClient(t *testing.T, clientset kubernetes.Interface) {
+	t.Helper()
+	originalGetClient := GetClient
+	originalBackoff := backoff
+	GetClient = func() (kubernetes.Interface, error) { return clientset, nil }
+	backoff = wait.Backoff{Duration: time.Millisecond, Factor: 1.0, Steps: 3}
+	t.Cleanup(func() {
+		GetClient = originalGetClient
+		backoff = originalBackoff
+	})
+}
+
+func newPV(name string, annotations map[string]string) *v1.PersistentVolume {
+	return &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: annotations},
+	}
+}
+
+func getAnnotations(ctx context.Context, t *testing.T, clientset kubernetes.Interface, pvName string) map[string]string {
+	t.Helper()
+	pv, err := clientset.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get PersistentVolume %s: %v", pvName, err)
+	}
+	return pv.Annotations
+}
+
+func TestSetPVAnnotation(t *testing.T) {
+	testCases := []struct {
+		name     string
+		existing map[string]string
+		value    string
+		expected string
+	}{
+		{
+			name:     "adds annotation when none exist",
+			existing: nil,
+			value:    "Pending",
+			expected: "Pending",
+		},
+		{
+			name:     "adds annotation alongside existing ones",
+			existing: map[string]string{"unrelated": "keep-me"},
+			value:    "Pending",
+			expected: "Pending",
+		},
+		{
+			name:     "overwrites an existing value",
+			existing: map[string]string{testAnnotationKey: "Pending"},
+			value:    "https://www.googleapis.com/compute/alpha/projects/p/zones/z/operations/op-1",
+			expected: "https://www.googleapis.com/compute/alpha/projects/p/zones/z/operations/op-1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			clientset := fake.NewSimpleClientset(newPV("test-pv", tc.existing))
+			withFakeClient(t, clientset)
+
+			if err := SetPVAnnotation(ctx, "test-pv", testAnnotationKey, tc.value); err != nil {
+				t.Fatalf("SetPVAnnotation failed: %v", err)
+			}
+
+			annotations := getAnnotations(ctx, t, clientset, "test-pv")
+			if got := annotations[testAnnotationKey]; got != tc.expected {
+				t.Errorf("Got annotation %q; want %q", got, tc.expected)
+			}
+			for k, v := range tc.existing {
+				if k == testAnnotationKey {
+					continue
+				}
+				if annotations[k] != v {
+					t.Errorf("Unrelated annotation %s = %q; want %q", k, annotations[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestRemovePVAnnotation(t *testing.T) {
+	testCases := []struct {
+		name     string
+		existing map[string]string
+	}{
+		{
+			name:     "removes an existing annotation",
+			existing: map[string]string{testAnnotationKey: "Pending"},
+		},
+		{
+			// A JSON patch "remove" would fail here with a 422, so this is the
+			// case the merge patch exists for.
+			name:     "removing an absent annotation succeeds",
+			existing: map[string]string{"unrelated": "keep-me"},
+		},
+		{
+			name:     "removing from a PV with no annotations succeeds",
+			existing: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			clientset := fake.NewSimpleClientset(newPV("test-pv", tc.existing))
+			withFakeClient(t, clientset)
+
+			if err := RemovePVAnnotation(ctx, "test-pv", testAnnotationKey); err != nil {
+				t.Fatalf("RemovePVAnnotation failed: %v", err)
+			}
+
+			annotations := getAnnotations(ctx, t, clientset, "test-pv")
+			if _, ok := annotations[testAnnotationKey]; ok {
+				t.Errorf("Annotation %s is still present: %v", testAnnotationKey, annotations)
+			}
+			if v, ok := tc.existing["unrelated"]; ok && annotations["unrelated"] != v {
+				t.Errorf("Unrelated annotation was dropped: %v", annotations)
+			}
+		})
+	}
+}
+
+func TestUpdatePVAnnotationRemovalValues(t *testing.T) {
+	// "" and "null" are the sentinels callers use to mean removal.
+	for _, value := range []string{"", "null"} {
+		t.Run("value "+value, func(t *testing.T) {
+			ctx := context.Background()
+			clientset := fake.NewSimpleClientset(newPV("test-pv", map[string]string{testAnnotationKey: "Pending"}))
+			withFakeClient(t, clientset)
+
+			if err := UpdatePVAnnotation(ctx, "test-pv", testAnnotationKey, value); err != nil {
+				t.Fatalf("UpdatePVAnnotation failed: %v", err)
+			}
+
+			if _, ok := getAnnotations(ctx, t, clientset, "test-pv")[testAnnotationKey]; ok {
+				t.Errorf("UpdatePVAnnotation with value %q did not remove the annotation", value)
+			}
+		})
+	}
+}
+
+func TestPatchPVAnnotationInvalidInput(t *testing.T) {
+	testCases := []struct {
+		name  string
+		pv    string
+		key   string
+		value string
+	}{
+		{name: "empty PV name", pv: "", key: testAnnotationKey, value: "Pending"},
+		{name: "empty annotation key", pv: "test-pv", key: "", value: "Pending"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset(newPV("test-pv", nil))
+			withFakeClient(t, clientset)
+
+			if err := SetPVAnnotation(context.Background(), tc.pv, tc.key, tc.value); err == nil {
+				t.Errorf("SetPVAnnotation(%q, %q) = nil; want error", tc.pv, tc.key)
+			}
+		})
+	}
+}
+
+// countingReactor fails every patch with err and records how many were made.
+func countingReactor(clientset *fake.Clientset, err error) *int {
+	var calls int
+	clientset.PrependReactor("patch", "persistentvolumes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		calls++
+		return true, nil, err
+	})
+	return &calls
+}
+
+func TestPatchPVAnnotationRetryBehaviour(t *testing.T) {
+	pvResource := schema.GroupResource{Resource: "persistentvolumes"}
+
+	testCases := []struct {
+		name          string
+		patchErr      error
+		expectedCalls int
+	}{
+		{
+			// The API server understood the request and refused it, so retrying
+			// only delays the CSI call that is waiting on this.
+			name:          "not found is not retried",
+			patchErr:      apierrors.NewNotFound(pvResource, "test-pv"),
+			expectedCalls: 1,
+		},
+		{
+			name:          "forbidden is not retried",
+			patchErr:      apierrors.NewForbidden(pvResource, "test-pv", nil),
+			expectedCalls: 1,
+		},
+		{
+			name:          "server timeout is retried",
+			patchErr:      apierrors.NewServerTimeout(pvResource, "patch", 1),
+			expectedCalls: 3,
+		},
+		{
+			name:          "conflict is retried",
+			patchErr:      apierrors.NewConflict(pvResource, "test-pv", nil),
+			expectedCalls: 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset(newPV("test-pv", nil))
+			calls := countingReactor(clientset, tc.patchErr)
+			withFakeClient(t, clientset)
+
+			err := SetPVAnnotation(context.Background(), "test-pv", testAnnotationKey, "Pending")
+			if err == nil {
+				t.Fatal("SetPVAnnotation = nil; want error")
+			}
+			// The backoff on its own reports only that it gave up, so check that
+			// the cause survived.
+			if !apierrors.IsNotFound(err) && !apierrors.IsForbidden(err) && !apierrors.IsServerTimeout(err) && !apierrors.IsConflict(err) {
+				t.Errorf("SetPVAnnotation error %v does not wrap the API error", err)
+			}
+			if *calls != tc.expectedCalls {
+				t.Errorf("Made %d patch calls; want %d", *calls, tc.expectedCalls)
+			}
+		})
+	}
+}
+
+func TestEmitPVEvent(t *testing.T) {
+	ctx := context.Background()
+	pv := newPV("test-pv", nil)
+	pv.UID = "b115f645-b9a5-44ea-82a4-80f92bc96535"
+	clientset := fake.NewSimpleClientset(pv)
+	withFakeClient(t, clientset)
+
+	EmitPVEvent(ctx, "test-pv", v1.EventTypeNormal, "DiskTypeConversionStart", "ConvertDiskType",
+		`Disk type conversion started for volume "test-pv"`)
+
+	events, err := clientset.CoreV1().Events(metav1.NamespaceDefault).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("Failed to list events: %v", err)
+	}
+	if len(events.Items) != 1 {
+		t.Fatalf("Got %d events; want 1", len(events.Items))
+	}
+
+	event := events.Items[0]
+	if event.Reason != "DiskTypeConversionStart" {
+		t.Errorf("Got reason %q; want DiskTypeConversionStart", event.Reason)
+	}
+	if event.Action != "ConvertDiskType" {
+		t.Errorf("Got action %q; want ConvertDiskType", event.Action)
+	}
+	if event.Type != v1.EventTypeNormal {
+		t.Errorf("Got type %q; want %q", event.Type, v1.EventTypeNormal)
+	}
+	if event.Source.Component != EventComponent {
+		t.Errorf("Got source component %q; want %q", event.Source.Component, EventComponent)
+	}
+	// The event has to point at the PersistentVolume for kubectl describe pv to
+	// show it.
+	if event.InvolvedObject.Kind != "PersistentVolume" || event.InvolvedObject.Name != "test-pv" {
+		t.Errorf("Got involved object %+v; want the test-pv PersistentVolume", event.InvolvedObject)
+	}
+	if event.InvolvedObject.UID != pv.UID {
+		t.Errorf("Got involved object UID %q; want %q", event.InvolvedObject.UID, pv.UID)
+	}
+}
+
+func TestEmitPVEventIsBestEffort(t *testing.T) {
+	testCases := []struct {
+		name    string
+		objects []runtime.Object
+	}{
+		{
+			// Events are a notification, not the record of what happened, so a
+			// volume with no PersistentVolume must not take down the caller.
+			name:    "no PersistentVolume to attach the event to",
+			objects: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			clientset := fake.NewSimpleClientset(tc.objects...)
+			withFakeClient(t, clientset)
+
+			EmitPVEvent(ctx, "test-pv", v1.EventTypeNormal, "DiskTypeConversionStart", "ConvertDiskType", "message")
+
+			events, err := clientset.CoreV1().Events(metav1.NamespaceDefault).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				t.Fatalf("Failed to list events: %v", err)
+			}
+			if len(events.Items) != 0 {
+				t.Errorf("Got %d events; want none", len(events.Items))
+			}
+		})
+	}
+}
+
+func TestGetVolumeAttributesClassForPV(t *testing.T) {
+	boundPV := func(claimName string) *v1.PersistentVolume {
+		pv := newPV("test-pv", nil)
+		if claimName != "" {
+			pv.Spec.ClaimRef = &v1.ObjectReference{Name: claimName, Namespace: "default"}
+		}
+		return pv
+	}
+	pvcWithClass := func(className *string) *v1.PersistentVolumeClaim {
+		return &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pvc", Namespace: "default"},
+			Spec:       v1.PersistentVolumeClaimSpec{VolumeAttributesClassName: className},
+		}
+	}
+	vac := &storagev1.VolumeAttributesClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "vac-hyperdisk"},
+		DriverName: "pd.csi.storage.gke.io",
+		Parameters: map[string]string{"type": "hyperdisk-balanced", "iops": "3000"},
+	}
+	className := "vac-hyperdisk"
+	emptyClassName := ""
+
+	testCases := []struct {
+		name      string
+		objects   []runtime.Object
+		expParams map[string]string
+		expExists bool
+		expectErr bool
+	}{
+		{
+			name:      "returns the parameters of the class the claim names",
+			objects:   []runtime.Object{boundPV("test-pvc"), pvcWithClass(&className), vac},
+			expParams: map[string]string{"type": "hyperdisk-balanced", "iops": "3000"},
+			expExists: true,
+		},
+		{
+			// This is how a user cancels work the driver has queued.
+			name:      "reports no class when the claim no longer names one",
+			objects:   []runtime.Object{boundPV("test-pvc"), pvcWithClass(nil), vac},
+			expExists: false,
+		},
+		{
+			name:      "reports no class when the claim names an empty one",
+			objects:   []runtime.Object{boundPV("test-pvc"), pvcWithClass(&emptyClassName), vac},
+			expExists: false,
+		},
+		{
+			name:      "reports no class when the volume is not bound to a claim",
+			objects:   []runtime.Object{boundPV(""), vac},
+			expExists: false,
+		},
+		{
+			name:      "reports no class when the claim is gone",
+			objects:   []runtime.Object{boundPV("test-pvc"), vac},
+			expExists: false,
+		},
+		{
+			name:      "reports no class when the class is gone",
+			objects:   []runtime.Object{boundPV("test-pvc"), pvcWithClass(&className)},
+			expExists: false,
+		},
+		{
+			name:      "reports no class when the volume has no PersistentVolume",
+			objects:   nil,
+			expExists: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset(tc.objects...)
+			withFakeClient(t, clientset)
+
+			params, exists, err := GetVolumeAttributesClassForPV(context.Background(), "test-pv")
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("GetVolumeAttributesClassForPV = %v, %v, nil; want error", params, exists)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GetVolumeAttributesClassForPV failed: %v", err)
+			}
+			if exists != tc.expExists {
+				t.Errorf("Got exists %v; want %v", exists, tc.expExists)
+			}
+			if !reflect.DeepEqual(params, tc.expParams) {
+				t.Errorf("Got parameters %v; want %v", params, tc.expParams)
+			}
+		})
+	}
+}
+
+func TestGetVolumeAttributesClassForPVAPIVersions(t *testing.T) {
+	boundPV := func() *v1.PersistentVolume {
+		pv := newPV("test-pv", nil)
+		pv.Spec.ClaimRef = &v1.ObjectReference{Name: "test-pvc", Namespace: "default"}
+		return pv
+	}
+	className := "vac-hyperdisk"
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pvc", Namespace: "default"},
+		Spec:       v1.PersistentVolumeClaimSpec{VolumeAttributesClassName: &className},
+	}
+	params := map[string]string{"type": "hyperdisk-balanced"}
+
+	testCases := []struct {
+		name      string
+		vac       runtime.Object
+		expParams map[string]string
+		expExists bool
+	}{
+		{
+			name: "reads the class from storage v1",
+			vac: &storagev1.VolumeAttributesClass{
+				ObjectMeta: metav1.ObjectMeta{Name: className},
+				DriverName: "pd.csi.storage.gke.io",
+				Parameters: params,
+			},
+			expParams: params,
+			expExists: true,
+		},
+		{
+			// Clusters before Kubernetes 1.34 serve the class at v1beta1 only.
+			// Reading the unserved v1 as a missing class would cancel every
+			// conversion on those clusters.
+			name: "falls back to storage v1beta1",
+			vac: &storagev1beta1.VolumeAttributesClass{
+				ObjectMeta: metav1.ObjectMeta{Name: className},
+				DriverName: "pd.csi.storage.gke.io",
+				Parameters: params,
+			},
+			expParams: params,
+			expExists: true,
+		},
+		{
+			name:      "reports no class when neither version has it",
+			vac:       nil,
+			expExists: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			objects := []runtime.Object{boundPV(), pvc}
+			if tc.vac != nil {
+				objects = append(objects, tc.vac)
+			}
+			clientset := fake.NewSimpleClientset(objects...)
+			withFakeClient(t, clientset)
+
+			gotParams, exists, err := GetVolumeAttributesClassForPV(context.Background(), "test-pv")
+			if err != nil {
+				t.Fatalf("GetVolumeAttributesClassForPV failed: %v", err)
+			}
+			if exists != tc.expExists {
+				t.Errorf("Got exists %v; want %v", exists, tc.expExists)
+			}
+			if !reflect.DeepEqual(gotParams, tc.expParams) {
+				t.Errorf("Got parameters %v; want %v", gotParams, tc.expParams)
+			}
+		})
+	}
+}

--- a/pkg/parameters/parameters.go
+++ b/pkg/parameters/parameters.go
@@ -312,13 +312,27 @@ func ExtractModifyVolumeParameters(parameters map[string]string) (ModifyVolumePa
 			if err != nil {
 				return ModifyVolumeParameters{}, fmt.Errorf("parameters contain invalid iops parameter: %w", err)
 			}
+			// A value at or below zero is invalid for every disk type. What
+			// counts as too low for a given type and size is left to the API.
+			if iops <= 0 {
+				return ModifyVolumeParameters{}, fmt.Errorf("parameters contain invalid iops parameter: %d, must be greater than zero", iops)
+			}
 			modifyVolumeParams.IOPS = &iops
 		case "throughput":
 			throughput, err := convert.ConvertMiStringToInt64(value)
 			if err != nil {
 				return ModifyVolumeParameters{}, fmt.Errorf("parameters contain invalid throughput parameter: %w", err)
 			}
+			if throughput <= 0 {
+				return ModifyVolumeParameters{}, fmt.Errorf("parameters contain invalid throughput parameter: %d, must be greater than zero", throughput)
+			}
 			modifyVolumeParams.Throughput = &throughput
+		case "type":
+			diskType := strings.ToLower(strings.TrimSpace(value))
+			if diskType == "" {
+				return ModifyVolumeParameters{}, fmt.Errorf("parameters contain empty type parameter")
+			}
+			modifyVolumeParams.DiskType = &diskType
 		default:
 			return ModifyVolumeParameters{}, fmt.Errorf("parameters contain unknown parameter: %s", key)
 		}

--- a/pkg/parameters/parameters_test.go
+++ b/pkg/parameters/parameters_test.go
@@ -694,3 +694,131 @@ func TestExtractModifyVolumeParameters(t *testing.T) {
 		t.Errorf("Got ExtractModifyVolumeParameters(%+v) = %+v; want: %v", parameters, result, expected)
 	}
 }
+
+func TestExtractModifyVolumeParametersNegativeValues(t *testing.T) {
+	testCases := []struct {
+		name       string
+		parameters map[string]string
+	}{
+		{
+			name:       "negative iops",
+			parameters: map[string]string{"iops": "-1000"},
+		},
+		{
+			name:       "zero iops",
+			parameters: map[string]string{"iops": "0"},
+		},
+		{
+			name:       "negative throughput",
+			parameters: map[string]string{"throughput": "-500Mi"},
+		},
+		{
+			name:       "zero throughput",
+			parameters: map[string]string{"throughput": "0Mi"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ExtractModifyVolumeParameters(tc.parameters)
+			if err == nil {
+				t.Errorf("ExtractModifyVolumeParameters(%+v) succeeded, expected an error rejecting the value", tc.parameters)
+			}
+		})
+	}
+}
+
+func TestExtractModifyVolumeParametersDiskType(t *testing.T) {
+	hyperdiskBalanced := "hyperdisk-balanced"
+	iops := int64(3000)
+
+	testCases := []struct {
+		name       string
+		parameters map[string]string
+		expected   ModifyVolumeParameters
+		expectErr  bool
+	}{
+		{
+			name:       "type only",
+			parameters: map[string]string{"type": "hyperdisk-balanced"},
+			expected:   ModifyVolumeParameters{DiskType: &hyperdiskBalanced},
+		},
+		{
+			name:       "type is case insensitive and trimmed",
+			parameters: map[string]string{"type": "  Hyperdisk-Balanced  "},
+			expected:   ModifyVolumeParameters{DiskType: &hyperdiskBalanced},
+		},
+		{
+			name:       "type alongside iops",
+			parameters: map[string]string{"type": "hyperdisk-balanced", "iops": "3000"},
+			expected:   ModifyVolumeParameters{DiskType: &hyperdiskBalanced, IOPS: &iops},
+		},
+		{
+			name:       "empty type is rejected",
+			parameters: map[string]string{"type": "  "},
+			expectErr:  true,
+		},
+		{
+			name:       "unknown parameter is still rejected",
+			parameters: map[string]string{"disktype": "hyperdisk-balanced"},
+			expectErr:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ExtractModifyVolumeParameters(tc.parameters)
+			if tc.expectErr {
+				if err == nil {
+					t.Errorf("ExtractModifyVolumeParameters(%+v) = %+v; want error", tc.parameters, result)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("Got ExtractModifyVolumeParameters(%+v) = %+v; want: %+v", tc.parameters, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestExtractModifyVolumeParametersRejectsInvalidValues(t *testing.T) {
+	testCases := []struct {
+		name       string
+		parameters map[string]string
+	}{
+		// Sent to the API these come back as a 400 the driver would otherwise
+		// keep retrying, leaving the volume queued behind a request that can
+		// never succeed.
+		{name: "zero iops", parameters: map[string]string{"iops": "0"}},
+		{name: "negative iops", parameters: map[string]string{"iops": "-1"}},
+		{name: "zero throughput", parameters: map[string]string{"throughput": "0"}},
+		{name: "negative throughput", parameters: map[string]string{"throughput": "-5"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ExtractModifyVolumeParameters(tc.parameters)
+			if err == nil {
+				t.Errorf("ExtractModifyVolumeParameters(%v) = %+v, nil; want an error", tc.parameters, got)
+			}
+		})
+	}
+}
+
+func TestExtractModifyVolumeParametersAcceptsValidValues(t *testing.T) {
+	// Whether a positive value is high enough for a given disk type and size is
+	// for the API to decide, so anything above zero is passed through.
+	params, err := ExtractModifyVolumeParameters(map[string]string{"iops": "1", "throughput": "1Mi"})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if params.IOPS == nil || *params.IOPS != 1 {
+		t.Errorf("Got iops %v; want 1", params.IOPS)
+	}
+	if params.Throughput == nil || *params.Throughput != 1 {
+		t.Errorf("Got throughput %v; want 1", params.Throughput)
+	}
+}

--- a/pkg/parameters/types.go
+++ b/pkg/parameters/types.go
@@ -130,4 +130,5 @@ func (pp *ParameterProcessor) isDynamicVolumesDisabled() bool {
 type ModifyVolumeParameters struct {
 	IOPS       *int64
 	Throughput *int64
+	DiskType   *string
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds Persistent Disk to Hyperdisk conversion driven entirely through the
Kubernetes API, so users can migrate volumes with `kubectl` alone rather than
needing access to GCP REST APIs.

Applying a `VolumeAttributesClass` whose `type` differs from the volume's actual
disk type triggers a conversion via the GCE `disks.convert` API. A conversion is
a long-running operation — minutes to hours depending on disk size — that runs
outside any CSI call, so this also adds the state and tracking needed to follow
one to completion and survive a driver restart:

- **Operation tracking.** A background watcher polls the GCE operation with capped
  backoff. The operation selfLink is recorded on the PV, so state survives a
  controller restart or leader election, with a fallback that records completion
  at the next attach, snapshot or expand if no watcher is alive.
- **Annotation lifecycle.** `Pending` → operation selfLink → `converted-from` /
  `converted-to`, with reconciliation for volumes queued for a conversion that is
  no longer wanted or already the target type. An operation-ownership check stops
  a superseded watcher from clearing a newer conversion.
- **Failure classification.** Terminal and retriable failures are distinguished by
  the GCE error *reason* rather than HTTP status, since 400 and 403 cover both.
  Applied to failures returned when the conversion is requested and to failures
  discovered mid-flight by the poller. Retriable failures return the volume to
  `Pending` and pass the GCE error through to the PVC status; terminal failures
  return `InvalidArgument` and leave attach unblocked.
- **Operation guards.** Attach, expand, snapshot and delete are refused while a
  conversion is in progress, and fail closed if the conversion state cannot be
  read.
- **Request pacing.** Conversion API calls are rate limited to stay within the
  per-region limit on `disks.convert` calls.

A VAC whose `type` matches the disk exactly is treated as an IOPS/throughput
update and does not trigger a conversion.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
action required: The GCE PD CSI driver can now convert Persistent Disks to
Hyperdisk in place. Applying a VolumeAttributesClass whose `type` differs from a
volume's current disk type converts it, preserving the disk's name and identity.
The disk must be detached: conversion starts immediately if it is, otherwise at
the next detach. Attach, expand, snapshot and delete are blocked while a
conversion runs. Enable with `--enable-pd-conversion`.

Two deployment requirements: csi-resizer must match the VolumeAttributesClass API
version the cluster serves (v1.13.2 for `storage.k8s.io/v1beta1`, v2.0.0 for
`storage.k8s.io/v1`) and must run with `--feature-gates=VolumeAttributesClass=true`;
and nodes must be Hyperdisk-capable (C3, C4 or N4) to attach converted volumes.
```
