### PR TITLE
Increase e2e timeout

### DIFF
--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -5,9 +5,6 @@ set -x
 
 readonly PKGDIR=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
 
-TIMEOUT=50m
-if [ "$RUN_CONTROLLER_MODIFY_VOLUME_TESTS" = true ]; then
-    TIMEOUT=45m
-fi
+TIMEOUT=80m
 
 go test --timeout "${TIMEOUT}" --v "${PKGDIR}/test/e2e/tests" --run-in-prow=true --delete-instances=true --logtostderr $@


### PR DESCRIPTION
/kind failing-test

See the related https://github.com/kubernetes/test-infra/pull/37849.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
